### PR TITLE
Refresh the documentation against what is built

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Nodes import each other's *statements*, never each other's *proofs*.
 | `IEANTN/Vocabulary/` | Mathlib only. **Definitions only — no theorems, no `sorry`.** |
 | `IEANTN/Nodes/<Family>/<version>/Conclusions.lean` | Mathlib, Vocabulary, other nodes' `Conclusions.lean` |
 | `IEANTN/Nodes/<Family>/<version>/Challenge.lean` | its own and imported `Conclusions.lean` — **generated, do not hand-edit** |
-| `Solutions/<Family>.<version>/` | anything. Separate Lake project, own toolchain pin. **Not in the core build.** |
+| `Solutions/<Family>.<version>/` | anything. Separate Lake project; takes the core as a path dependency, must not import the node's `Challenge`. **Not in the core build.** |
 
 The Mathlib-only closure of Vocabulary and Conclusions is load-bearing, not stylistic: it is what
 lets any node be spun off as a standalone Palomar submission. An import that reaches outside it
@@ -43,7 +43,13 @@ breaks the architecture silently and CI will reject it.
   rather than false. Vocabulary docstrings flag the specific traps — read them.
 - **Do not add a theorem to Vocabulary.** Every claim belongs to a node.
 - **Never edit a conclusion that anything depends on.** Make a new version instead:
-  `python scripts/ieantn.py new-version <Family>`. See NODES.md.
+  `python scripts/ieantn.py new-version <Family>`. CI enforces this. See NODES.md.
+- **Never write a receipt, and never set `justification: lean-comparator` by hand.** Receipts are
+  written by the verification workflow; one you can write attests nothing.
+- **Never hand-edit a generated file.** `Challenge.lean` and `fingerprints.json` are regenerated
+  and diffed in CI.
+- **After changing a conclusion, run `python scripts/ieantn.py fingerprint`** and commit the
+  result. Cosmetic edits will not change it; a change of meaning will, which is the point.
 
 ## Build
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,9 @@ one.
 Read [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) once before your first contribution.
 [docs/NODES.md](docs/NODES.md) is the reference for node file formats.
 
-> **Status.** Marked *(planned)* below: the `/verify` bot, and posting the reviewer report as a PR
-> comment rather than to the job summary. Everything else works today.
+> **Status.** Everything below works today except where marked *(planned)*: posting the reviewer
+> report as a PR comment rather than to the job summary, and the `verification` environment gate
+> that would let any contributor *request* a verification. See [docs/ROADMAP.md](docs/ROADMAP.md).
 
 ## Two principles
 
@@ -28,8 +29,15 @@ reviewer notices — which is exactly what a routine, always-required acknowledg
 
 You want to begin proving an existing challenge.
 
-**Do:** create `Solutions/<Family>.<version>/` as its own Lake project with its own
-`lean-toolchain`. Declare the same theorem names as `Challenge.lean` and prove what you can.
+**Do:**
+
+```bash
+python scripts/ieantn.py new-solution Lcm.v1
+```
+
+That scaffolds `Solutions/Lcm.v1/` as its own Lake project, with a `Solution.lean` declaring
+exactly what the challenge states and a `comparator.json` naming those theorems. Prove what you
+can.
 
 **Metadata:** the justification does **not** change. Add a progress marker instead:
 
@@ -199,10 +207,16 @@ two hundred nodes still touches exactly two files.
 **CI:** two things must hold, and one is red if it fails:
 
 - The core must build — Vocabulary, Conclusions and Challenges all compile under the new Mathlib.
-- **Every conclusion's elaborated-statement hash must be unchanged.** Normally it is. If a hash
-  *did* move, Mathlib has silently changed what one of your statements means, and that is a genuine
-  semantic change to be handled as workflow 5 — red, not yellow. This is the case that earns the
-  hash mechanism its keep: it is otherwise invisible.
+- **Every statement fingerprint must be unchanged**, and normally it is — by construction, in
+  fact. Fingerprints treat Mathlib constants as opaque names (see `Tools/Hash.lean`), so a bump
+  that reorganises proofs or restates a lemma equivalently cannot move one. What *can* move one is
+  a Mathlib rename that changes which constant a statement refers to; a rename that removes the old
+  name is a build error instead.
+
+  So this check is less a detector of Mathlib misbehaviour than a guard against the bump PR
+  quietly carrying an unrelated edit. The case it cannot see is Mathlib changing what a definition
+  *means* while keeping its name — that is stated plainly in `Tools/Hash.lean` and is not
+  detectable at this price.
 
 If both hold, every affected node simply moves one release further from its verification, and the
 PR is green with warnings.

