### PR TITLE
Docs audit: first full pass

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,8 @@ Read [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) once before your first contrib
 [docs/NODES.md](docs/NODES.md) is the reference for node file formats.
 
 > **Status.** Everything below works today except where marked *(planned)*: the `/verify` comment
-> trigger, and posting the reviewer report as a PR comment rather than to the job summary. See
+> trigger (workflow 3 gives what to do meanwhile), the `build-solution` label (workflow 2), and
+> posting the reviewer report as a pull request comment rather than to the job summary. See
 > [docs/ROADMAP.md](docs/ROADMAP.md).
 
 ## Two principles
@@ -119,13 +120,18 @@ can.
 **Metadata:** the justification does **not** change. Add a progress marker instead:
 
 ```yaml
-    justification:
-      kind: none-yet
+    justifications:
+      - id: unjustified
+        kind: none-yet
+    designated: unjustified
     progress:
       solution: Solutions/Lcm.v1/
       state: in-progress
       remaining_holes: 7
 ```
+
+(`justifications` is a list and `designated` names the one that counts — see
+[docs/NODES.md](docs/NODES.md). A conclusion may carry several grounds; exactly one carries trust.)
 
 **CI:** nothing runs. Solutions are outside the core build.
 
@@ -154,10 +160,25 @@ builds just that project *(planned)*. It is not in core CI because a solution ca
 
 All holes closed and you believe Comparator will accept it.
 
-**Do:** push, then comment `/verify <Family>.<version>` on the PR *(planned)*.
+**Do:** push, then ask a maintainer to dispatch the verification workflow for your branch. Until
+the `/verify` comment trigger exists *(planned)*, that is a `workflow_dispatch`, which needs write
+access — so requesting one means saying so on the pull request. A maintainer runs:
 
-A maintainer approves the run; Comparator executes against the generated challenge; on success the
-bot commits the receipt and flips the justification to `lean-comparator`.
+```bash
+gh workflow run verify.yml -f node=Lcm.v1 -f branch=<your-branch>
+```
+
+Then approves the `verification` environment when GitHub asks. The gate is on the *run*, not the
+request: verification is hour-scale compute, so it is not self-serve, but neither should asking for
+one require write access.
+
+Comparator executes against the generated challenge; on success the workflow commits the receipt to
+your branch and designates the `lean-comparator` justification.
+
+**Before requesting one**, check locally what Comparator will check — that the challenge and
+solution declare the same type and that only the three permitted axioms are used. Both are
+checkable from inside the solution project without Comparator itself; [docs/NODES.md](docs/NODES.md)
+step 4 gives the commands. A rejected run costs a maintainer's approval and an hour of compute.
 
 **Do not write the receipt yourself, and do not set `kind: lean-comparator` by hand.**
 
