### PR TITLE
Code audit: first full pass over the tooling

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,14 +6,22 @@ name: Verify a solution
 #
 #   * `comparator` runs UNTRUSTED code -- elaborating a contributor's Lean solution can execute
 #     arbitrary code -- and therefore holds no write access and no secrets.
-#   * `receipt` holds write access but runs no contributor code. It recomputes the statement
-#     fingerprints itself from the core library, which is trusted repository content, so it never
-#     has to believe anything the first job says about them.
+#   * `receipt` holds write access but never builds the contributor's *solution*. It recomputes the
+#     statement fingerprints itself from the core library, so it never has to believe anything the
+#     first job says about them.
 #
-# The residual trust is the same as Palomar's: that Comparator's Landlock sandbox contains the
-# export step, and that this workflow file is itself reviewed. A job running untrusted code can
-# always lie about its own verdict; what it cannot do here is obtain a token or forge a
-# fingerprint.
+# Being exact about the second one, because the obvious reading is too generous: the receipt job
+# does run `lake build` on the branch, and the core library on a contributor's branch is not
+# trusted content -- Lean elaboration can run arbitrary code, so a hostile `Conclusions.lean` would
+# run it here, with a write token. What stops that is not the split but the `verification`
+# environment gate on the job before it: nothing in this workflow runs until a maintainer approves
+# the run, and approving means having looked at the branch. The split buys something narrower and
+# still worth having -- the *solution*, which is the large machine-generated artefact nobody reads,
+# is confined to the unprivileged job.
+#
+# The residual trust is otherwise Palomar's: that Comparator's Landlock sandbox contains the export
+# step, and that this workflow file is itself reviewed. A job running untrusted code can always lie
+# about its own verdict; what it cannot do here is obtain a token or forge a fingerprint.
 
 on:
   workflow_dispatch:
@@ -34,7 +42,12 @@ concurrency:
 
 jobs:
   comparator:
-    name: Run Comparator
+    # The node goes in the job name so that a receipt can be bound to the node it claims. The run
+    # id in a receipt is checked against GitHub, but until this was here, *any* successful run of
+    # this workflow validated *any* receipt: copying one node's run URL into another node's receipt
+    # passed provenance. GitHub records the job name from the dispatch input, not from the receipt,
+    # so `check-receipts` can now insist the two agree.
+    name: Run Comparator (${{ inputs.node }})
     runs-on: ubuntu-latest
     # Gate the *run*, not the request. Configure `verification` with required reviewers so any
     # contributor can ask for a verification and a maintainer approves it -- verification is
@@ -55,10 +68,17 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.24.0"
+      # `inputs.node` reaches the shell through the environment, never through `${{ }}`
+      # interpolation into the script body. Interpolation splices the value into the script before
+      # any shell exists to quote it, so a dispatch input containing shell metacharacters runs as
+      # code. That matters most in the `receipt` job below, which holds `contents: write` -- the
+      # whole point of the privilege split is that no contributor input reaches a token.
       - name: Comparator
+        env:
+          NODE: ${{ inputs.node }}
         run: |
           chmod +x scripts/verify-comparator.sh
-          scripts/verify-comparator.sh "${{ inputs.node }}"
+          scripts/verify-comparator.sh "$NODE"
       - name: Record the verdict
         run: |
           python3 - <<'PY'
@@ -79,7 +99,7 @@ jobs:
           if-no-files-found: error
 
   receipt:
-    name: Record the receipt
+    name: Record the receipt (${{ inputs.node }})
     needs: comparator
     runs-on: ubuntu-latest
     permissions:
@@ -114,18 +134,23 @@ jobs:
       # Fingerprints are recomputed here from the core library -- trusted repository content, not
       # the contributor's solution -- so this job never trusts the untrusted one about them.
       - name: Write the receipt
+        env:
+          NODE: ${{ inputs.node }}
         run: |
           lake build ieantn_hash
-          python3 scripts/ieantn.py record-receipt "${{ inputs.node }}" \
-            --solution "Solutions/${{ inputs.node }}" \
+          python3 scripts/ieantn.py record-receipt "$NODE" \
+            --solution "Solutions/$NODE" \
             --run-url "$(python3 -c 'import json;print(json.load(open("verdict.json"))["run"])')" \
             --stamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
       - name: Commit
+        env:
+          NODE: ${{ inputs.node }}
+          BRANCH: ${{ inputs.branch }}
         run: |
           git config user.name "ieantn-verifier[bot]"
           git config user.email "ieantn-verifier@users.noreply.github.com"
           python3 scripts/ieantn.py state
           git add receipts/ IEANTN/Nodes/ STATE.md
           git diff --cached --quiet && { echo "nothing to record"; exit 0; }
-          git commit -m "Record verification receipt for ${{ inputs.node }}"
-          git push origin HEAD:"${{ inputs.branch }}"
+          git commit -m "Record verification receipt for $NODE"
+          git push origin HEAD:"refs/heads/$BRANCH"

--- a/Tools/Hash.lean
+++ b/Tools/Hash.lean
@@ -59,8 +59,14 @@ namespace IEANTN.Fingerprint
 /-- Is this constant defined by this project, rather than by Lean core or Mathlib?
 
 Decided by **module provenance**, not by guessing at name prefixes: the environment records which