--- a/README.md
+++ b/README.md
@@ -48,11 +48,14 @@ defeat the purpose of the split.
 
 ## Status
 
-Early. Vocabulary, two proof-of-concept nodes, challenge generation, the network checks and the
-housekeeping queue exist and run in CI. Verification receipts, the breaking-change detector, the
-`/verify` bot, the reviewer report and the visualisation are not built yet — and no node yet
-carries a Lean-verified justification. Sections marked *(planned)* in the documentation are not
-implemented.
+Early, but the machinery is in place. Vocabulary, two proof-of-concept nodes, challenge
+generation, statement fingerprints, verification receipts, the breaking-change detector, the
+network checks and the housekeeping queue all exist and run in CI.
+
+**No node carries a Lean-verified justification yet**, so the Comparator path is untested end to
+end; that waits on porting a first solution. Visualisation, unit tests for the tooling, and the
+code and security audits are outstanding. [docs/ROADMAP.md](docs/ROADMAP.md) tracks what is
+deliberately not built and why.
 
 This work grows out of the IEANTN subproject of
 [PNT+](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd), whose blueprint-based structure

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -96,12 +96,23 @@ the real one: CI regenerates and diffs, so a hand-edited challenge or a stale ya
 ### Solution
 
 May import anything — PNT+, LeanCert, PrimeCert, whatever is convenient. **Each solution is its own
-Lake project with its own pinned `lean-toolchain`**, not a library of the core. That is what lets a
-solution be verified once and then left alone: without its own pin, the next Mathlib bump would
-break every frozen solution in the repository.
+Lake project**, not a library of the core, with its own lakefile and its own manifest. That is what
+keeps a proof's dependencies its own: a solution needing PNT+ must not force PNT+ on the core, which
+has to stay Mathlib-only and fast.
 
-Solutions are **not built by core CI**. Core CI builds Vocabulary and Conclusions only, and must
-stay fast.
+It takes the core as a path dependency, in order to see its node's `Conclusions`. It deliberately
+does *not* import the node's `Challenge`: Comparator compares two modules declaring the same names,
+so importing it would collide.
+
+**A solution's environment is pinned by its receipt's commit, not by a separate `lean-toolchain`.**
+An earlier draft of this document gave each solution its own toolchain file, to protect frozen
+solutions from Mathlib bumps. That does not work alongside a path dependency on the core, and it is
+unnecessary: the receipt records the commit it was verified at, so *re-running at the recorded pin*
+means checking out that commit, where core and solution agree by construction. What a bump costs is
+staleness, not breakage — see §4.
+
+Solutions are **not built by core CI**. Core CI builds Vocabulary, Conclusions and Challenges only,
+and must stay fast.
 
 ## 3. Justification
 
@@ -377,19 +388,42 @@ registering. *(planned)*
 
 ## 8. What exists today
 
-- `IEANTN/Vocabulary/` — the shared language. Builds clean; Mathlib-only closure verified.
-- `IEANTN/Nodes/Dusart2018/v1/`, `IEANTN/Nodes/Lcm/v1/` — two proof-of-concept nodes and the
-  edge between them.
-- `scripts/ieantn.py` — the challenge generator, the network checks (import closure, both
-  acyclicity conditions, generated-challenge diffing), the dependency report, the housekeeping
-  queue, and the `new-version` / `deprecate` commands.
-- `scripts/check_palomar_metadata.py` — validates every node against Palomar's *current*
-  contract, fetched fresh rather than vendored.
-- `.github/workflows/ci.yml` — core build plus the checks above. Does not run Comparator.
-- `docs/` — this document and [NODES.md](NODES.md).
+Built and running in CI:
 
-Still to build: verification receipts and staleness (§4), the housekeeping queue (§6), the
-Palomar spin-off generator (§7), and any solution at all — no node currently carries a
-`lean-comparator` justification.
+| | |
+|---|---|
+| `IEANTN/Vocabulary/` | The shared language. Definitions only, Mathlib-only closure enforced. |
+| `IEANTN/Nodes/*/v1/` | Two proof-of-concept nodes and the edge between them. |
+| `Tools/Hash.lean` | Statement fingerprints (§4), Merkle-chained over IEANTN's own definitions. |
+| `receipts/` | Verification receipts, written by the workflow and never by hand. |
+| `scripts/ieantn.py` | Everything below. |
+| `scripts/verify-comparator.sh` | Comparator with the four trusted tools pinned. |
+| `scripts/check_palomar_metadata.py` | Validates each node against Palomar's *current* contract. |
+| `.github/workflows/ci.yml` | Core build, network checks, fingerprint check, impact report. |
+| `.github/workflows/verify.yml` | Verification, split on privilege (§4). |
 