@@ -206,6 +227,35 @@ Deprecate the old version when you want it retired:
 python scripts/ieantn.py deprecate Lcm.v1 --for Lcm.v2
 ```
 
+### Writing the bridge
+
+Usually the cheapest of the three, and often only a few lines. Put it at
+`IEANTN/Bridges/<Family>/<Name>.lean` — inside the library, so the core build compiles it — and
+prove the target's conclusion from the source's:
+
+```lean
+theorem bridge_v2_to_v1
+    (general : Lcm.v2.lcmUpto_not_highlyAbundant_of_primeGap)
+    (dusart : Dusart2018.v1.proposition_5_4) :
+    Lcm.v1.lcmUpto_not_highlyAbundant :=
+  fun n hn => general 89693 lt_log_89693 dusart n (by exact_mod_cast hn)
+```
+
+Its hypotheses are the conclusions you name in `from`, plus whatever the *target* node already
+imports. Then record it, run `gen-challenges` so the generated `IEANTN/Bridges.lean` picks it up,
+and `lake build` — a bridge is checked by the ordinary build, not by Comparator, because there is
+no untrusted development in it.
+
+```yaml
+  - id: bridge-from-v2
+    kind: bridged
+    from: Lcm.v2.lcmUpto_not_highlyAbundant_of_primeGap
+    bridge: IEANTN/Bridges/Lcm/V2ToV1.lean
+```
+
+`IEANTN/Bridges/Lcm/V2ToV1.lean` is the worked example. Rules: no `sorry`, no importing a
+`Challenge`, and the same import closure as a Conclusions file — all checked by `check-closure`.
+
 ## 5. Modify Vocabulary
 
 The riskiest change in the repository: Vocabulary is shared, so a semantic change can alter what
@@ -233,9 +283,9 @@ and delete the old definition when nothing uses it.
 A solution is stuck because the paper leans on a result it does not prove, or a numerical
 computation, or a piece of folklore.
 
-**Do:** promote each remaining hole to its own node — `kind: folklore` or `computation`, with
-`justification: asserted` or `none-yet` — add it to the stuck node's imports, and the solution
-becomes complete relative to those new imports.
+**Do:** promote each remaining hole to its own node — `node.kind: folklore` or `computation`, with
+a designated justification of kind `asserted` or `none-yet` — add it to the stuck node's imports,
+and the solution becomes complete relative to those new imports.
 
 This is the main way the network grows, and it is why workflow 1 tracks `remaining_holes`: **the
 holes in a stuck solution are a ready-made list of candidate nodes.** If the extracted fact serves
@@ -295,7 +345,8 @@ so a half-finished node cannot be merged by accident.
 
 `--kind` is one of `paper` (default), `pipeline`, `folklore`, `computation`.
 
-Most new nodes start with `justification: none-yet` or `literature` and no solution at all. That is
+Most new nodes start with a designated justification of kind `none-yet` or `literature`, and no
+solution at all. That is
 the normal, expected state: a node that merely *records* a result and its dependencies is already
 useful to the network, and workflows 1–3 exist to justify it later.
 
@@ -305,7 +356,14 @@ This gently degrades everything at once, and it is the case the two-axis trust m
 (ARCHITECTURE §4) exists for: a bump changes the **environment**, not the **statements**. Every
 receipt was made under an older Mathlib; no edge has broken. That is a yellow light, not a red one.
 
-**Do:** update `lean-toolchain` and `lake-manifest.json`. That is the whole PR.
+**Do:** update `lean-toolchain` and `lake-manifest.json` — and the same two files in **every**
+`Solutions/<node>/`, because a solution's toolchain must equal the repository's and `check-closure`
+fails otherwise. If the Lean *release* changed, also move `lean4export_commit` and
+`lean4export_toolchain` in `scripts/verify-comparator.sh` to the matching tag; `check-pins` fails
+the bump otherwise, deliberately, so that the pin is fixed while the reason is obvious rather than
+weeks later when a verification breaks for no visible cause.
+
+No node metadata changes.
 
 **Metadata:** *nothing changes, in any node.* Staleness is **derived**, not stored — it is computed
 by comparing each receipt's recorded environment against the current one. So a bump that degrades
@@ -338,9 +396,15 @@ Three levels, with the third defined by something real rather than a made-up num
 | **yellow** | Stale, but within the Mathlib cache window — a refresh costs about one node-sized run. |
 | **orange** | Past the cache window. Dependencies must now build from source, so a refresh costs many times the per-node budget. |
 
-Solutions keep their own toolchain pins, so a core bump does not break them: they still build at
-the Mathlib they were verified against, and re-running at that pin stays cheap. What has aged is
-the *claim that the result holds under current Mathlib*, not the proof.
+A solution's toolchain pin must **equal** the repository's, so a bump moves the solutions with it
+— that is why the bump PR touches their `lean-toolchain` and `lake-manifest.json` too. What stays
+cheap is re-running a verification *at the commit its receipt records*, where the core and the
+solution agree by construction. What has aged is the *claim that the result holds under current
+Mathlib*, not the proof.
+
+(An earlier version of this file said solutions pin independently and so are unaffected. They do
+not, and this is the rule the project has got wrong twice; the reasoning is in
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) §2.)
 
 **Do not chase bumps.** Let staleness accumulate, and run refresh sweeps ordered by fan-in when
 compute is available (`python scripts/ieantn.py housekeeping`). The one thing worth avoiding is

--- a/README.md
+++ b/README.md
@@ -28,10 +28,13 @@ separate, auditable question.
 ## Layout
 
 ```
-IEANTN/Vocabulary/          the shared language — definitions only, Mathlib-only
-IEANTN/Nodes/<Id>/          Conclusions.lean, Challenge.lean, formalization.yaml
-Solutions/<Id>/             proofs — separate Lake projects, not in the core build
-docs/                       ARCHITECTURE.md, NODES.md
+IEANTN/Vocabulary/               the shared language — definitions only, Mathlib-only
+IEANTN/Nodes/<Family>/<version>/ Conclusions.lean, Challenge.lean, formalization.yaml
+IEANTN/Bridges/<Family>/         proofs that one version's conclusions imply another's
+Solutions/<Family>.<version>/    proofs — separate Lake projects, not in the core build
+receipts/                        one JSON file per Lean-verified conclusion
+fingerprints.json, STATE.md      generated and committed, so a change of meaning is a diff line
+docs/                            ARCHITECTURE.md, NODES.md, ROADMAP.md
 ```
 
 The core build is Vocabulary and Nodes only, and is deliberately fast. Solution verification is a
@@ -48,14 +51,16 @@ defeat the purpose of the split.
 
 ## Status
 
-Early, but the machinery is in place. Vocabulary, two proof-of-concept nodes, challenge
-generation, statement fingerprints, verification receipts, the breaking-change detector, the
-network checks and the housekeeping queue all exist and run in CI.
+Early, but the machinery is in place and exercised. Vocabulary, three proof-of-concept node
+versions and the bridge between two of them, challenge generation, statement fingerprints,
+verification receipts, the breaking-change detector, the network checks and the housekeeping queue
+all exist and run in CI.
 
-**No node carries a Lean-verified justification yet**, so the Comparator path is untested end to
-end; that waits on porting a first solution. Visualisation, unit tests for the tooling, and the
-code and security audits are outstanding. [docs/ROADMAP.md](docs/ROADMAP.md) tracks what is
-deliberately not built and why.
+**The Comparator path works end to end**: `Lcm.v1` carries a receipt written by the verification
+workflow, and `ieantn.py status` grades it against the current environment.
+
+Outstanding: visualisation, the `/verify` comment trigger, the Palomar spin-off generator, and the
+security audit. [docs/ROADMAP.md](docs/ROADMAP.md) tracks what is deliberately not built and why.
 
 This work grows out of the IEANTN subproject of
 [PNT+](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd), whose blueprint-based structure
@@ -70,5 +75,5 @@ lake exe cache get
 lake build
 ```
 