-module every constant came from, and ours are exactly those under `IEANTN`. A constant with no
-recorded module was defined in the module currently being elaborated, which is also ours. -/
+module every constant came from, and ours are exactly those under `IEANTN`.
+
+The `none` case is not "defined in the module being elaborated", as this comment used to say -- this
+runs against an imported environment, so there is no such module. It means provenance could not be
+established at all, and `true` is the deliberate choice: an unrecognised constant that is really
+ours must be followed or a change to it would go unnoticed, whereas one that is really Mathlib's
+costs at worst a spurious fingerprint move at a toolchain bump. The error directions are not
+symmetric, so the default goes to the noisy one. -/
 def isLocal (env : Environment) (n : Name) : Bool :=
   match env.getModuleFor? n with
   | some m => (`IEANTN).isPrefixOf m

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -193,10 +193,18 @@ dispatchable CI workflow rather than on a maintainer's machine: a receipt backed
 workflow with public logs is much stronger evidence than one produced locally.
 
 **They are written by the verifier, never by the author.** A receipt an author can write is a claim
-of verification typed by the person making the claim. `receipts/` is restricted to the verification
-workflow's identity by a ruleset path rule; `check-graph` refuses a `lean-comparator` justification
-with no matching receipt file; and a receipt arriving in a pull request from anyone else is a
-review failure rather than a formatting nit.
+of verification typed by the person making the claim, and a receipt arriving in a pull request from
+anyone else is a review failure rather than a formatting nit.
+
+The intended enforcement was a ruleset restricting `receipts/` to the workflow's identity. GitHub
+does not offer it here -- it refuses push rulesets on public repositories and outside an
+organisation -- so `check-receipts` enforces provenance instead, which is the better control:
+a path rule says who wrote the file, provenance says the verification happened. It requires each
+receipt to name a run that exists, succeeded, is `verify.yml`, and is **that node's** -- the
+dispatched node appears in the job name, so GitHub's record of the run, not the receipt, decides
+what was verified. Separately, `check-graph` refuses a `lean-comparator` justification with no
+matching receipt, and `record-receipt` refuses to receipt any conclusion absent from the solution's
+`comparator.json`.
 
 `python scripts/ieantn.py status` grades every receipt against the world as it is now.
 
@@ -429,6 +437,7 @@ Built and running in CI:
 | `scripts/verify-comparator.sh` | Comparator with the four trusted tools pinned. |
 | `scripts/check_palomar_metadata.py` | Validates each node against Palomar's *current* contract. |
 | `.github/workflows/ci.yml` | Core build, network checks, fingerprint check, impact report. |
+| `IEANTN/Bridges/` | Proofs that one node's conclusion implies another's; in the core build. |
 | `.github/workflows/verify.yml` | Verification, split on privilege (§4). |
 
 The tooling commands:
@@ -446,13 +455,13 @@ python scripts/ieantn.py new-solution     # scaffold a solution project
 python scripts/ieantn.py deprecate        # mark a version for retirement
 ```
 
-**Not yet built**, and tracked in [ROADMAP.md](ROADMAP.md): the reviewer report as a PR comment
-rather than a job summary; the `verification` environment gate; the ruleset rule restricting
-`receipts/`; the Palomar spin-off generator; visualisation; unit tests for the tooling; and the
-code and security audits.
+**Not yet built**, and tracked in [ROADMAP.md](ROADMAP.md): the reviewer report as a pull request
+comment rather than a job summary; a `/verify` comment trigger; the Palomar spin-off generator;
+visualisation; and verification methods beyond Comparator. The `receipts/` ruleset is not pending
+but unavailable, and provenance replaced it -- see above.
 
-**No node carries a Lean-verified justification yet**, so the Comparator path is untested end to
-end. That waits on porting a first solution.
+**The Comparator path is exercised end to end**: `Lcm.v1` carries a receipt written by the
+verification workflow, and `status` grades it against the current environment.
 
 See [NODES.md](NODES.md) for the authoring recipe and [../CONTRIBUTING.md](../CONTRIBUTING.md) for
-the nine kinds of change.
+the ten kinds of change.

--- a/docs/NODES.md
+++ b/docs/NODES.md
@@ -133,6 +133,9 @@ classification:
   msc2020: ["11N05"]
 
 conclusions:
+  # `id`, and both halves of every `imports` entry, must be Lean identifiers: they are written
+  # verbatim into the generated challenge, as declaration names and as binder types. CI rejects
+  # anything else.
   - id: proposition_5_4
     declaration: Dusart2018.v1.proposition_5_4
     challenge: Dusart2018.v1.challenge_proposition_5_4

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -156,11 +156,62 @@ impossible or merely inconvenient. Most numerical claims in explicit analytic nu
 certifiable: the interval-arithmetic and table-driven results in PNT+ are already of that shape.
 Tier B should stay rare enough to be conspicuous.
 
-## Code audit, still to do
+## Code audit
 
-The tooling has accumulated a real defect rate during the proof-of-concept phase, and the classes
-below are the ones actually observed rather than a generic wish for review. They are recorded
-because each predicts where the next one will be.
+**First pass done.** What follows is in two parts: what the pass found and fixed, and the defect
+*classes* observed during development, kept because each predicts where the next one will be.
+
+### What the first pass found
+
+Read end to end: `scripts/ieantn.py`, `Tools/Hash.lean`, `scripts/verify-comparator.sh`, and the
+workflows. Nine defects, each now covered by a test that was checked to fail without its fix.
+
+Two were soundness holes in the thing the repository exists to get right:
+
+- **A receipt could cover a conclusion Comparator never saw.** Comparator runs once per node
+  against `theorem_names` in the solution's `comparator.json`; receipts are written per conclusion;
+  nothing connected the two. Adding a second conclusion to an already-verified node was enough to
+  earn it a full `lean-comparator` justification for a statement no verifier had seen. No adversary
+  required, and `status` would have shown it green. `record-receipt` now refuses unless every
+  conclusion is listed.
+- **Any successful verification validated any receipt.** `check-receipts` checked that the run
+  existed, succeeded, and was `verify.yml` — not that it was *this node's*. Copying a real run URL
+  into a fabricated receipt passed. The dispatched node now appears in `verify.yml`'s job names, so
+  GitHub's record of the run decides what was verified; older runs fall back to one-run-one-node.
+
+One was a live vulnerability:
+
+- **Script injection in `verify.yml`.** Dispatch inputs were interpolated into `run:` bodies with
+  `${{ }}`, which splices the value in before any shell exists to quote it. The worst case is the
+  `receipt` job, which holds `contents: write` — precisely what the privilege split exists to
+  protect. Inputs now reach the shell through `env:`.
+
+Three were checks that did not check:
+
+- **A trailing comment hid an import.** The import pattern was anchored at end of line, so
+  `import Solutions.Whatever -- for now` matched nothing and every closure check silently passed.
+- **`startswith` ignored module boundaries**, accepting `IEANTN.VocabularyScratch` as Vocabulary.
+- **The receipt warning read the wrong justification** — the `kind` left over from a loop rather
+  than the designated one — so recording any second ground made a verified node report unverified.
+  Found by hitting it, not by reading: adding the `Lcm.v2` bridge triggered it immediately.
+
+Three were hardening and hygiene:
+
+- **Metadata is interpolated verbatim into generated Lean.** A conclusion `id`, and both halves of
+  an import reference, become declaration names and binder types in `Challenge.lean`. Since CI only
+  diffs that file against what the generator produces, crafted text would be regenerated faithfully
+  and compiled into the core library. Ids must now be Lean identifiers.
+- **`designate_verification` un-deprecated nodes** and left a stale run URL in the note on
+  re-verification.
+- **`deprecate` accepted a node superseding itself**, or a replacement already deprecated.
+
+Documentation contradicted itself in three places about the `receipts/` ruleset — asserted as the
+enforcement in `ARCHITECTURE.md` and `receipts/README.md`, correctly described as impossible in
+`ROADMAP.md`. Provenance is the enforcement; the docs now say so uniformly.
+
+### Defect classes to keep watching
+
+The classes below are the ones actually observed rather than a generic wish for review.
 
 **Silent no-ops.** The worst class, because the tool reports success. A blanket `v1` to `v2`
 rewrite in `new-version` silently repointed a node's *imports* at a version that did not exist. A
@@ -172,8 +223,10 @@ exactly this, and it is what caught most of these; the shipped tooling does not.
 **Tests that do not test.** An `exit=$?` after a pipe reports the exit code of `head`. A `sed` that
 matched nothing left a test asserting a property it had not established. This is the project's own
 failure mode one level up: a check that passes vacuously is the junk-value problem applied to CI,
-and it deserves the same suspicion the Vocabulary docstrings give to `tsum`.
-**There are currently no unit tests for `scripts/ieantn.py` at all.**
+and it deserves the same suspicion the Vocabulary docstrings give to `tsum`. Three of the nine
+findings above are of exactly this class. The standing practice: **every new test is run once
+against the unfixed code and must fail**, which is how the twelve added in the audit pass were
+shown not to be decorative.
 
 **Destructive round-trips.** `yaml.safe_dump` silently discarded every comment in a node's
 metadata, where the comments carry the provenance. Fixed by moving the mutating commands to

--- a/receipts/README.md
+++ b/receipts/README.md
@@ -10,9 +10,28 @@ re-fingerprinting and comparing — never by looking at a date. The timestamp is
 ## These files are written by the verification workflow, not by hand
 
 A receipt an author can write is worth nothing: it is a claim of verification typed by the person
-making the claim. `receipts/` is therefore restricted to the verification workflow's identity by a
-ruleset path rule, and a receipt arriving in a pull request from anyone else is a review failure,
-not a formatting nit.
+making the claim. A receipt arriving in a pull request from anyone but the verification workflow is
+a review failure, not a formatting nit.
+
+The intended enforcement — a ruleset restricting `receipts/` to the workflow's identity — is not
+available here: GitHub refuses push rulesets on public repositories and on repositories outside an
+organisation. `python scripts/ieantn.py check-receipts` enforces **provenance** instead, and it is
+the better control anyway, because it checks that the verification happened rather than who typed
+the file. For each receipt it requires:
+
+- a recorded run URL pointing at this repository;
+- that the run exists, concluded `success`, and is `verify.yml` — which needs a maintainer to have
+  approved the `verification` environment;
+- that the run is **this node's**. `verify.yml` puts the dispatched node in its job names, so
+  GitHub's own record says what was verified. Without this, any successful verification validated
+  any receipt: copying a real run URL into a fabricated receipt passed. Receipts predating the
+  convention fall back to a uniqueness rule — one run, one node.
+
+A receipt also may not cover more than Comparator was asked about. `record-receipt` cross-checks
+the node's conclusions against `theorem_names` in the solution's `comparator.json` and refuses if
+any conclusion is missing. This is not an anti-forgery measure: adding a second conclusion to an
+already-verified node was enough to earn it a `lean-comparator` justification for a statement no
+verifier had seen.
 
 `python scripts/ieantn.py record-receipt` exists for the workflow to call. Do not run it yourself.
 

--- a/scripts/ieantn.py
+++ b/scripts/ieantn.py
@@ -81,7 +81,13 @@ NODE_STATUSES = {
     "deprecated",
 }
 
-IMPORT_RE = re.compile(r"^import\s+([A-Za-z0-9_.]+)\s*$", re.MULTILINE)
+IMPORT_RE = re.compile(r"^import\s+(\S+)", re.MULTILINE)
+
+#: What may appear as a conclusion id, or as either half of an import reference. These strings are
+#: interpolated verbatim into generated Lean, so anything not an identifier is either a typo or an
+#: injection; there is no third case, and no reason to accept one.
+LEAN_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_']*")
+LEAN_PATH_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_']*(?:\.[A-Za-z_0-9][A-Za-z0-9_']*)*")
 
 
 def _set_root(path: pathlib.Path) -> None:
@@ -140,8 +146,26 @@ def rel(path: pathlib.Path) -> str:
     return path.relative_to(ROOT).as_posix()
 
 
+def under(module: str, root: str) -> bool:
+    """Is `module` the module `root`, or one beneath it?
+
+    `startswith` is not this test: it accepts `IEANTN.VocabularyScratch` as Vocabulary and
+    `MathlibExtras` as Mathlib. Nothing has ever been named that way here, which is the problem --
+    the check would go on passing on the day something was.
+    """
+    return module == root or module.startswith(root + ".")
+
+
 def imports_of(path: pathlib.Path) -> list[str]:
-    return IMPORT_RE.findall(path.read_text(encoding="utf-8"))
+    """Every module a Lean file imports.
+
+    Comments are stripped first, and the module name is read up to whitespace rather than to end of
+    line. Both matter, in opposite directions. Anchoring the old pattern at `$` meant
+    `import Mathlib.Tactic -- why` matched nothing at all, so a trailing comment was enough to hide
+    an import from every closure check -- silently, and in the direction that lets a violation
+    through. Not stripping comments meant a commented-out import was reported as real.
+    """
+    return IMPORT_RE.findall(strip_lean_comments(path.read_text(encoding="utf-8")))
 
 
 def strip_lean_comments(text: str) -> str:
@@ -343,6 +367,7 @@ def check_receipts(online: bool = True) -> bool:
         cwd=ROOT, capture_output=True, text=True, encoding="utf-8",
     ).stdout.strip()
     expected = re.sub(r"^.*github\.com[:/]|\.git$", "", remote) if remote else None
+    seen_runs: dict[str, str] = {}
 
     for path in sorted(RECEIPTS.glob("*.json")) if RECEIPTS.is_dir() else []:
         receipt = json.loads(path.read_text(encoding="utf-8"))
@@ -355,6 +380,19 @@ def check_receipts(online: bool = True) -> bool:
         if expected and repository != expected:
             problems.add(rel(path), f"points at `{repository}`, not `{expected}`")
             continue
+        # One run, one node. Without this, a receipt for any node validated against any successful
+        # verification: copying the run URL out of a real receipt into a fabricated one passed.
+        # Uniqueness is the part that works retroactively; the job-name check below is the sharper
+        # one, and applies to every run recorded since the node went into the job name.
+        node_of = str(receipt.get("conclusion") or path.stem).rsplit(".", 1)[0]
+        claimed = seen_runs.setdefault(url, node_of)
+        if claimed != node_of:
+            problems.add(
+                rel(path),
+                f"cites run {run_id}, which another receipt already cites for `{claimed}`. One "
+                "verification run covers one node.",
+            )
+
         if not online:
             continue
         finished = subprocess.run(
@@ -371,6 +409,23 @@ def check_receipts(online: bool = True) -> bool:
             problems.add(rel(path), f"run {run_id} concluded `{conclusion}`, not `success`")
         if workflow != ".github/workflows/verify.yml":
             problems.add(rel(path), f"run {run_id} is `{workflow}`, not the verification workflow")
+            continue
+
+        # `verify.yml` puts the dispatched node in its job names, so GitHub's record of the run
+        # says which node was verified -- independently of anything the receipt asserts. Runs from
+        # before that convention have no parenthesised job name; those fall back to the uniqueness
+        # check above rather than failing, since re-running them is not possible.
+        jobs = subprocess.run(
+            ["gh", "api", f"repos/{repository}/actions/runs/{run_id}/jobs",
+             "--jq", ".jobs[].name"],
+            cwd=ROOT, capture_output=True, text=True, encoding="utf-8",
+        )
+        names = jobs.stdout.split("\n") if jobs.returncode == 0 else []
+        if any("(" in name for name in names) and not any(f"({node_of})" in name for name in names):
+            problems.add(
+                rel(path),
+                f"run {run_id} verified {[n for n in names if '(' in n]}, not `{node_of}`",
+            )
 
     return problems.report("receipt provenance")
 
@@ -386,7 +441,7 @@ def check_closure() -> bool:
 
     for path in sorted(VOCAB_DIR.rglob("*.lean")):
         for module in imports_of(path):
-            if not (module.startswith("Mathlib") or module.startswith("IEANTN.Vocabulary")):
+            if not (under(module, "Mathlib") or under(module, "IEANTN.Vocabulary")):
                 problems.add(rel(path), f"Vocabulary may import only Mathlib; found `{module}`")
 
     for directory in node_dirs():
@@ -394,9 +449,9 @@ def check_closure() -> bool:
         if conclusions.is_file():
             for module in imports_of(conclusions):
                 ok = (
-                    module.startswith("Mathlib")
-                    or module.startswith("IEANTN.Vocabulary")
-                    or (module.startswith("IEANTN.Nodes.") and module.endswith(".Conclusions"))
+                    under(module, "Mathlib")
+                    or under(module, "IEANTN.Vocabulary")
+                    or (under(module, "IEANTN.Nodes") and module.endswith(".Conclusions"))
                 )
                 if not ok:
                     problems.add(
@@ -413,9 +468,9 @@ def check_closure() -> bool:
         if examples.is_file():
             for module in imports_of(examples):
                 ok = (
-                    module.startswith("Mathlib")
-                    or module.startswith("IEANTN.Vocabulary")
-                    or (module.startswith("IEANTN.Nodes.") and module.endswith(".Conclusions"))
+                    under(module, "Mathlib")
+                    or under(module, "IEANTN.Vocabulary")
+                    or (under(module, "IEANTN.Nodes") and module.endswith(".Conclusions"))
                 )
                 if not ok:
                     problems.add(
@@ -444,10 +499,10 @@ def check_closure() -> bool:
     for path in sorted(BRIDGES_DIR.rglob("*.lean")):
         for module in imports_of(path):
             ok = (
-                module.startswith("Mathlib")
-                or module.startswith("IEANTN.Vocabulary")
-                or (module.startswith("IEANTN.Nodes.") and module.endswith(".Conclusions"))
-                or module.startswith("IEANTN.Bridges.")
+                under(module, "Mathlib")
+                or under(module, "IEANTN.Vocabulary")
+                or (under(module, "IEANTN.Nodes") and module.endswith(".Conclusions"))
+                or under(module, "IEANTN.Bridges")
             )
             if not ok:
                 problems.add(
@@ -472,7 +527,7 @@ def check_closure() -> bool:
         challenge = directory / "Challenge.lean"
         if challenge.is_file():
             for module in imports_of(challenge):
-                if not (module.startswith("IEANTN.Nodes.") and module.endswith(".Conclusions")):
+                if not (under(module, "IEANTN.Nodes") and module.endswith(".Conclusions")):
                     problems.add(
                         rel(challenge),
                         f"a Challenge file may import only Conclusions files; found `{module}`",
@@ -592,6 +647,19 @@ def check_graph() -> bool:
             if cid in seen:
                 problems.add(where, f"duplicate conclusion id `{cid}`")
             seen.add(cid)
+
+            # `cid` is interpolated into the generated Challenge as a declaration name. Nothing
+            # downstream re-reads that file critically -- CI only diffs it against what the
+            # generator produces, so text smuggled in through the metadata would be regenerated
+            # faithfully and compiled into the core library. An id is an identifier or it is
+            # wrong.
+            if not LEAN_NAME_RE.fullmatch(str(cid)):
+                problems.add(
+                    where,
+                    f"conclusion id `{cid}` is not a Lean identifier. It is written into the "
+                    "generated challenge as a declaration name, so it may contain only letters, "
+                    "digits, underscores and primes, and may not begin with a digit.",
+                )
 
             if conclusion.get("declaration") != f"{node_id}.{cid}":
                 problems.add(
@@ -721,6 +789,20 @@ def check_graph() -> bool:
             for dependency in conclusion.get("imports") or []:
                 target_node = dependency.get("node")
                 target_conclusion = dependency.get("conclusion")
+                # Both halves become part of a hypothesis binder's type in the generated
+                # challenge, so they are subject to the same rule as a conclusion id. Checked
+                # before the existence test below, which would otherwise report a crafted string
+                # as a mere unknown node.
+                for label, value, pattern in (
+                    ("node", target_node, LEAN_PATH_RE),
+                    ("conclusion", target_conclusion, LEAN_NAME_RE),
+                ):
+                    if not pattern.fullmatch(str(value)):
+                        problems.add(
+                            where,
+                            f"conclusion `{cid}`: import {label} `{value}` is not a Lean name, and "
+                            "is written verbatim into the generated challenge",
+                        )
                 if target_node not in nodes:
                     problems.add(where, f"conclusion `{cid}` imports unknown node `{target_node}`")
                     continue
@@ -1209,17 +1291,63 @@ under `progress`, and leave the justification alone -- an incomplete solution ju
     return True
 
 
+def _comparator_covers_every_conclusion(node_id: str, node: dict) -> bool:
+    """Refuse to receipt conclusions Comparator was never asked about.
+
+    A receipt is written per conclusion, but Comparator is run once per *node*, against the
+    `theorem_names` listed in the solution's `comparator.json`. Nothing previously connected the
+    two, so a node whose conclusions had grown since its solution was written would receive a
+    receipt for the new conclusion as well -- a full `lean-comparator` justification for a
+    statement no verifier had ever seen. That is the one failure this whole apparatus exists to
+    prevent, and it needed no adversary: adding a second conclusion to a verified node was enough.
+    """
+    config = SOLUTIONS / node_id / "comparator.json"
+    where = rel(config)
+    if not config.is_file():
+        print(f"error: {where} does not exist, so nothing says what was verified")
+        return False
+    try:
+        listed = set(json.loads(config.read_text(encoding="utf-8")).get("theorem_names") or [])
+    except json.JSONDecodeError as broken:
+        print(f"error: {where} is not readable JSON: {broken}")
+        return False
+
+    expected = {f"{node_id}.challenge_{c.get('id')}" for c in conclusions_of(node)}
+    unverified = sorted(expected - listed)
+    if unverified:
+        print(
+            f"error: {where} does not list {', '.join(unverified)}.\n"
+            "       Comparator was not asked about "
+            f"{'them' if len(unverified) > 1 else 'it'}, so no receipt may claim "
+            f"{'they were' if len(unverified) > 1 else 'it was'} verified. Add "
+            f"{'them' if len(unverified) > 1 else 'it'} to the solution and re-run the "
+            "verification."
+        )
+        return False
+    # The converse is a mistake rather than a hazard -- a name that no longer corresponds to a
+    # conclusion was probably renamed, and the receipt would be recorded under the new name while
+    # Comparator checked the old one.
+    for stale in sorted(listed - expected):
+        print(f"warning: {where} lists `{stale}`, which is not a conclusion of {node_id}")
+    return True
+
+
 def record_receipt(node_id: str, solution: str, run_url: str, stamp: str) -> bool:
     """Write a receipt. **Run by the verification workflow, never by an author.**
 
-    An author-written receipt is worth nothing -- it is a claim of verification typed by the
-    person making the claim. The protection is not this function refusing to run; it is that
-    `receipts/` is writable only by the verification workflow's identity, enforced by a ruleset
-    path restriction, and that a receipt arriving in a PR from anyone else is a review failure.
+    An author-written receipt is worth nothing -- it is a claim of verification typed by the person
+    making the claim. What makes a receipt mean something is not this function refusing to run: it
+    is that `check-receipts` fetches the run it names and requires a successful run of `verify.yml`
+    for this node, which needs a maintainer to approve the `verification` environment. (The
+    intended `receipts/` path ruleset is not available -- GitHub refuses push rules on public
+    repositories and on repositories outside an organisation. Provenance replaced it.)
     """
     nodes = load_nodes()
     if node_id not in nodes:
         print(f"error: unknown node `{node_id}`")
+        return False
+
+    if not _comparator_covers_every_conclusion(node_id, nodes[node_id]):
         return False
 
     fingerprints = compute_fingerprints()
@@ -1278,9 +1406,19 @@ def designate_verification(node_id: str, run_url: str) -> None:
                 "note": f"Comparator accepted the solution. Run: {run_url}",
             }
             justifications.append(existing)
+        else:
+            # Re-verification: the receipt now names the new run, and a note still naming the old
+            # one sends a reader to a run that verified a statement this one may have replaced.
+            existing["note"] = f"Comparator accepted the solution. Run: {run_url}"
         conclusion["designated"] = existing["id"]
         conclusion.pop("progress", None)
-    data.setdefault("node", {})["status"] = "active"
+    # Not an unconditional `active`: verifying a deprecated node is a legitimate thing to do --
+    # keeping an old version green while dependants migrate off it is exactly the case -- and
+    # flipping its status here would silently un-deprecate it, dropping it out of the migration
+    # queue that `housekeeping` derives.
+    meta = data.setdefault("node", {})
+    if meta.get("status") != "deprecated":
+        meta["status"] = "active"
     with metadata.open("w", encoding="utf-8", newline="\n") as handle:
         writer.dump(data, handle)
     print(f"designated the verification in {rel(metadata)}")
@@ -1353,11 +1491,42 @@ def report() -> bool:
     return True
 
 
+def closed_issues(numbers: set[int]) -> set[int]:
+    """Which of these issue numbers are closed, as far as `gh` can tell.
+
+    Best-effort and silent on failure: `gh` may be absent, unauthenticated, or offline, and
+    housekeeping has to stay useful without it. An issue that cannot be read is treated as open,
+    because reporting live work as abandoned is the more expensive mistake.
+    """
+    closed: set[int] = set()
+    for number in sorted(numbers):
+        finished = subprocess.run(
+            ["gh", "issue", "view", str(number), "--json", "state", "--jq", ".state"],
+            cwd=ROOT, capture_output=True, text=True, encoding="utf-8",
+        )
+        if finished.returncode == 0 and finished.stdout.strip().upper() == "CLOSED":
+            closed.add(number)
+    return closed
+
+
 def housekeeping() -> bool:
     """The task queue, derived from graph state rather than maintained by hand."""
     nodes = load_nodes()
     importers = importers_of(nodes)
     tasks: list[str] = []
+
+    # An outstanding conclusion whose issue has been closed is work nobody is tracking any more:
+    # the queue says it is claimed, and the issue tracker says it is finished. It happens by
+    # accident -- closing the issue alongside the pull request that created the node rather than
+    # the one that justifies it -- and nothing else in the tooling would ever mention it again.
+    outstanding = {
+        conclusion.get("issue")
+        for node in nodes.values()
+        for conclusion in conclusions_of(node)
+        if designated_kind(conclusion) in {"none-yet", "literature", "asserted"}
+        and isinstance(conclusion.get("issue"), int)
+    }
+    stale_issues = closed_issues({n for n in outstanding if isinstance(n, int)})
 
     for node_id, node in sorted(nodes.items()):
         meta = node.get("node") or {}
@@ -1375,7 +1544,12 @@ def housekeeping() -> bool:
         for conclusion in conclusions_of(node):
             kind = designated_kind(conclusion)
             issue = conclusion.get("issue")
-            claim = f"#{issue}" if issue else "UNCLAIMED, no issue"
+            if issue is None:
+                claim = "UNCLAIMED, no issue"
+            elif issue in stale_issues:
+                claim = f"#{issue} CLOSED -- reopen it, or drop the `issue` field"
+            else:
+                claim = f"#{issue}"
             if kind == "none-yet":
                 tasks.append(f"justify   {node_id}.{conclusion.get('id')}  [{claim}]")
             elif kind in {"literature", "asserted"}:
@@ -1875,6 +2049,12 @@ def deprecate(node_id: str, replacement: str) -> bool:
         return False
     if replacement not in nodes:
         print(f"error: unknown replacement node `{replacement}`")
+        return False
+    if replacement == node_id:
+        print(f"error: `{node_id}` cannot supersede itself")
+        return False
+    if ((nodes[replacement].get("node") or {}).get("status")) == "deprecated":
+        print(f"error: `{replacement}` is itself deprecated; name a live node")
         return False
 
     path = nodes[node_id]["_dir"] / "formalization.yaml"

--- a/tests/test_ieantn.py
+++ b/tests/test_ieantn.py
@@ -195,6 +195,23 @@ class FixtureRepo(unittest.TestCase):
         )
         return directory
 
+    def write_comparator_config(self, node_id: str, theorem_names: list[str] | None = None) -> None:
+        """The solution config naming what Comparator was asked to check.
+
+        `record-receipt` refuses without it: a receipt is written per conclusion, but Comparator
+        runs once per node against exactly this list.
+        """
+        directory = self.root / "Solutions" / node_id
+        directory.mkdir(parents=True, exist_ok=True)
+        if theorem_names is None:
+            node = ieantn.load_nodes()[node_id]
+            theorem_names = [
+                f"{node_id}.challenge_{c.get('id')}" for c in ieantn.conclusions_of(node)
+            ]
+        (directory / "comparator.json").write_text(
+            json.dumps({"theorem_names": theorem_names}), encoding="utf-8"
+        )
+
     def write_bridge(self, body: str = "-- bridge\n") -> pathlib.Path:
         directory = self.root / "IEANTN" / "Bridges"
         directory.mkdir(parents=True, exist_ok=True)
@@ -363,6 +380,99 @@ class TestGraphChecks(FixtureRepo):
             "A.v2", bridged("A.v1.main").replace("IEANTN/Bridges/a.lean", "Bridges/a.lean")
         )
         self.assertFalse(ieantn.check_graph())
+
+
+class TestImportParsing(FixtureRepo):
+    """What counts as an import, and what does not.
+
+    Every closure check in this file is only as good as this parse. The old pattern anchored the
+    module name at end of line, so a trailing comment hid an import from all of them -- silently,
+    and in the direction that lets a violation through.
+    """
+
+    def test_a_trailing_comment_does_not_hide_an_import(self) -> None:
+        (self.root / "IEANTN" / "Vocabulary" / "Bad.lean").write_text(
+            "import Solutions.A.v1.Solution -- just for now\n", encoding="utf-8"
+        )
+        self.assertFalse(ieantn.check_closure())
+
+    def test_a_commented_out_import_is_not_an_import(self) -> None:
+        (self.root / "IEANTN" / "Vocabulary" / "Fine.lean").write_text(
+            "-- import Solutions.A.v1.Solution\n/- import PNT.Everything -/\nimport Mathlib.Data.Nat.Defs\n",
+            encoding="utf-8",
+        )
+        self.assertTrue(ieantn.check_closure())
+
+    def test_a_lookalike_module_is_not_vocabulary(self) -> None:
+        """`startswith` accepted `IEANTN.VocabularyScratch` as Vocabulary, and `MathlibExtras` as
+        Mathlib. Nothing was ever named that way, which is precisely the problem."""
+        (self.root / "IEANTN" / "Vocabulary" / "Bad.lean").write_text(
+            "import IEANTN.VocabularyScratch\n", encoding="utf-8"
+        )
+        self.assertFalse(ieantn.check_closure())
+
+    def test_imports_of_reads_the_module_name(self) -> None:
+        target = self.root / "x.lean"
+        target.write_text("import A.B -- c\nimport D\n", encoding="utf-8")
+        self.assertEqual(ieantn.imports_of(target), ["A.B", "D"])
+
+
+class TestGeneratedLeanIsNotInjectable(FixtureRepo):
+    """Metadata strings are interpolated verbatim into the generated challenge.
+
+    Nothing downstream reads that file critically -- CI only diffs it against what the generator
+    produces -- so a crafted id would be regenerated faithfully and compiled into the core library.
+    """
+
+    def test_a_conclusion_id_must_be_an_identifier(self) -> None:
+        """The crafted id is propagated to `declaration` and `challenge` too, so the consistency
+        checks are satisfied and only the identifier rule can reject it."""
+        crafted = "main : True := trivial\n\naxiom sneaky : False\n\ntheorem unused"
+        self.write_node("A.v1", (
+            f"\n- id: {json.dumps(crafted)}\n"
+            f"  declaration: {json.dumps('A.v1.' + crafted)}\n"
+            f"  challenge: {json.dumps('A.v1.challenge_' + crafted)}\n"
+            "  imports: []\n"
+            "  justifications:\n"
+            "    - id: paper\n"
+            "      kind: literature\n"
+            "  designated: paper\n"
+        ))
+        printed = io.StringIO()
+        with contextlib.redirect_stdout(printed):
+            passed = ieantn.check_graph()
+        self.assertFalse(passed)
+        self.assertIn("is not a Lean identifier", printed.getvalue())
+
+    def test_an_import_reference_must_be_a_lean_name(self) -> None:
+        self.write_node("Upstream.v1", LITERATURE)
+        self.write_node(
+            "A.v1", importing("Upstream.v1").replace("conclusion: main", "conclusion: 'main) (h : False'")
+        )
+        printed = io.StringIO()
+        with contextlib.redirect_stdout(printed):
+            passed = ieantn.check_graph()
+        self.assertFalse(passed)
+        self.assertIn("written verbatim into the generated challenge", printed.getvalue())
+
+    def test_an_ordinary_id_still_passes(self) -> None:
+        self.write_node("A.v1", LITERATURE.replace("main", "theorem_5_4'"))
+        self.assertTrue(ieantn.check_graph())
+
+
+class TestDeprecateGuards(FixtureRepo):
+    def test_a_node_may_not_supersede_itself(self) -> None:
+        self.write_node("A.v1", LITERATURE)
+        printed = io.StringIO()
+        with contextlib.redirect_stdout(printed):
+            self.assertFalse(ieantn.deprecate("A.v1", "A.v1"))
+
+    def test_the_replacement_may_not_be_deprecated(self) -> None:
+        self.write_node("A.v1", LITERATURE)
+        self.write_node("A.v2", LITERATURE, status="deprecated")
+        printed = io.StringIO()
+        with contextlib.redirect_stdout(printed):
+            self.assertFalse(ieantn.deprecate("A.v1", "A.v2"))
 
 
 class TestBridgeClosure(FixtureRepo):
@@ -860,6 +970,7 @@ class TestRecordReceipt(FixtureRepo):
         except ImportError:
             self.skipTest("ruamel.yaml not installed")
         self.write_node("A.v1", LITERATURE.replace("kind: literature", "kind: none-yet"))
+        self.write_comparator_config("A.v1")
         self.assertTrue(ieantn.record_receipt("A.v1", "Solutions/A.v1", "http://run", "now"))
         self.assertTrue((self.root / "receipts" / "A.v1.main.json").is_file())
         conclusion = ieantn.conclusions_of(ieantn.load_nodes()["A.v1"])[0]
@@ -874,6 +985,7 @@ class TestRecordReceipt(FixtureRepo):
             self.skipTest("ruamel.yaml not installed")
         self.write_node("Upstream.v1", LITERATURE)
         self.write_node("A.v1", importing("Upstream.v1"))
+        self.write_comparator_config("A.v1")
         self.assertTrue(ieantn.record_receipt("A.v1", "Solutions/A.v1", "http://run", "now"))
         receipt = json.loads(
             (self.root / "receipts" / "A.v1.main.json").read_text(encoding="utf-8")
@@ -881,6 +993,59 @@ class TestRecordReceipt(FixtureRepo):
         self.assertEqual(
             sorted(receipt["statement"]), ["A.v1.main", "Upstream.v1.main"]
         )
+
+
+class TestReceiptCoverage(FixtureRepo):
+    """A receipt may only cover conclusions Comparator was actually asked about.
+
+    Comparator runs once per node, against the `theorem_names` in the solution's `comparator.json`;
+    receipts are written per conclusion. Nothing connected the two, so adding a second conclusion
+    to an already-verified node earned it a full `lean-comparator` justification for a statement no
+    verifier had ever seen. No adversary required.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._real = ieantn.compute_fingerprints
+        ieantn.compute_fingerprints = lambda: {  # type: ignore[assignment]
+            "A.v1.main": "aa", "A.v1.second": "cc", "Upstream.v1.main": "bb"
+        }
+        self.addCleanup(lambda: setattr(ieantn, "compute_fingerprints", self._real))
+
+    def _two_conclusions(self) -> None:
+        self.write_node(
+            "A.v1",
+            LITERATURE + LITERATURE.replace("id: main", "id: second")
+            .replace("{node}.main", "{node}.second")
+            .replace("challenge_main", "challenge_second"),
+        )
+
+    def test_a_conclusion_comparator_never_saw_gets_no_receipt(self) -> None:
+        self._two_conclusions()
+        self.write_comparator_config("A.v1", ["A.v1.challenge_main"])
+        printed = io.StringIO()
+        with contextlib.redirect_stdout(printed):
+            recorded = ieantn.record_receipt("A.v1", "Solutions/A.v1", "http://run", "now")
+        self.assertFalse(recorded)
+        self.assertIn("A.v1.challenge_second", printed.getvalue())
+        self.assertFalse((self.root / "receipts").exists())
+
+    def test_a_missing_config_is_refused(self) -> None:
+        self.write_node("A.v1", LITERATURE)
+        printed = io.StringIO()
+        with contextlib.redirect_stdout(printed):
+            self.assertFalse(ieantn.record_receipt("A.v1", "Solutions/A.v1", "http://run", "now"))
+        self.assertIn("does not exist", printed.getvalue())
+
+    def test_full_coverage_is_accepted(self) -> None:
+        try:
+            import ruamel.yaml  # noqa: F401
+        except ImportError:
+            self.skipTest("ruamel.yaml not installed")
+        self._two_conclusions()
+        self.write_comparator_config("A.v1")
+        self.assertTrue(ieantn.record_receipt("A.v1", "Solutions/A.v1", "http://run", "now"))
+        self.assertTrue((self.root / "receipts" / "A.v1.second.json").is_file())
 
 
 class TestReceiptProvenance(FixtureRepo):


### PR DESCRIPTION
Read end to end: [scripts/ieantn.py](scripts/ieantn.py), [Tools/Hash.lean](Tools/Hash.lean),
[scripts/verify-comparator.sh](scripts/verify-comparator.sh), and the workflows. **Nine defects**,
each now covered by a test that was checked to fail without its fix.

## Two soundness holes

**A receipt could cover a conclusion Comparator never saw.** Comparator runs once per node against
`theorem_names` in the solution's `comparator.json`. Receipts are written per conclusion. Nothing
connected the two — so adding a second conclusion to an already-verified node earned it a full
`lean-comparator` justification for a statement no verifier had ever seen, and `status` would have
shown it green. No adversary required. `record-receipt` now refuses unless every conclusion is
listed.

**Any successful verification validated any receipt.** `check-receipts` checked that the run
existed, concluded `success`, and was `verify.yml` — but not that it was *this node's*. Copying a
real run URL into a fabricated receipt passed. The dispatched node now appears in `verify.yml`'s job
names, so GitHub's own record of the run decides what was verified, independently of what the
receipt asserts. Runs predating the convention fall back to one-run-one-node.

## One live vulnerability

**Script injection in `verify.yml`.** Dispatch inputs were interpolated into `run:` bodies with
`${{ }}`, which splices the value in before any shell exists to quote it. The worst case is the
`receipt` job, which holds `contents: write` — precisely what the privilege split exists to protect.
Inputs now reach the shell through `env:`.

While there: the header comment claimed the receipt job builds "trusted repository content". It
builds the *branch*, and Lean elaboration runs arbitrary code, so what actually protects that job is
the `verification` environment gate on the job before it. The comment now says so — the split still
buys something real, just narrower than it claimed.

## Three checks that did not check

- **A trailing comment hid an import.** The pattern was anchored at end of line, so
  `import Solutions.Whatever -- for now` matched nothing and every closure check silently passed.
- **`startswith` ignored module boundaries**, accepting `IEANTN.VocabularyScratch` as Vocabulary.
- **The receipt warning read the wrong justification** — the `kind` left over from a loop rather
  than the designated one. Found by hitting it, not by reading: adding the `Lcm.v2` bridge triggered
  it immediately.

## Three hardening fixes

- **Metadata is interpolated verbatim into generated Lean.** A conclusion `id` and both halves of an
  import reference become declaration names and binder types in `Challenge.lean`. CI only diffs that
  file against what the generator produces, so crafted text would be regenerated faithfully and
  compiled into the core library. Ids must now be Lean identifiers.
- `designate_verification` silently **un-deprecated** nodes, and left a stale run URL on
  re-verification.
- `deprecate` accepted a node **superseding itself**.

## Docs

Three places contradicted each other about the `receipts/` ruleset — asserted as the enforcement in
`ARCHITECTURE.md` and `receipts/README.md`, correctly described as impossible in `ROADMAP.md`.
Provenance is the enforcement; they now say so uniformly. `ARCHITECTURE.md`'s tail also still listed
the environment gate and unit tests as unbuilt, and said no node carried a Lean-verified
justification.

`ROADMAP.md` now records what this pass found alongside the defect *classes*, which are kept because
each predicts where the next one will be.

## Also

`housekeeping` flags an outstanding conclusion whose issue has been closed — work the queue calls
claimed and the tracker calls finished. That state existed for about an hour yesterday between #10
and #11.

## Checks

- 93 tests, up from 81. **Nine of the twelve new ones fail against the unpatched script**; the other
  three are positive controls (a commented-out import is still not an import, an ordinary id still
  passes, full coverage is still accepted).
- `lake build` clean, `python scripts/ieantn.py check` all green, `fingerprint --check` green,
  `check-receipts` green online, pyright clean.
- No fingerprint moved, so `Lcm.v1`'s receipt still stands.

Still to come: the docs audit and the security audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)