### PR TITLE
Breaking-change detector and network impact report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,24 @@ jobs:
           touch /tmp/pal/scripts/__init__.py
       - name: Validate each node
         run: python3 scripts/check_palomar_metadata.py /tmp/pal
+
+  impact:
+    name: Network impact
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Full history: the base state is recovered with `git show`, not by checking it out.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install pyyaml
+      # Fails only on the one class that must not be silent: editing a conclusion that other
+      # nodes depend on, or removing one that is still imported. Everything else is reported to
+      # the job summary for the reviewer and does not block.
+      - name: What this branch degrades
+        run: python3 scripts/ieantn.py diff --base "${{ github.event.pull_request.base.sha }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,8 @@ lake build                              # Vocabulary + Conclusions + Challenges.
 lake build IEANTN.Vocabulary.PrimeGaps  # a single module while iterating
 python scripts/ieantn.py check          # every network invariant
 python scripts/ieantn.py report         # what each conclusion rests on
+python scripts/ieantn.py status         # green / yellow / orange / BROKEN per conclusion
+python scripts/ieantn.py diff           # what your branch degrades, and for whom
 python scripts/ieantn.py housekeeping   # the derived task queue
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@ one.
 Read [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) once before your first contribution.
 [docs/NODES.md](docs/NODES.md) is the reference for node file formats.
 
-> **Status.** Marked *(planned)* below: the breaking-change detector, the `/verify` bot, and the
-> reviewer report. Everything else works today.
+> **Status.** Marked *(planned)* below: the `/verify` bot, and posting the reviewer report as a PR
+> comment rather than to the job summary. Everything else works today.
 
 ## Two principles
 
@@ -107,8 +107,8 @@ is least work:
 | Port the solution | The proof survives the restatement with small edits. |
 | Bridge from the old version | The old conclusion implies the new one. Usually the cheapest. |
 
-**CI:** editing a depended-on conclusion in place is a hard failure *(planned)*; making a new
-version is always green. **Downstream nodes need no action** — they still import the old version.
+**CI:** editing a depended-on conclusion in place is a hard failure; making a new version is
+always green. **Downstream nodes need no action** — they still import the old version.
 
 Deprecate the old version when you want it retired:
 
@@ -245,8 +245,7 @@ that touch enough nodes for the consequences to be hard to hold in your head.
 
 ## The acknowledgement escape hatch
 