-Two `declaration uses 'sorry'` warnings are expected — one per node conclusion. A challenge states;
-it does not prove.
+One `declaration uses 'sorry'` warning per node conclusion is expected. A challenge states; it does
+not prove.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -177,11 +177,22 @@ several papers, the whole network benefits at once.
 
 A verification records a **receipt**, content-addressed rather than timestamped:
 
-- the `pp.all`-elaborated statement hash of each conclusion proved;
+- the statement fingerprint of the conclusion proved;
 - the same for each imported conclusion;
 - the Lean toolchain and Mathlib revision;
 - the pinned Comparator, `lean4export`, NanoDa and Landrun revisions;
 - the repository commit, and a timestamp **for display only**.
+
+The fingerprint is a *structural* serialisation of the elaborated statement, not its `pp.all` text.
+Pretty-printed output is a presentation and Lean is free to change it between versions, so
+fingerprinting it would turn every toolchain bump red for reasons having nothing to do with the
+mathematics. `Tools/Hash.lean` documents what is erased and the one change this deliberately cannot
+see.
+
+The last two entries were claimed here before they were recorded, and the docs audit caught it.
+They matter for the same reason: without them a receipt says a verification happened but not what
+tree it ran against or what checked it, and "re-run at the recorded pin" below has no referent.
+Receipts written before that fix carry `"schema": 1` and lack both.
 
 Staleness is computed by re-hashing, never by comparing dates. The payoff: because the hash is of
 the *elaborated* statement, cosmetic edits to an upstream conclusions file — renamed binders,
@@ -264,8 +275,10 @@ penalised for writing the convenient one, and a required acknowledgement decays 
 So the network does not ask for one. The dangerous case is made mechanically impossible instead:
 
 - Editing a conclusion that has **downstream importers or a recorded receipt** is a **hard CI
-  failure**, carrying its own fix: `python scripts/ieantn.py new-version <Family>`. *(planned:
-  this needs a diff against the base commit, which `check-graph` does not yet do.)*
+  failure**, carrying its own fix: `python scripts/ieantn.py new-version <Family>`. This is
+  `ieantn.py diff`, run by the `Network impact` job against the pull request's base commit; it
+  reads the base state with `git show` rather than checking it out, which is what makes it cheap
+  enough for every pull request.
 - Editing a conclusion with neither is silently fine — nothing depends on it, and nothing has been
   verified against it.
 
@@ -350,9 +363,15 @@ old version can be deprecated and eventually deleted. If only `C_old → C_new` 
 conclusion is *weaker*: `X.v2` is fine, but downstream nodes cannot migrate, so `X.v1` persists
 legitimately and the graph should say so. If neither holds, the change is an **amendment**.
 
-This makes the classification **derivable rather than trusted**: CI attempts both bridges and
-reports which succeed. The author's declared classification is a hypothesis that gets checked, not
-an assertion that gets believed — which is what makes it safe to let an agent propose it.
+The classification is therefore **derivable rather than trusted**, and that is the point: an
+author's declaration that a restatement is equivalent is exactly the kind of claim nobody is
+penalised for getting wrong. Writing the two bridges settles it, because a bridge that does not
+hold does not compile.
+
+*(planned)* CI does not yet attempt them for you. Today an author writes whichever bridges hold and
+CI checks those; nothing detects that a bridge which *could* be written has not been. Attempting
+both automatically would turn the classification into an output rather than an input — which is
+what would make it safe to let an agent propose one.
 
 ### Prefer many small conclusions to few large ones
 
@@ -377,11 +396,15 @@ Because solutions sit outside the core build, a stale or broken solution is a **
 recorded in the graph, not a build failure. Conclusions may be improved ahead of their solutions,
 and the network stays honest about the gap in the meantime.
 
-## 6. The housekeeping queue *(planned)*
+## 6. The housekeeping queue
 
 The graph **is** the task queue. Because every task below is a derivable property of graph state,
 nobody maintains a list: the tooling computes it, and work is scheduled against whatever compute
 and AI assistance happens to be available.