-See [NODES.md](NODES.md) for the authoring recipe.
+The tooling commands:
+
+```bash
+python scripts/ieantn.py check            # closure, graph, acyclicity, generated challenges
+python scripts/ieantn.py fingerprint      # recompute statement fingerprints
+python scripts/ieantn.py status           # green / yellow / orange / BROKEN per conclusion
+python scripts/ieantn.py diff             # what a branch degrades, and for whom
+python scripts/ieantn.py report           # what each conclusion rests on
+python scripts/ieantn.py housekeeping     # the derived task queue
+python scripts/ieantn.py new-node         # scaffold a node
+python scripts/ieantn.py new-version      # scaffold the next version of one
+python scripts/ieantn.py new-solution     # scaffold a solution project
+python scripts/ieantn.py deprecate        # mark a version for retirement
+```
+
+**Not yet built**, and tracked in [ROADMAP.md](ROADMAP.md): the reviewer report as a PR comment
+rather than a job summary; the `verification` environment gate; the ruleset rule restricting
+`receipts/`; the Palomar spin-off generator; visualisation; unit tests for the tooling; and the
+code and security audits.
+
+**No node carries a Lean-verified justification yet**, so the Comparator path is untested end to
+end. That waits on porting a first solution.
+
+See [NODES.md](NODES.md) for the authoring recipe and [../CONTRIBUTING.md](../CONTRIBUTING.md) for
+the nine kinds of change.

--- a/docs/NODES.md
+++ b/docs/NODES.md
@@ -203,8 +203,15 @@ diffed in CI.
 
 Only when a conclusion is to carry `justification: lean-comparator`.
 
-`Solutions/<NodeId>/` is a **separate Lake project with its own `lean-toolchain`**. It may import
-anything. It declares the same theorem names as the challenge, and proves them.
+```bash
+python scripts/ieantn.py new-solution Lcm.v1
+```
+
+`Solutions/<NodeId>/` is a **separate Lake project**, so its dependencies stay its own. It takes
+the core as a path dependency to see the node's `Conclusions`, and must *not* import the
+`Challenge`: Comparator compares two modules declaring the same names, so importing it collides.
+
+Its environment is pinned by the receipt's commit, not by a separate `lean-toolchain`.
 
 Namespace collision is the usual trap: if the development's own theorems live in `Lcm`, the
 compared declarations cannot also be `Lcm.*`. Bridge in two lines.
@@ -233,6 +240,10 @@ The axiom line must show only `propext`, `Classical.choice`, `Quot.sound`.
 4. Every `formalization.yaml` passes Palomar's current validator.
 5. The import graph is acyclic, and so is justification transport along *designated* bridges.
 6. Every conclusion's statement fingerprint matches `fingerprints.json`.
+7. No conclusion that other nodes depend on has been edited in place, and none still imported has
+   been removed (`ieantn.py diff`).
+8. Every `lean-comparator` justification has a matching file in `receipts/`.
+9. The tooling type-checks (`pyright`, at `basic`).
 
 On (6): after any deliberate change to a conclusion's meaning, run
 `python scripts/ieantn.py fingerprint` and commit the result. Committing the fingerprints is what


### PR DESCRIPTION
The design outran the docs during the proof-of-concept phase. This reconciles them, with three
substantive corrections rather than cosmetic edits.

## Corrections

**Solutions no longer claim their own pinned `lean-toolchain`.** That was written to protect frozen
solutions from Mathlib bumps, but it does not work alongside the path dependency on the core, and
it is unnecessary: the receipt records the commit, so re-running at the recorded pin means checking
out that commit, where core and solution agree by construction. A bump costs staleness, not
breakage.

**The Mathlib-bump section no longer claims a moved fingerprint means Mathlib silently changed a
statement.** Fingerprints treat Mathlib constants as opaque names, so a bump essentially cannot
move one -- the check is really a guard against a bump PR carrying an unrelated edit. The case it
*cannot* see is now stated plainly instead of implied away.

**Status sections describe what exists**, not what was planned, and say clearly that no node
carries a Lean-verified justification yet.

## Additions

- `ARCHITECTURE.md` §8 now lists the built components and every tooling command in one place.
- `CLAUDE.md` gains the rules learned the hard way this session: never write a receipt, never
  hand-edit a generated file, re-run `fingerprint` after changing a conclusion.
- `NODES.md` lists all nine CI invariants rather than six.
- `CONTRIBUTING.md` points at `new-solution` instead of describing the layout by hand.

Also deletes the four merged `infra/*` branches, whose stacking caused #3 and #4 to merge into each
other rather than into `main`.

Made with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)