### PR TITLE
Security audit: first full pass (re-targeted to main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
-      - uses: leanprover/lean-action@v1
+      - uses: leanprover/lean-action@50fcf42d2e460296f1a34b402e990d1b24f8b596 # v1
         with:
           build: true
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - run: pip install pyyaml
@@ -48,16 +48,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - run: pip install pyyaml
       # Cheap automated review of the tooling itself. Most of this code is written by agents
       # and read closely by nobody, which is exactly where a type checker earns its keep.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
       # Installs ruamel too: it is optional at runtime but the type checker should still see
@@ -84,30 +84,46 @@ jobs:
   # node stays spin-off-ready. The validator is fetched fresh on every run and never vendored:
   # its required-field list moves, and a cached copy would accept files the live contract now
   # rejects. Non-blocking until the metadata settles.
+  #
+  # This job imports and runs Python fetched from another repository, which is a deliberate
+  # trade -- pinning it would defeat the point, since tracking the moving contract is the whole
+  # reason it exists. So the exposure is bounded instead of eliminated:
+  #
+  #   * `permissions: {}` -- the job holds no token at all, and the fetch is an anonymous HTTPS
+  #     GET rather than an authenticated `gh api` call. A compromised validator therefore gets
+  #     compute on a throwaway runner and nothing else. This is the whole reason the fetch does
+  #     not use `gh`.
+  #   * `persist-credentials: false` -- no credential is left in `.git/config` to be read.
+  #   * the resolved commit is recorded in the job summary, so *which* validator ran is visible
+  #     after the fact rather than being whatever `main` happened to be.
   palomar-metadata:
     name: Validate node metadata against Palomar
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: true
+    permissions: {}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - run: pip install pyyaml
       - name: Fetch the current validator
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPSTREAM: PalomarRegistry/PalomarSubmission
         run: |
+          set -euo pipefail
           mkdir -p /tmp/pal/scripts /tmp/pal/taxonomies
+          commit=$(curl -fsSL "https://api.github.com/repos/$UPSTREAM/commits/main" \
+                     | python3 -c 'import json,sys; print(json.load(sys.stdin)["sha"])')
           for f in scripts/submission_contract.py scripts/verification_errors.py \
                    taxonomies/arxiv-categories.json taxonomies/msc2020-codes.json; do
-            gh api "repos/PalomarRegistry/PalomarSubmission/contents/$f" --jq '.content' \
-              | base64 -d > "/tmp/pal/$f"
+            curl -fsSL "https://raw.githubusercontent.com/$UPSTREAM/$commit/$f" -o "/tmp/pal/$f"
           done
           touch /tmp/pal/scripts/__init__.py
+          echo "Validated against \`$UPSTREAM\` at \`$commit\`." >> "$GITHUB_STEP_SUMMARY"
       - name: Validate each node
         run: python3 scripts/check_palomar_metadata.py /tmp/pal
 
@@ -118,11 +134,11 @@ jobs:
     timeout-minutes: 10
     steps:
       # Full history: the base state is recovered with `git show`, not by checking it out.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - run: pip install pyyaml

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
     steps:
     - name: lean-release-tag action
-      uses: leanprover-community/lean-release-tag@v1
+      uses: leanprover-community/lean-release-tag@9ca7ed09e240259871327bfc3a3a8d8c4bcb41aa # v1 branch
       with:
         do-release: true
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Run the action
         id: check-for-updates
-        uses: leanprover-community/mathlib-update-action@v1
+        uses: leanprover-community/mathlib-update-action@2af1e578ac4eded399514f76a2a4d1e5b1b409ee # v1 branch
         # START CONFIGURATION BLOCK 1
         # END CONFIGURATION BLOCK 1
   do-update: # Runs the upgrade, tests it, and makes a PR/issue/commit.
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Run the action
         id: update-the-repo
-        uses: leanprover-community/mathlib-update-action/do-update@v1
+        uses: leanprover-community/mathlib-update-action/do-update@2af1e578ac4eded399514f76a2a4d1e5b1b409ee # v1 branch
         with:
           tag: ${{ matrix.tag }}
           # START CONFIGURATION BLOCK 2

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -58,14 +58,14 @@ jobs:
       contents: read
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.branch }}
           persist-credentials: false