+
+`python scripts/ieantn.py housekeeping` derives it. The table is the full set of task types; the
+command implements the rows whose trigger is a plain property of the metadata, and marks a task
+whose issue has been closed while the work remains outstanding.
 
 | Task | Trigger | Rough cost |
 |---|---|---|
@@ -430,10 +453,11 @@ Built and running in CI:
 | | |
 |---|---|
 | `IEANTN/Vocabulary/` | The shared language. Definitions only, Mathlib-only closure enforced. |
-| `IEANTN/Nodes/*/v1/` | Two proof-of-concept nodes and the edge between them. |
+| `IEANTN/Nodes/<Family>/<version>/` | Three proof-of-concept node versions, the import edge between two and the bridge between two others. |
 | `Tools/Hash.lean` | Statement fingerprints (§4), Merkle-chained over IEANTN's own definitions. |
 | `receipts/` | Verification receipts, written by the workflow and never by hand. |
 | `scripts/ieantn.py` | Everything below. |
+| `tests/test_ieantn.py` | Unit tests for it, run in CI. |
 | `scripts/verify-comparator.sh` | Comparator with the four trusted tools pinned. |
 | `scripts/check_palomar_metadata.py` | Validates each node against Palomar's *current* contract. |
 | `.github/workflows/ci.yml` | Core build, network checks, fingerprint check, impact report. |
@@ -443,17 +467,33 @@ Built and running in CI:
 The tooling commands:
 
 ```bash
-python scripts/ieantn.py check            # closure, graph, acyclicity, generated challenges
-python scripts/ieantn.py fingerprint      # recompute statement fingerprints
+# checks -- `check` runs all of these in --check mode except the fingerprints, which need Lean
+python scripts/ieantn.py check            # everything below, non-destructively
+python scripts/ieantn.py check-closure    # import discipline, and the no-`sorry` rules
+python scripts/ieantn.py check-graph      # metadata, referential integrity, both acyclicities
+python scripts/ieantn.py check-pins       # the verification toolchain against `lean-toolchain`
+python scripts/ieantn.py check-receipts   # every receipt names a real run of `verify.yml`
+
+# generated and committed; CI diffs each against what the generator emits
+python scripts/ieantn.py gen-challenges   # Challenge.lean, Nodes.lean, Bridges.lean
+python scripts/ieantn.py fingerprint      # fingerprints.json  (needs a built `ieantn_hash`)
+python scripts/ieantn.py state            # STATE.md
+
+# reports
 python scripts/ieantn.py status           # green / yellow / orange / BROKEN per conclusion
-python scripts/ieantn.py diff             # what a branch degrades, and for whom
 python scripts/ieantn.py report           # what each conclusion rests on
+python scripts/ieantn.py diff             # what a branch degrades, and for whom
 python scripts/ieantn.py housekeeping     # the derived task queue
+
+# scaffolding
 python scripts/ieantn.py new-node         # scaffold a node
 python scripts/ieantn.py new-version      # scaffold the next version of one
 python scripts/ieantn.py new-solution     # scaffold a solution project
 python scripts/ieantn.py deprecate        # mark a version for retirement
 ```
+
+`record-receipt` also exists and is deliberately not listed as something to run: it is called by
+the verification workflow, and a receipt you can write attests nothing.
 
 **Not yet built**, and tracked in [ROADMAP.md](ROADMAP.md): the reviewer report as a pull request
 comment rather than a job summary; a `/verify` comment trigger; the Palomar spin-off generator;

--- a/docs/NODES.md
+++ b/docs/NODES.md
@@ -3,9 +3,6 @@
 Practical recipe. For *why* the structure is what it is, read [ARCHITECTURE.md](ARCHITECTURE.md)
 first — especially §1, which explains why a node is a conditional theorem.
 
-> **Status.** Challenge generation and the graph checks exist — see `scripts/ieantn.py`. Receipts
-> and staleness tracking do not yet, so `receipt:` is always `null` for now.
-
 ## What a node is
 
 A node is one folder recording:
@@ -32,7 +29,7 @@ IEANTN/Nodes/<Family>/<version>/
   formalization.yaml     metadata: imports, justification, sources, receipts
   README.md              optional prose
   Examples.lean          optional — consequences, to show what the node buys