-If CI reports that your change breaks something and you need it to land anyway, add
-`changes/<slug>.yaml`:
+If `Network impact` fails and you need the change to land anyway, add `changes/<slug>.yaml`:
 
 ```yaml
 acknowledge:

--- a/changes/README.md
+++ b/changes/README.md
@@ -1,0 +1,31 @@
+# Acknowledged breakage
+
+Almost always this directory is empty, and that is the point.
+
+`python scripts/ieantn.py diff` fails a pull request that edits a conclusion other nodes depend on,
+or removes one that is still imported. The normal response is not to acknowledge it but to make a
+new version, which breaks nothing:
+
+```bash
+python scripts/ieantn.py new-version <Family>
+```
+
+An acknowledgement is the **override**, for the case where a change is genuinely breaking and has
+to land anyway -- a conclusion that was transcribed wrongly, say, where preserving the edge would
+mean preserving a false claim.
+
+```yaml
+acknowledge:
+  - conclusion: Dusart2018.v1.proposition_5_4
+    effect: statement-changed
+    reason: >-
+      The recorded threshold was a transcription error. Correcting it matters more than preserving
+      the edge, which was verifying the wrong claim.
+```
+
+Downstream nodes are not repaired by this; they are flagged for human re-examination. Their
+receipts are void, not stale.
+
+**The value of an acknowledgement comes from being rare enough that a reviewer notices one.** If
+they become routine, they stop meaning anything -- which is why nothing asks you to write one in
+the ordinary course of work.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,13 +28,17 @@ orange / BROKEN. `check-graph` refuses a `lean-comparator` justification with no
 `receipts/` to the verification workflow's identity. Until that is set, the protection is review
 convention rather than enforcement.
 
-**3. The breaking-change detector.** Compute the graph at the PR base and at `HEAD`, then diff.
-Hard-fails when a conclusion with downstream importers or a recorded receipt is edited in place,
-with `new-version` as the suggested fix.
+**3. The breaking-change detector.** *Done* -- `ieantn.py diff --base <ref>`, run on every pull
+request. Fails when a conclusion with downstream importers or a recorded receipt is edited in
+place, or when one that is still imported is removed, with `new-version` as the suggested fix and
+`changes/*.yaml` as the override.
 
-**4. The reviewer report.** Same machinery as (3): posts a PR comment naming the receipts that went
-stale, new unjustified leaves, blast radius, and a recommended modification. Advisory, never
-blocking.
+Recovering the base state needs no Lean: `fingerprints.json` is committed, so the statements as
+they were are readable with `git show`. That is most of why this is cheap enough to run per PR.
+
+**4. The reviewer report.** *Partly done* -- `diff` writes its findings to the job summary, which
+needs no token and no permissions. Still to do: posting it as a PR comment so it appears inline,
+and adding the recommended-modification text for cases beyond the in-place edit.
 
 **5. The `/verify` bot.** A maintainer-approved `workflow_dispatch` that runs Comparator on one
 node's solution and, on success, commits the receipt and flips the justification.

--- a/scripts/ieantn.py
+++ b/scripts/ieantn.py
@@ -12,6 +12,7 @@ routine node-management tasks.
     python scripts/ieantn.py fingerprint             recompute the statement fingerprints
     python scripts/ieantn.py fingerprint --check     fail if any has moved
     python scripts/ieantn.py status                  the traffic light for every conclusion
+    python scripts/ieantn.py diff --base origin/main what this branch degrades, and for whom
     python scripts/ieantn.py housekeeping            the derived task queue
     python scripts/ieantn.py check                   every check, in --check mode
 
@@ -31,6 +32,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import pathlib
 import subprocess
 import re
@@ -47,6 +49,7 @@ NODES_DIR = ROOT / "IEANTN" / "Nodes"
 VOCAB_DIR = ROOT / "IEANTN" / "Vocabulary"
 FINGERPRINTS = ROOT / "fingerprints.json"
 RECEIPTS = ROOT / "receipts"
+CHANGES = ROOT / "changes"
 
 #: Toolchain minor releases behind current, past which a refresh is assumed to fall outside the
 #: Mathlib cache window and cost many times the per-node budget. A heuristic, not a measurement.
@@ -852,6 +855,184 @@ def housekeeping() -> bool:
 
 
 # ---------------------------------------------------------------------------
+# diff: what this branch degrades
+# ---------------------------------------------------------------------------
+
+
+def git_show(ref: str, path: str) -> str | None:
+    """The contents of `path` at `ref`, or None if it did not exist there."""
+    finished = subprocess.run(
+        ["git", "show", f"{ref}:{path}"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    return finished.stdout if finished.returncode == 0 else None
+
+
+def state_at(ref: str | None) -> dict:
+    """The graph as it stands at `ref`, or in the working tree when `ref` is None.
+
+    Reading the base state needs no Lean at all: `fingerprints.json` is committed, so the
+    statements as they were are recoverable with `git show`. That is most of why this check is
+    cheap enough to run on every pull request.
+    """
+    if ref is None:
+        nodes = load_nodes()
+        fingerprints = (
+            json.loads(FINGERPRINTS.read_text(encoding="utf-8")) if FINGERPRINTS.is_file() else {}
+        )
+        receipts = {
+            path.stem: json.loads(path.read_text(encoding="utf-8"))
+            for path in (RECEIPTS.glob("*.json") if RECEIPTS.is_dir() else [])
+        }
+    else:
+        listing = subprocess.run(
+            ["git", "ls-tree", "-r", "--name-only", ref],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        ).stdout.splitlines()
+        nodes = {}
+        for path in listing:
+            if path.startswith("IEANTN/Nodes/") and path.endswith("formalization.yaml"):
+                raw = git_show(ref, path)
+                if raw is None:
+                    continue
+                data = yaml.safe_load(raw) or {}
+                directory = ROOT / pathlib.PurePosixPath(path).parent
+                data["_dir"] = directory
+                nodes[node_id_of(directory)] = data
+        raw = git_show(ref, "fingerprints.json")
+        fingerprints = json.loads(raw) if raw else {}
+        receipts = {}
+        for path in listing:
+            if path.startswith("receipts/") and path.endswith(".json"):
+                raw = git_show(ref, path)
+                if raw:
+                    receipts[pathlib.PurePosixPath(path).stem] = json.loads(raw)
+
+    conclusions = {}
+    for node_id, node in nodes.items():
+        for conclusion in conclusions_of(node):
+            conclusions[f"{node_id}.{conclusion.get('id')}"] = {
+                "imports": [
+                    f"{d.get('node')}.{d.get('conclusion')}"
+                    for d in (conclusion.get("imports") or [])
+                ],
+                "kind": designated_kind(conclusion),
+            }
+    return {"conclusions": conclusions, "fingerprints": fingerprints, "receipts": receipts}
+
+
+def acknowledged() -> dict[str, str]:
+    """Conclusions this branch explicitly acknowledges breaking, and why.
+
+    An override, not a routine step -- see CONTRIBUTING.md. It exists for the case where a change
+    is genuinely breaking and has to land anyway, and its value comes from being rare enough that a
+    reviewer notices one in the diff.
+    """
+    result: dict[str, str] = {}
+    for path in sorted(CHANGES.glob("*.yaml")) if CHANGES.is_dir() else []:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        for entry in data.get("acknowledge") or []:
+            if entry.get("conclusion"):
+                result[entry["conclusion"]] = entry.get("reason", "(no reason given)")
+    return result
+
+
+def diff(base: str) -> bool:
+    """Report what this branch degrades, and fail on the one class that must not be silent."""
+    before, after = state_at(base), state_at(None)
+    excused = acknowledged()
+    errors: list[str] = []
+    warnings: list[str] = []
+    notes: list[str] = []
+
+    importers_before: dict[str, list[str]] = {}
+    for key, entry in before["conclusions"].items():
+        for target in entry["imports"]:
+            importers_before.setdefault(target, []).append(key)
+
+    for key, entry in sorted(before["conclusions"].items()):
+        old = before["fingerprints"].get(key)
+        new = after["fingerprints"].get(key)
+
+        if key not in after["conclusions"]:
+            users = importers_before.get(key, [])
+            if users:
+                errors.append(
+                    f"**`{key}` was removed** but {len(users)} conclusion(s) still import it at "
+                    f"the base: {', '.join(f'`{u}`' for u in users)}."
+                )
+            else:
+                notes.append(f"`{key}` removed; nothing imported it.")
+            continue
+
+        if old is None or new is None or old == new:
+            continue
+
+        users = importers_before.get(key, [])
+        had_receipt = key in before["receipts"]
+        detail = []
+        if users:
+            detail.append(f"{len(users)} importer(s): " + ", ".join(f"`{u}`" for u in users))
+        if had_receipt:
+            detail.append("a recorded receipt")
+
+        if not detail:
+            notes.append(f"`{key}` restated; nothing depended on it.")
+        elif key in excused:
+            warnings.append(
+                f"**`{key}` edited in place** ({'; '.join(detail)}) -- acknowledged: "
+                f"{excused[key]}"
+            )
+        else:
+            errors.append(
+                f"**`{key}` was edited in place**, and it has {'; '.join(detail)}.\n\n"
+                f"  Editing a conclusion others depend on changes what *they* claim. Make a new "
+                f"version instead:\n\n  ```bash\n  python scripts/ieantn.py new-version "
+                f"{key.split('.')[0]}\n  ```\n\n  If this must land anyway, add a `changes/*.yaml` "
+                f"acknowledgement (see CONTRIBUTING.md)."
+            )
+
+    for key, receipt in sorted(after["receipts"].items()):
+        for name, digest in (receipt.get("statement") or {}).items():
+            if after["fingerprints"].get(name) != digest:
+                warnings.append(
+                    f"Receipt for `{key}` is now **BROKEN**: `{name}` no longer matches what was "
+                    "verified."
+                )
+                break
+
+    for key, entry in sorted(after["conclusions"].items()):
+        if key not in before["conclusions"]:
+            notes.append(f"new conclusion `{key}` (`{entry['kind']}`).")
+
+    lines = ["## Network impact", ""]
+    if not (errors or warnings or notes):
+        lines.append("No change to any statement, dependency, or receipt.")
+    for heading, items in (
+        ("### Breaking", errors),
+        ("### Degraded", warnings),
+        ("### Informational", notes),
+    ):
+        if items:
+            lines += [heading, ""] + [f"- {item}" for item in items] + [""]
+    report = "\n".join(lines)
+    print(report)
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as handle:
+            handle.write(report + "\n")
+
+    return not errors
+
+
+# ---------------------------------------------------------------------------
 # new-version / deprecate
 # ---------------------------------------------------------------------------
 
@@ -1096,6 +1277,8 @@ def main() -> int:
     )
     version = sub.add_parser("new-version")
     version.add_argument("family", help="e.g. Lcm")
+    changed = sub.add_parser("diff")
+    changed.add_argument("--base", default="origin/main")
     written = sub.add_parser("record-receipt", help="verification workflow only")
     written.add_argument("conclusion")
     written.add_argument("--solution", required=True)
@@ -1118,6 +1301,8 @@ def main() -> int:
         return 0 if report() else 1
     if args.command == "status":
         return 0 if status() else 1
+    if args.command == "diff":
+        return 0 if diff(args.base) else 1
     if args.command == "record-receipt":
         return 0 if record_receipt(args.conclusion, args.solution, args.run_url, args.stamp) else 1
     if args.command == "housekeeping":


### PR DESCRIPTION
Piece 3 of docs/ROADMAP.md, and most of piece 4. **Stacked on #3.**

## What it does

`ieantn.py diff --base <ref>` compares the graph at the base against the working tree. It **fails**
on the one class that must not be silent -- editing a conclusion other nodes depend on, or removing
one still imported -- and **reports** everything else without blocking.

## No Lean needed for the base state

`fingerprints.json` is committed, so the statements as they were are recoverable with `git show`.
The whole check runs from git plumbing, which is most of why it is cheap enough to run per PR.

## Verified, not assumed

| Situation | Result |
|---|---|
| edit `Dusart2018.v1.proposition_5_4` in place (Lcm imports it) | **fails**, message carries `new-version Dusart2018` |
| same edit, with a `changes/*.yaml` acknowledgement | passes, listed under Degraded |
| edit `Lcm.v1` (nothing imports it, no receipt) | passes, Informational |
| make a new version instead | passes, clean |
| remove a still-imported conclusion | **fails** |

## The acknowledgement override

Now real, and still an override rather than a routine step. `changes/README.md` says why: its value
comes entirely from being rare enough that a reviewer notices one. Nothing asks you to write one in
the ordinary course of work -- the normal answer to a failure is `new-version`, which breaks
nothing.

## Reviewer report

The findings also go to the CI job summary, which needs no token and no permissions. Posting them
as an inline PR comment is still to do, and ROADMAP.md says so.

Made with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)