-      - uses: leanprover/lean-action@v1
+      - uses: leanprover/lean-action@50fcf42d2e460296f1a34b402e990d1b24f8b596 # v1
         with:
           build: false
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.24.0"
       # `inputs.node` reaches the shell through the environment, never through `${{ }}`
@@ -92,7 +92,7 @@ jobs:
         env:
           NODE: ${{ inputs.node }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: verdict
           path: verdict.json
@@ -106,19 +106,19 @@ jobs:
       contents: write
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.branch }}
-      - uses: leanprover/lean-action@v1
+      - uses: leanprover/lean-action@50fcf42d2e460296f1a34b402e990d1b24f8b596 # v1
         with:
           build: true
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       # ruamel too: record-receipt designates the verification in the node metadata, and that
       # file's comments carry the provenance.
       - run: pip install -r requirements-dev.txt
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: verdict
       - name: Check the verdict is what it claims
@@ -146,7 +146,17 @@ jobs:
         env:
           NODE: ${{ inputs.node }}
           BRANCH: ${{ inputs.branch }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
+          # A receipt goes onto the branch being verified, and then through review like anything
+          # else. Writing one straight to the default branch would put the one file the network
+          # trusts most into `main` without a pull request -- and this job is the only place in
+          # the repository holding a write token, so it is the only place that could.
+          if [ "$BRANCH" = "$DEFAULT_BRANCH" ]; then
+            echo "refusing to commit a receipt directly to $DEFAULT_BRANCH." >&2
+            echo "Verify a branch and merge the receipt through review." >&2
+            exit 1
+          fi
           git config user.name "ieantn-verifier[bot]"
           git config user.email "ieantn-verifier@users.noreply.github.com"
           python3 scripts/ieantn.py state

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,8 @@ from the file you edited. The workflows below are designed so that the cheap pat
 one.
 
 Read [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) once before your first contribution.
-[docs/NODES.md](docs/NODES.md) is the reference for node file formats.
+[docs/NODES.md](docs/NODES.md) is the reference for node file formats, and
+[SECURITY.md](SECURITY.md) states what the repository trusts and why.
 
 > **Status.** Everything below works today except where marked *(planned)*: the `/verify` comment
 > trigger (workflow 3 gives what to do meanwhile), the `build-solution` label (workflow 2), and

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ defeat the purpose of the split.
 3. [docs/NODES.md](docs/NODES.md) — node file formats, in detail.
 4. [CLAUDE.md](CLAUDE.md) — the short version, for coding agents.
 5. [docs/ROADMAP.md](docs/ROADMAP.md) — what is deliberately not built yet, and why.
+6. [SECURITY.md](SECURITY.md) — the trust model, and what a forged receipt would take.
 
 ## Status
 
@@ -59,8 +60,9 @@ all exist and run in CI.
 **The Comparator path works end to end**: `Lcm.v1` carries a receipt written by the verification
 workflow, and `ieantn.py status` grades it against the current environment.
 
-Outstanding: visualisation, the `/verify` comment trigger, the Palomar spin-off generator, and the
-security audit. [docs/ROADMAP.md](docs/ROADMAP.md) tracks what is deliberately not built and why.
+Outstanding: visualisation, the `/verify` comment trigger, and the Palomar spin-off generator.
+[docs/ROADMAP.md](docs/ROADMAP.md) tracks what is deliberately not built and why; [SECURITY.md](SECURITY.md)
+states the trust model.
 
 This work grows out of the IEANTN subproject of
 [PNT+](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd), whose blueprint-based structure

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,134 @@
+# Security
+
+## What is being protected
+
+Not confidentiality — everything here is public and there are no secrets in the repository or in
+any environment. What is worth attacking is the **integrity of the justification graph**, and one
+claim in particular:
+
+> A `lean-comparator` justification means Comparator actually accepted a solution against the
+> generated challenge, in this repository, for that conclusion.
+
+Everything below exists to make that sentence hard to falsify. A second, lesser goal is that CI
+compute is not free for strangers.
+
+Report a suspected problem by opening an issue, or privately to the maintainer if it would be
+harmful to state publicly.
+
+## Who can do what
+
+| | |
+|---|---|
+| Anyone | Open a pull request. CI runs with a read-only token and no secrets. |
+| Collaborator (write) | Push branches, dispatch `verify.yml`. Cannot merge to `main` without review. |
+| Maintainer (admin) | Approve the `verification` environment, bypass the `main` ruleset. |
+
+The `main` ruleset requires a pull request and code-owner review, and blocks deletion and
+force-push. Administrators can bypass it; that is a deliberate current choice, not an oversight.
+[CODEOWNERS](.github/CODEOWNERS) puts `IEANTN/Vocabulary/`, `.github/workflows/`,
+`scripts/verify-comparator.sh` and `receipts/` behind maintainer review.
+
+## Running untrusted code
+
+Lean elaboration executes arbitrary code. Three places compile code this repository did not write,
+and they are not equally exposed.
+
+**Core CI (`ci.yml`, `build`).** Compiles a pull request's Vocabulary, Conclusions, Challenges and
+bridges — including from a fork, unreviewed, on every push. It is not sandboxed. What bounds it:
+the job holds only `contents: read` on a public repository, no secrets exist to read, and
+`persist-credentials: false` means no token is left in `.git/config` for the compiled code to find.
+So a hostile `Conclusions.lean` gets sixty minutes of throwaway runner and nothing else. That is an
+accepted cost, not a mitigated risk: the alternative is not building pull requests.
+
+**Verification (`verify.yml`).** Split across two jobs on privilege:
+
+- `comparator` runs the contributor's *solution* — the large machine-generated artefact nobody
+  reads — with `contents: read`, no secrets, `persist-credentials: false`, and Comparator's own
+  Landlock sandbox around the export step. It cannot obtain a token.
+- `receipt` holds `contents: write` and never builds the solution. It recomputes the statement
+  fingerprints itself, so it need not believe anything the first job says about them; the only
+  thing it takes from that job is a verdict artefact, whose node and verdict it re-checks.
+
+Being exact about the second one, because the obvious reading is too generous: the receipt job does
+run `lake build` on the branch, and the branch's *core* Lean is not trusted content either. What
+protects it is not the split but the `verification` environment gate on the job before it — nothing
+runs until a maintainer approves, and approving means having looked at the branch. **Approving a
+verification vouches for the branch's `Conclusions.lean` and bridges, not merely its solution.**
+Those are tens of lines; that is the point of the layer separation.
+
+**Palomar metadata validation (`ci.yml`, `palomar-metadata`).** Imports and runs Python fetched
+from `PalomarRegistry/PalomarSubmission` on every run. Pinning it would defeat the purpose — the
+job exists to track a moving contract. So the exposure is bounded instead: the job declares
+`permissions: {}` and holds no token at all, the fetch is an anonymous HTTPS `GET` rather than an
+authenticated `gh api` call, and the resolved upstream commit is written to the job summary so
+*which* validator ran is visible after the fact.
+
+## The trusted base of a receipt
+
+A receipt is worth exactly what these are worth:
+
+- **Comparator, `lean4export`, NanoDa and Landrun**, each pinned to a commit in
+  [`scripts/verify-comparator.sh`](scripts/verify-comparator.sh) and recorded in the receipt.
+  `lean4export` must match the repository's toolchain; `check-pins` fails the build if a Mathlib
+  bump leaves it behind.
+- **The workflow file itself**, which is under CODEOWNERS.
+- **A maintainer's approval** of the `verification` environment.
+- **GitHub's record of the run**, which `check-receipts` queries rather than trusting the receipt.
+
+Every GitHub Action is pinned to a full commit SHA. Two of the three third-party actions resolve
+`@v1` to a *branch*, not a tag — a branch head moves on every push, and both were used in jobs
+holding `contents: write`.
+
+## What a forged receipt would take
+
+The intended control was a ruleset restricting `receipts/` to the workflow's identity. GitHub
+refuses push rulesets on public repositories and outside an organisation, so there is none, and
+`check-receipts` enforces provenance instead — which is the better control anyway, since a path
+rule says who wrote a file and provenance says the verification happened. It requires, for every
+receipt:
+
+1. a run URL in **this** repository — determined from `git remote get-url origin`, and the check
+   refuses outright rather than asking the repository the receipt names if it cannot tell;
+2. that the run exists, concluded `success`, and is `verify.yml` — which needed a maintainer to
+   approve an environment;
+3. that the run is **that node's**, since `verify.yml` puts the dispatched node in its job names,
+   so GitHub's record decides what was verified rather than the receipt asserting it;
+4. one run, one node, which covers runs predating (3).
+
+Separately, `record-receipt` refuses to write a receipt for any conclusion absent from the
+solution's `comparator.json`, so a receipt cannot cover a statement Comparator was never asked
+about. That one needed no adversary: adding a second conclusion to a verified node was enough.
+
+The receipt job also refuses to commit to the default branch. It is the only job in the repository
+holding a write token, so it is the only thing that could put the most trusted file in the network
+into `main` without review.
+
+## Residual risks, stated plainly
+
+- **Nothing checks that a conclusion says what its docstring claims.** Every mechanism here checks
+  that statements are *stable*, never that they are *right*, and a node justified by a citation has
+  no proof to fail. A mis-transcribed threshold or a flipped inequality survives indefinitely. This
+  is the largest risk in the project and it is not a software problem; the mitigations are the
+  bounded review surface, `Examples.lean`, and maintainer-side review against the source.
+- **Mathlib redefining a name.** Fingerprints treat Mathlib constants as opaque names, so a change
+  to what a definition *means* while keeping its name moves nothing. Detecting it would mean
+  fingerprinting Mathlib's own bodies, which would turn every bump red. `Tools/Hash.lean` says so.
+- **A job running untrusted code can lie about its own verdict.** It cannot obtain a token or forge
+  a fingerprint, which is what the split buys; it can fail to report a rejection honestly. This is
+  Palomar's residual too.
+- **Denial of service.** Nothing rate-limits pull requests beyond GitHub's own limits. Every job
+  has a timeout and core CI cancels superseded runs per ref. Verification, the expensive one, is
+  behind the environment gate.
+- **Administrator bypass of the `main` ruleset**, used deliberately today, means a mistaken direct
+  push is possible. It has happened once.
+
+## Configuration this depends on
+
+These are repository settings, not files, so they are worth re-checking after any settings change:
+
+- `main` ruleset: active, requires a pull request and code-owner review.
+- `verification` environment: required reviewers, non-empty.
+- Default workflow permissions: **read**.
+- Allow GitHub Actions to approve pull requests: should be **off** — otherwise a workflow can
+  satisfy a review requirement by approving its own pull request.
+- Require approval for fork pull request workflows: at least "first-time contributors".

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -129,6 +129,8 @@ These are repository settings, not files, so they are worth re-checking after an
 - `main` ruleset: active, requires a pull request and code-owner review.
 - `verification` environment: required reviewers, non-empty.
 - Default workflow permissions: **read**.
-- Allow GitHub Actions to approve pull requests: should be **off** — otherwise a workflow can
-  satisfy a review requirement by approving its own pull request.
+- Allow GitHub Actions to approve pull requests: **off**, so a workflow cannot satisfy a review
+  requirement by approving its own pull request.
+- Required status checks on `main`: `Build Vocabulary and Nodes`, `Check the node network`, and
+  `Network impact` — the last being the hard gate against editing a conclusion others depend on.
 - Require approval for fork pull request workflows: at least "first-time contributors".

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -311,40 +311,58 @@ verification approval procedure and what to actually look at before approving, t
 checking recipe that needs an LLM and so cannot be CI, cross-repository paths, PNT+ migration
 state, and the accumulated traps in operational form.
 
-## Security audit, still to do
+## Security audit
 
-Worth being proactive about, given that contributors are increasingly agents and that some pull
-requests will be too large for a human to review. Four vectors, with what exists today:
+**First pass done.** The written outcome is [SECURITY.md](../SECURITY.md) — the trust model, the
+trusted base of a receipt, and the residual risks. What follows is what the pass found.
 
-**Executable code in submitted Lean.** Elaboration can run arbitrary code, so any job that
-compiles contributor Lean is running their program. Mitigated for verification by the privilege
-split in `verify.yml` and by Comparator's Landlock sandbox. **Not** separately mitigated for the
-*core* CI build, which compiles a PR's `Conclusions.lean`; it holds only `contents: read` and no
-secrets, so the exposure is compute rather than credentials, but it has not been audited.
+The starting position was better than expected in one respect and worse in another. Better: there
+are **no secrets** in the repository or in any environment, default workflow permissions are read,
+`persist-credentials: false` is set everywhere but the one job that must push, and the `main`
+ruleset requires code-owner review. So the untrusted job has nothing to steal, and the exposure
+from compiling contributor Lean really is compute rather than credentials — which is worth stating
+positively rather than leaving as "not audited".
 
-**Denial of service by triggering CI.** The verification workflow is hour-scale and should sit
-behind the environment gate above. Core CI runs per push and is cheap, but nothing rate-limits it.
+Worse: the supply chain was unpinned.
 
-**Alignment checking stays maintainer-side, deliberately.** The obvious answer to the gap below is
-an LLM that reads a conclusions file against its informal description and its cited source. That is
-**not** going into CI: it needs API keys, and it would put a paid, non-deterministic, prompt-
-injectable step on the path of every pull request. Instead it belongs in **agent skills that
-individual maintainers run**, against the bounded surface the architecture already guarantees — the
-conclusions files and the metadata, not the solutions. So the design requirement on this repository
-is only that the surface stay small and the metadata stay machine-readable, which it is.
+**Every action was pinned to a mutable ref, and two of them were branches.** `@v1` for
+`leanprover-community/mathlib-update-action` and `leanprover-community/lean-release-tag` resolves
+to a *branch*, not a tag — a branch head moves on every push upstream. Both are used in jobs
+holding `contents: write`, and the update workflow additionally holds `issues: write` and
+`pull-requests: write`. `leanprover/lean-action@v1` is a tag, and is used in the receipt job, which
+also holds `contents: write`. All actions are now pinned to full commit SHAs with the ref they came
+from in a trailing comment.
 
-**Degradation of the informal layer -- the one that most deserves attention.** Statement
-fingerprints cover the *Lean* statement and nothing else. A pull request can rewrite a conclusion's
-docstring so it appears to say something it does not, change a `locator` from "Proposition 5.4" to
-"Proposition 5.7", swap a `source` for a different paper, or flip a justification from `none-yet`
-to `literature` with a fabricated citation -- **and no fingerprint moves, so nothing in CI
-notices.** For `literature`, `asserted` and `numerical` nodes, which will be most of the network,
-that informal layer *is* the evidence. The cheap first step is to fingerprint each conclusion's
-justification and sources alongside its statement, so that such a change at least appears in the
-impact report rather than passing silently.
+This is the highest-severity finding of the three audits, and it is entirely conventional — it is
+the first thing any Actions hardening guide says. It survived because the workflows were copied
+from working examples, which is exactly how supply-chain exposure normally arrives.
 
-**Trust in the tool pins.** Four revisions in `scripts/verify-comparator.sh` are the trusted base
-of every receipt. Bumping them is a security change, not a chore.
+**The job that runs foreign code held a token.** `palomar-metadata` imports and executes Python
+fetched from `PalomarRegistry/PalomarSubmission`, deliberately unpinned because the job exists to
+track a moving contract. It fetched with an authenticated `gh api` call, so a compromised upstream
+would have run with the workflow token. It now declares `permissions: {}`, fetches anonymously over
+HTTPS, and records the resolved upstream commit in the job summary so which validator ran is
+visible after the fact. Bounding the blast radius was available where pinning was not.
+
+**Provenance was bypassable by deleting a git remote.** `check-receipts` identifies this repository
+from `git remote get-url origin`; if that produced nothing it skipped the comparison and went on to
+query whichever repository the receipt named. Since anyone can stand up a repository with a
+`verify.yml` whose jobs succeed, that was the whole check. It now refuses.
+
+**Two smaller ones.** The receipt job would push to any branch the dispatcher named, including
+`main` — and it is the only job in the repository holding a write token, so it was the only thing
+that could put a receipt into `main` without review; it now refuses the default branch.
+`verify-comparator.sh` did not constrain the node id it turns into a path; shell injection was
+already closed in the code audit, but `x/../../elsewhere` was not.
+
+### Settings, which are not files
+
+Three repository settings are worth changing and one worth confirming; they are listed at the end
+of SECURITY.md so they can be re-checked after any settings change. The one that matters most is
+**"Allow GitHub Actions to approve pull requests"**, currently on: it lets a workflow satisfy a
+review requirement by approving its own pull request. Also worth adding **`Network impact` to the
+required status checks** — it is the hard gate against editing a depended-on conclusion, and a pull
+request can currently merge with it red.
 
 ## A bridge must be trust-neutral
 

--- a/scripts/ieantn.py
+++ b/scripts/ieantn.py
@@ -369,6 +369,20 @@ def check_receipts(online: bool = True) -> bool:
     expected = re.sub(r"^.*github\.com[:/]|\.git$", "", remote) if remote else None
     seen_runs: dict[str, str] = {}
 
+    # Everything below rests on the receipt naming a run in *this* repository: anyone can stand up
+    # a repository with a workflow called `verify.yml` whose jobs succeed. So when the check is
+    # online and cannot tell which repository this is, it must refuse rather than go and ask the
+    # one the receipt names -- which is what it used to do, making the whole check bypassable by
+    # deleting a git remote.
+    if online and expected is None and RECEIPTS.is_dir() and any(RECEIPTS.glob("*.json")):
+        problems.add(
+            rel(RECEIPTS),
+            "cannot determine this repository from `git remote get-url origin`, so a receipt's "
+            "recorded run cannot be checked against it. Refusing rather than trusting the "
+            "repository the receipt names.",
+        )
+        return problems.report("receipt provenance")
+
     for path in sorted(RECEIPTS.glob("*.json")) if RECEIPTS.is_dir() else []:
         receipt = json.loads(path.read_text(encoding="utf-8"))
         url = (receipt.get("run") or {}).get("workflow_run", "")

--- a/scripts/verify-comparator.sh
+++ b/scripts/verify-comparator.sh
@@ -13,6 +13,15 @@
 set -euo pipefail
 
 node=${1:?usage: verify-comparator.sh <Family>.<version>}
+# The node id is a workflow_dispatch input and lands in a path below. It cannot inject shell -- the
+# workflow passes it through the environment, not through `${{ }}` interpolation -- but an id such
+# as `x/../../elsewhere` would still point `solution_dir` outside `Solutions/`. Constrain it to the
+# shape an id actually has.
+case "$node" in
+  *[!A-Za-z0-9_.]* | *..* | .* | *. )
+    echo "error: '$node' is not a node id (expected <Family>.<version>, e.g. Lcm.v1)" >&2
+    exit 1 ;;
+esac
 repository_root=$(cd "$(dirname "$0")/.." && pwd)
 solution_dir="$repository_root/Solutions/$node"
 config="$solution_dir/comparator.json"