-Solutions/<Family>.<version>/    optional; separate Lake project, own toolchain pin
+Solutions/<Family>.<version>/    optional; separate Lake project, toolchain pinned equal
 IEANTN/Bridges/<Family>/         short proofs that one version implies another
 ```
 
@@ -117,8 +114,12 @@ as a submission without restructuring, and validated in CI against Palomar's own
 version: "v0.4"
 
 node:
-  id: Dusart2018
+  id: Dusart2018.v1     # must equal the path-derived id; check-graph compares them
+  family: Dusart2018
+  version: v1
   kind: paper
+  status: stub          # template | stub | awaiting-solution | awaiting-verification |
+                        # active | deprecated.  `template` is a hard CI failure.
 
 project:
   name: "..."
@@ -174,7 +175,8 @@ Notes:
 - Editing a node's metadata with `new-version` or `deprecate` requires `ruamel.yaml`
   (`pip install ruamel.yaml`), which preserves comments. The read-only checks need only PyYAML,
   so CI does not install it.
-- `receipt` is `null` until a verification runs.
+- There is no `receipt` field. Receipts live in `receipts/`, one JSON file per verified
+  conclusion, written by the verification workflow. See [../receipts/README.md](../receipts/README.md).
 - Palomar's required-field list is a **moving target**. CI re-fetches the validator; do not vendor
   a copy and do not work from the list above as if it were closed.
 - **Never claim novelty without a documented search.** "Unknown" is acceptable and safe; an
@@ -206,7 +208,7 @@ diffed in CI.
 
 ## Step 4 (optional, last): a solution
 
-Only when a conclusion is to carry `justification: lean-comparator`.
+Only when a conclusion is to carry a `lean-comparator` justification.
 
 ```bash
 python scripts/ieantn.py new-solution Lcm.v1
@@ -254,15 +256,24 @@ incomplete.
 ## Invariants CI enforces
 
 1. Vocabulary and every `Conclusions.lean` build clean.
-2. No `Conclusions.lean` imports anything outside Mathlib, Vocabulary, and other Conclusions.
-3. Every `Challenge.lean` matches what the generator would emit from Conclusions + yaml.
+2. No `Conclusions.lean` imports anything outside Mathlib, Vocabulary, and other Conclusions; no
+   `Examples.lean` or bridge does either, and neither contains `sorry`. Vocabulary holds no
+   theorems.
+3. Every `Challenge.lean` matches what the generator would emit from Conclusions + yaml, and so do
+   `IEANTN/Nodes.lean` and `IEANTN/Bridges.lean`.
 4. Every `formalization.yaml` passes Palomar's current validator.
 5. The import graph is acyclic, and so is justification transport along *designated* bridges.
-6. Every conclusion's statement fingerprint matches `fingerprints.json`.
+6. Every conclusion's statement fingerprint matches `fingerprints.json`, and `STATE.md` is current.
 7. No conclusion that other nodes depend on has been edited in place, and none still imported has
-   been removed (`ieantn.py diff`).
-8. Every `lean-comparator` justification has a matching file in `receipts/`.
-9. The tooling type-checks (`pyright`, at `basic`).
+   been removed (`ieantn.py diff`, in the `Network impact` job).
+8. Every `lean-comparator` justification has a matching file in `receipts/`, every receipt names a
+   successful run of `verify.yml` **for that node**, and no receipt covers a conclusion absent from
+   its solution's `comparator.json`.
+9. Every conclusion `id`, and both halves of every import reference, is a Lean identifier — they are
+   written verbatim into the generated challenge.
+10. Every solution's `lean-toolchain` equals the repository's, and `verify-comparator.sh` pins
+    `lean4export` for that same toolchain.
+11. The tooling type-checks (`pyright`, at `basic`) and its unit tests pass.
 
 On (6): after any deliberate change to a conclusion's meaning, run
 `python scripts/ieantn.py fingerprint` and commit the result. Committing the fingerprints is what
@@ -277,9 +288,9 @@ would defeat the purpose of the split.
 
 Read ARCHITECTURE §5 first. The short version: **you usually should not.**
 
-CI will hard-fail if you edit a conclusion that has downstream importers or a recorded receipt
-*(not yet implemented -- it needs a diff against the base commit)*. There
-is no acknowledgement to write and no classification to declare — an author's declaration cannot be
+CI will hard-fail if you edit a conclusion that has downstream importers or a recorded receipt.
+This is the `Network impact` job, which runs `ieantn.py diff` against the pull request's base
+commit. There is no acknowledgement to write and no classification to declare — an author's declaration cannot be
 trusted to say whether a change altered the mathematics, and a required one just becomes a box to
 tick. The failure carries its own fix:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -264,6 +264,53 @@ done so in the CI summary. Line endings are converted on every commit.
 index into a throwaway tuple, which also ignored the major version, so `v4.34` to `v5.2` came out
 as thirty-two releases apart. Now caught by `pyrightconfig.json` in CI.
 