--- a/tests/test_ieantn.py
+++ b/tests/test_ieantn.py
@@ -1078,6 +1078,38 @@ class TestReceiptCoverage(FixtureRepo):
         self.assertTrue((self.root / "receipts" / "A.v1.second.json").is_file())
 
 
+class TestProvenanceCannotBeBypassed(FixtureRepo):
+    """The whole check rests on the run being in *this* repository.
+
+    Anyone can stand up a repository with a `verify.yml` whose jobs succeed, so "the run exists and
+    succeeded" is worth nothing on its own. The repository is identified from `git remote get-url
+    origin` -- and when that could not be determined, the check used to go and ask the repository
+    the receipt named, which made it bypassable by deleting a remote.
+    """
+
+    def _receipt(self, key: str, url: str) -> None:
+        (self.root / "receipts").mkdir(exist_ok=True)
+        (self.root / "receipts" / f"{key}.json").write_text(
+            json.dumps({"conclusion": key, "run": {"workflow_run": url}}), encoding="utf-8"
+        )
+
+    def test_an_unknown_repository_is_refused_online(self) -> None:
+        self._receipt("A.v1.main", "https://github.com/attacker/lookalike/actions/runs/1")
+        printed = io.StringIO()
+        with contextlib.redirect_stdout(printed):
+            passed = ieantn.check_receipts(online=True)
+        self.assertFalse(passed, "with no origin remote, provenance must refuse, not go and ask")
+        self.assertIn("cannot determine this repository", printed.getvalue())
+
+    def test_offline_still_checks_only_shape(self) -> None:
+        """Offline the check stays useful without a network, so it does not need the remote."""
+        self._receipt("A.v1.main", "https://github.com/attacker/lookalike/actions/runs/1")
+        self.assertTrue(ieantn.check_receipts(online=False))
+
+    def test_no_receipts_means_nothing_to_refuse(self) -> None:
+        self.assertTrue(ieantn.check_receipts(online=True))
+
+
 class TestReceiptProvenance(FixtureRepo):
     """A receipt must name a real, successful run of the verification workflow.
 


### PR DESCRIPTION
Same content as #15, cherry-picked onto `main`, **plus** a commit recording the two settings you
asked me to apply.

#15 was based on `audit/docs-to-main` and merged into it rather than into `main`, so its content
never landed — the same stranding as #13. That is now three times, and it is my practice at fault,
not the merges: I will base every PR in this repository on `main` from here on and take the
conflict if there is one, rather than stacking.

Nothing new to review in the audit itself; findings are in #15's description.

## Settings applied

Both verified after the change:

- **Allow GitHub Actions to approve pull requests: off.** It was on, which let a workflow satisfy a
  review requirement by approving its own pull request.
- **`Network impact` added to the required status checks** on `main`, alongside `Build Vocabulary
  and Nodes` and `Check the node network`. It is the hard gate against editing a conclusion others
  depend on, and could previously merge red.

The rulesets API replaces the `rules` array wholesale, so that was a read-modify-write of the entire
ruleset rather than a patch of the one rule. Confirmed preserved afterwards: `deletion`,
`non_fast_forward`, `pull_request` (with code-owner review), and your admin bypass actor.

SECURITY.md's settings section now records these as applied rather than recommended.

## Checks

`ieantn.py check` green, 97 tests pass, all four workflows parse, `bash -n` clean on
`verify-comparator.sh`.

Note that `Network impact` is now required, so this PR must pass it to merge — which it will, being
documentation and workflow changes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)