+## Docs audit
+
+**First pass done**, alongside the code audit. The docs had drifted in one direction throughout:
+they described the design as it was *intended*, and the design moved. Nothing was wrong in a way a
+reader would notice as wrong — every error read as confident and current.
+
+Twelve corrections, in three classes.
+
+**Claims the code contradicted.** Six. `NODES.md` opened with a banner saying receipts and
+staleness tracking did not exist yet; both had existed for weeks. `ARCHITECTURE.md` said the
+statement hash was of `pp.all` output, which `Tools/Hash.lean` explicitly rejects and explains at
+length why. Two documents said the breaking-change detector was unimplemented while a third listed
+it as an enforced invariant and CI ran it on every pull request. The housekeeping section was
+headed *(planned)*. And `ARCHITECTURE.md` claimed CI attempts both bridges of a restatement and
+reports which succeed — an appealing idea that nothing implements, stated as fact.
+
+**Instructions that would have failed.** Three, and these are the ones that matter, because an
+agent follows them literally. `NODES.md`'s `formalization.yaml` example omitted `node.family`,
+`node.version` and `node.status` and gave the id as `Dusart2018` rather than `Dusart2018.v1` — as
+written it fails `check-graph`. Three workflows in `CONTRIBUTING.md` showed a singular
+`justification:` key; the schema has been a `justifications:` list with `designated:` since the
+multiple-grounds design landed. And the Mathlib bump procedure said "update `lean-toolchain` and
+`lake-manifest.json` — that is the whole PR", which fails `check-closure`: every solution's
+toolchain must equal the repository's, so a bump sweeps them all, and a Lean release bump also
+moves the `lean4export` pin.
+
+That last one is the toolchain rule getting stated wrongly for the *third* time, in a document
+whose neighbouring section explains at length that it was got wrong twice before. Which is the
+lesson: a correction written in one place does not propagate, and this class is only findable by
+re-deriving each claim from the code rather than reading for sense.
+
+**Documentation ahead of the code.** One, fixed in the code instead. `ARCHITECTURE.md` said a
+receipt records the repository commit and the four pinned tool revisions, and §2 leans on that —
+"what pins a verification is the commit its receipt records". Receipts recorded neither. Rather
+than weaken the doc, `record-receipt` now records both, at `"schema": 2`; without them a receipt
+says a verification happened but not what tree it ran against or what checked it, so "re-run at the
+recorded pin" had no referent.
+
+Also swept: every relative link resolves, and every `ieantn.py` subcommand named in prose exists
+while every subcommand that exists is documented. Both are now cheap to re-check and worth doing
+after any tooling change.
+
+A **local maintainer skill** now carries what is deliberately *not* in the repository: the
+verification approval procedure and what to actually look at before approving, the alignment-
+checking recipe that needs an LLM and so cannot be CI, cross-repository paths, PNT+ migration
+state, and the accumulated traps in operational form.
+
 ## Security audit, still to do
 
 Worth being proactive about, given that contributors are increasingly agents and that some pull
@@ -317,12 +364,12 @@ computation of that kind. Introducing one would have made the bridged `Lcm.v1` d
 more than the original did. The abstraction has to be chosen so that it introduces **no new import
 requirements, computational or otherwise.**
 
-## Deferred test case: `Lcm.v2` as a pipeline
+## Done: `Lcm.v2` as a pipeline
 
-The first real refactoring exercise, to run once the metaarchitecture above is in place. It
-exercises pipeline abstraction, bridging, and parameter instantiation together.
+The first real refactoring exercise, kept here for what the sequencing taught. `Lcm.v2` and
+`IEANTN/Bridges/Lcm/V2ToV1.lean` now exist; the solution for `Lcm.v2` is issue #10.
 
-**Sequencing.** Do not design `Lcm.v2` first. The right order is:
+**Sequencing.** Do not design `Lcm.v2` first. The order used was:
 
 1. **Port `Lcm.v1`'s solution from PNT+** (`PrimeNumberTheoremAnd/IEANTN/Lcm.lean`, commit
    `ae881f2e2b3acefc9b92f8d4dda7c2b8f6e8f5fe`, declaration `Lcm.L_not_HA_of_ge`) and verify it.
@@ -333,23 +380,27 @@ exercises pipeline abstraction, bridging, and parameter instantiation together.
 Designing the abstraction before reading the proof is how you end up with side conditions that are
 either wrong or that smuggle in new dependencies.
 
-**The idea.** `Lcm.v1` hardcodes Dusart's threshold. `Lcm.v2` should instead internalise the
-Dusart-type hypothesis and its numerical side conditions, taking `X₀` as a variable — so `Lcm.v2`
-has **no imports at all**, roughly:
+**The idea.** `Lcm.v1` hardcodes Dusart's threshold. `Lcm.v2` internalises the Dusart-type
+hypothesis and its numerical side condition, taking `X₀` as a variable — so `Lcm.v2` has **no
+imports at all**:
 
 ```lean
-def lcmUpto_not_highlyAbundant : Prop :=
-  ∀ X₀ : ℝ, <numerical side conditions on X₀> →
-    IEANTN.HasPrimeInInterval.logPower X₀ 3 →
-      ∀ n : ℕ, X₀ ^ 2 ≤ (n : ℝ) → ¬ HighlyAbundant (Nat.lcmUpto n)
+def lcmUpto_not_highlyAbundant_of_primeGap : Prop :=
+  ∀ X₀ : ℝ, 11.4 < Real.log X₀ → IEANTN.HasPrimeInInterval.logPower X₀ 3 →
+    ∀ n : ℕ, X₀ ^ 2 ≤ (n : ℝ) → ¬ HighlyAbundant (Nat.lcmUpto n)
 ```
 
-The side conditions are deliberately left blank: step 2 above determines them.
+Step 2 determined the side condition: `log X₀ > 11.4`, and nothing else.
 
-**The bridge** then discharges `Lcm.v1`'s challenge from `Lcm.v2`'s conclusion by instantiating
-`X₀ := 89693`, verifying the side conditions, and handling the ℕ→ℝ cast. Note this is a bridge,
-not an import edge: `Lcm.v1` keeps `Dusart2018.v1` as its declared import and gains a `bridged`
-justification.
+**The bridge** discharges `Lcm.v1`'s conclusion from `Lcm.v2`'s by instantiating `X₀ := 89693`,
+verifying the side condition, and handling the ℕ→ℝ cast — three lines. It is a bridge, not an
+import edge: `Lcm.v1` keeps `Dusart2018.v1` as its declared import and gains a **non-designated**
+`bridged` justification, non-designated because `Lcm.v2` is itself unjustified and the direct
+Comparator receipt depends on no other node.
+
+Building it also forced the rule that bridges live inside the library and are compiled by the core
+build. A bridge recorded only as a path would keep satisfying "the file named exists" after either
+statement moved — and versions exist precisely so that statements can move.
 
 **The numerical obstacle was imaginary.** Scouting this before the port suggested the bridge's
 side condition `11.4 < Real.log 89693` would be hard: true by a margin of only `0.0041`, and

--- a/receipts/README.md
+++ b/receipts/README.md
@@ -4,8 +4,13 @@ One JSON file per Lean-verified conclusion, named `<Family>.<version>.<conclusio
 
 A receipt records what a verification actually depended on: the statement fingerprint of the
 conclusion **and of every conclusion it imports**, the Lean toolchain and Mathlib revision, the
+repository commit, the pinned revisions of Comparator, `lean4export`, Landrun and NanoDa, the
 solution project, and the workflow run that produced it. Staleness is then *computed* by
 re-fingerprinting and comparing — never by looking at a date. The timestamp is for display only.
+
+The commit and the tool pins are what make *re-running at the recorded pin* a defined operation:
+check out that commit, where core and solution agree by construction, and run those four tools.
+`"schema": 1` receipts predate that and carry neither.
 
 ## These files are written by the verification workflow, not by hand
 

--- a/scripts/ieantn.py
+++ b/scripts/ieantn.py
@@ -1083,6 +1083,39 @@ def current_environment() -> dict:
     }
 
 
+def verification_tools() -> dict[str, str]:
+    """The pinned revisions of the four tools a verification actually trusts.
+
+    Read out of `verify-comparator.sh` rather than duplicated, so they cannot drift apart. Recording
+    them is what makes "re-run at the recorded pin" (ARCHITECTURE section 4) a defined operation
+    rather than a phrase: without them a receipt says a verification happened but not what checked
+    it, and a later Comparator or NanoDa is a different verifier.
+    """
+    if not VERIFY_SCRIPT.is_file():
+        return {}
+    text = VERIFY_SCRIPT.read_text(encoding="utf-8")
+    found = {}
+    for tool in ("comparator", "lean4export", "landrun", "nanoda"):
+        match = re.search(rf"^{tool}_commit=(\S+)", text, re.MULTILINE)
+        if match:
+            found[tool] = match.group(1)
+    return found
+
+
+def repository_commit() -> str | None:
+    """The commit a verification ran against, if this is a git checkout.
+
+    The receipt's own pin: re-running means checking this out, where the core and the solution agree
+    by construction. Without it the receipt names a workflow run and a set of statements but not the
+    tree they were verified in.
+    """
+    finished = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=ROOT, capture_output=True, text=True, encoding="utf-8",
+    )
+    return finished.stdout.strip() or None if finished.returncode == 0 else None
+
+
 def receipt_path(conclusion_key: str) -> pathlib.Path:
     return RECEIPTS / f"{conclusion_key}.json"
 
@@ -1362,11 +1395,13 @@ def record_receipt(node_id: str, solution: str, run_url: str, stamp: str) -> boo
             print(f"error: no fingerprint for {missing}")
             return False
         receipt = {
-            "schema": 1,
+            "schema": 2,
             "conclusion": key,
             "challenge": conclusion.get("challenge"),
             "statement": {name: fingerprints[name] for name in wanted},
             "environment": current_environment(),
+            "repository": {"commit": repository_commit()},
+            "tools": verification_tools(),
             "solution": {"project": solution},
             "run": {"workflow_run": run_url, "recorded_at": stamp},
         }

--- a/tests/test_ieantn.py
+++ b/tests/test_ieantn.py
@@ -1037,6 +1037,36 @@ class TestReceiptCoverage(FixtureRepo):
             self.assertFalse(ieantn.record_receipt("A.v1", "Solutions/A.v1", "http://run", "now"))
         self.assertIn("does not exist", printed.getvalue())
 
+    def test_the_receipt_records_what_pinned_the_verification(self) -> None:
+        """ARCHITECTURE says "what pins a verification is the commit its receipt records", and says
+        the receipt carries the four tool revisions. Neither was true until the docs audit checked.
+
+        Both matter for the same reason: without them a receipt says a verification happened but
+        not what tree it ran against or what checked it, and "re-run at the recorded pin" has no
+        referent."""
+        try:
+            import ruamel.yaml  # noqa: F401
+        except ImportError:
+            self.skipTest("ruamel.yaml not installed")
+        self.write_node("A.v1", LITERATURE)
+        self.write_comparator_config("A.v1")
+        (self.root / "scripts").mkdir(exist_ok=True)
+        (self.root / "scripts" / "verify-comparator.sh").write_text(
+            "comparator_commit=aaa\nlean4export_commit=bbb\n"
+            "lean4export_toolchain=leanprover/lean4:v4.34.0-rc2\n"
+            "landrun_commit=ccc\nnanoda_commit=ddd\n",
+            encoding="utf-8",
+        )
+        self.assertTrue(ieantn.record_receipt("A.v1", "Solutions/A.v1", "http://run", "now"))
+        receipt = json.loads(
+            (self.root / "receipts" / "A.v1.main.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(
+            receipt["tools"],
+            {"comparator": "aaa", "lean4export": "bbb", "landrun": "ccc", "nanoda": "ddd"},
+        )
+        self.assertIn("commit", receipt["repository"])
+
     def test_full_coverage_is_accepted(self) -> None:
         try:
             import ruamel.yaml  # noqa: F401


### PR DESCRIPTION
Stacked on #12 — merge that first.

The docs had drifted in one direction throughout: they described the design as *intended*, and the
design moved. Nothing was wrong in a way a reader would notice — every error read as confident and
current. Twelve corrections, in three classes.

## Claims the code contradicted (6)

- `NODES.md` opened with a banner saying receipts and staleness tracking **did not exist yet**.
  Both had for weeks.
- `ARCHITECTURE.md` said the statement hash is of `pp.all` output. `Tools/Hash.lean` explicitly
  *rejects* that and explains at length why — pretty-printed output is a presentation, so
  fingerprinting it would turn every toolchain bump red.
- Two documents said the breaking-change detector was unimplemented, while a third listed it as an
  enforced invariant and CI ran it on every PR.
- The housekeeping section was headed *(planned)*. It ships.
- `ARCHITECTURE.md` claimed CI attempts both bridges of a restatement and reports which succeed —
  an appealing idea that nothing implements, stated as fact. Now marked planned, with what actually
  happens today.

## Instructions that would have failed (3)

These are the ones that matter, because an agent follows them literally.

- `NODES.md`'s `formalization.yaml` example omitted `node.family`, `node.version` and
  `node.status`, and gave the id as `Dusart2018` rather than `Dusart2018.v1`. **As written it fails
  `check-graph`.**
- Three `CONTRIBUTING.md` workflows showed a singular `justification:` key. The schema has been a
  `justifications:` list with `designated:` since the multiple-grounds design landed.
- The Mathlib bump procedure said updating `lean-toolchain` and `lake-manifest.json` was "the whole
  PR". **That fails `check-closure`**: a solution's toolchain must *equal* the repository's, so a
  bump sweeps every solution, and a Lean release bump also moves the `lean4export` pin.

That last is the toolchain rule stated wrongly for the **third** time — in a document whose
neighbouring section explains that the project got it wrong twice before. A correction in one place
does not propagate, and this class is only findable by re-deriving each claim from the code rather
than reading for sense.

## Documentation ahead of the code (1) — fixed in the code

`ARCHITECTURE.md` said a receipt records the repository commit and the four pinned tool revisions,
and §2 leans on it: *"what pins a verification is the commit its receipt records"*. Receipts
recorded neither. Rather than weaken the doc, `record-receipt` now records both, at `"schema": 2` —
without them a receipt says a verification happened but not what tree it ran against or what checked
it, so "re-run at the recorded pin" had no referent.

## Two gaps filled

- **No working instructions for getting a solution verified** — the one thing a contributor most
  needs — only the planned `/verify` trigger. Workflow 3 now gives the `gh workflow run` invocation,
  the approval step, and what to check locally first so a rejected run doesn't burn an hour.
- **No procedure for writing a bridge**, though the first one now exists. Added to workflow 4.

## Sweeps

Every relative link resolves. Every `ieantn.py` subcommand named in prose exists, and every
subcommand that exists is documented — both now cheap to re-check after any tooling change.

94 tests, up from 93; `check` green, pyright clean.

Separately, and outside this repo: a local maintainer skill now carries what is deliberately *not*
here — the verification approval procedure, the alignment-checking recipe that needs an LLM and so
cannot be CI, cross-repo paths, PNT+ migration state, and the accumulated traps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)