### PR TITLE
Lcm.v2: make the threshold constant a parameter, and correct it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,7 +239,8 @@ theorem bridge_v2_to_v1
     (general : Lcm.v2.lcmUpto_not_highlyAbundant_of_primeGap)
     (dusart : Dusart2018.v1.proposition_5_4) :
     Lcm.v1.lcmUpto_not_highlyAbundant :=
-  fun n hn => general 89693 lt_log_89693 dusart n (by exact_mod_cast hn)
+  fun n hn =>
+    general 11.4 89693 (by norm_num) lt_log_89693.le dusart n (by exact_mod_cast hn)
 ```
 
 Its hypotheses are the conclusions you name in `from`, plus whatever the *target* node already

--- a/IEANTN/Bridges/Lcm/V2ToV1.lean
+++ b/IEANTN/Bridges/Lcm/V2ToV1.lean
@@ -58,13 +58,19 @@ theorem lt_log_89693 : (11.4 : ℝ) < Real.log 89693 := by
 /-- **The bridge.**  `Lcm.v2`'s abstract form, together with the Dusart hypothesis that `Lcm.v1`
 imports, gives `Lcm.v1`'s conclusion.
 
-The whole content is instantiating `X₀ := 89693`, discharging the side condition, and moving the
-threshold hypothesis from `ℕ` to `ℝ`. That it is this short is the point: `v1` is an instance of
-`v2`, and the bridge exhibits the instantiation. -/
+The whole content is instantiating `c := 11.4` and `X₀ := 89693`, discharging the side conditions,
+and moving the threshold hypothesis from `ℕ` to `ℝ`. That it is this short is the point: `v1` is an
+instance of `v2`, and the bridge exhibits the instantiation.
+
+`11.4` is passed for `c` because that is the value `Lcm.v1`'s development uses, and `lt_log_89693`
+is exactly the side condition it needs. `Lcm.v2` requires only `5 ≤ c`, so any value in `[5, 11.4]`
+would do here; keeping `11.4` makes the bridge a faithful record of what the ported proof actually
+establishes. -/
 theorem bridge_v2_to_v1
     (general : Lcm.v2.lcmUpto_not_highlyAbundant_of_primeGap)
     (dusart : Dusart2018.v1.proposition_5_4) :
     Lcm.v1.lcmUpto_not_highlyAbundant :=
-  fun n hn => general 89693 lt_log_89693 dusart n (by exact_mod_cast hn)
+  fun n hn =>
+    general 11.4 89693 (by norm_num) lt_log_89693.le dusart n (by exact_mod_cast hn)
 
 end Lcm

--- a/IEANTN/Nodes/Lcm/v2/Conclusions.lean
+++ b/IEANTN/Nodes/Lcm/v2/Conclusions.lean
@@ -41,18 +41,35 @@ def HighlyAbundant (N : ℕ) : Prop := ∀ m : ℕ, m < N → sigma 1 m < sigma 
 
 /-- **The argument, with its threshold abstracted.**
 
-If `X₀` is large enough that `log X₀ > 11.4`, and every `x ≥ X₀` admits a prime in
+If some `c ≥ 5` bounds `log X₀` from below, and every `x ≥ X₀` admits a prime in
 `(x, x + x/(log x)³]`, then `Lₙ = lcm(1, …, n)` fails to be highly abundant for every `n ≥ X₀²`.
 
-The side condition is exactly what the estimates need: the argument compares products of three
-primes just above `√n` against three just below `n`, and the comparison closes once
-`ε = 1/(log √n)³` is small enough, which `log √n ≥ 11.4` secures.
+## What `c` is, and where the bound on it comes from
 
-`11.4` is not sacred — it is the bound the existing proof happens to use, and a sharper analysis
-would lower it. What matters is that the threshold and the prime-gap input move together, which is
-what `v1` cannot express. -/
+`c` is a lower bound for `log √n`, and the *only* thing the argument uses it for: it bounds the
+relative gap `ε = 1/(log √n)³ ≤ 1/c³`. The argument adjoins three primes just above `√n` and
+removes three just below `n`, and closes exactly when the resulting comparison of products holds,
+which is a numerical condition on `ε` and on `X₀`.
+
+An earlier version of this statement wrote `11.4` here instead. That number is not a property of
+the argument at all — it is `log 89693` rounded down, which is to say it came from the threshold
+`Lcm.v1` happens to use. Reading the constraint out of the development
+(`Solutions/Lcm.v1/LcmDev.lean`) and evaluating it gives a genuine threshold near **`c > 4.12`**,
+attained in the worst permitted case `X₀ = eᶜ`; at `X₀ = 89693` it is nearer `3.6`. `5` is that
+threshold with margin, chosen so a solver has room and so the constant is not itself a fitted
+number. **The margin is deliberate and the bound is not claimed to be sharp.**
+
+## `c` is eliminable, and is kept anyway
+
+Since the conclusion does not mention `c`, this is equivalent to `5 ≤ log X₀ → …`. The parameter
+earns its place as documentation rather than logic: it names the quantity the numerics constrain,
+so a sharper analysis lowers a stated bound instead of silently changing a magic number, and a
+reader can see that `11.4` was never doing the work it appeared to be doing.
+
+The practical gain is the lowered bound, not the parameter: a prime-gap result at any threshold
+above `e⁵ ≈ 149` now feeds this node, where `11.4` demanded one above `89000`. -/
 def lcmUpto_not_highlyAbundant_of_primeGap : Prop :=
-  ∀ X₀ : ℝ, 11.4 < Real.log X₀ → IEANTN.HasPrimeInInterval.logPower X₀ 3 →
+  ∀ c X₀ : ℝ, 5 ≤ c → c ≤ Real.log X₀ → IEANTN.HasPrimeInInterval.logPower X₀ 3 →
     ∀ n : ℕ, X₀ ^ 2 ≤ (n : ℝ) → ¬ HighlyAbundant (Nat.lcmUpto n)
 
 end Lcm.v2

--- a/IEANTN/Nodes/Lcm/v2/formalization.yaml
+++ b/IEANTN/Nodes/Lcm/v2/formalization.yaml
@@ -17,9 +17,9 @@ project:
   name: "The lcm sequence is not highly abundant, with the threshold abstracted"
   description: >-
     The argument of Lcm.v1 with its threshold abstracted: any Dusart-type prime-gap result at a threshold
-    X0 with log X0 > 11.4 gives that lcm(1..n) fails to be highly abundant for every n >= X0^2. Lcm.v1
-    is the instance at 89693. Stated without imports, so a downstream user supplies whichever prime-gap
-    result they have.
+    X0 admitting a lower bound c >= 5 on log X0 gives that lcm(1..n) fails to be highly abundant for every
+    n >= X0^2. Lcm.v1 is the instance at 89693. Stated without imports, so a downstream user supplies
+    whichever prime-gap result they have.
   authors: ["Terence Tao"]
   license: "Apache-2.0"
   responsible_maintainers: ["Terence Tao"]
@@ -39,9 +39,15 @@ conclusions:
   justifications:
   - id: unjustified
     kind: none-yet
-    note: Generalising Solutions/Lcm.v1/LcmDev.lean. The development fixes X0 = 89693 as an abbrev 
-      and uses the literal in several estimates, so this is real work rather than a rename. The 
-      numerical side condition itself is already proved there as `log_X0_gt`.
+    note: >-
+      Generalising Solutions/Lcm.v1/LcmDev.lean. The development fixes X0 = 89693 as an abbrev and uses
+      the literal in several estimates, so this is real work rather than a rename. Two things the solver
+      should know. The numerical side condition at the instance is already proved there as `log_X0_gt`.
+      And the bound c >= 5 is the constraint read out of that development's final product comparison (Criterion.h_crit,
+      via prod_epsilon_le / final_comparison / prod_epsilon_ge) and evaluated: it binds near c > 4.12
+      in the worst permitted case X0 = e^c, and near c > 3.6 at X0 = 89693. 5 carries margin deliberately
+      and is not claimed sharp -- if the generalised proof will not close at 5, the right response is
+      to say so and raise it, not to weaken anything else.
   designated: unjustified
 
   issue: 10

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -404,11 +404,28 @@ imports at all**:
 
 ```lean
 def lcmUpto_not_highlyAbundant_of_primeGap : Prop :=
-  ∀ X₀ : ℝ, 11.4 < Real.log X₀ → IEANTN.HasPrimeInInterval.logPower X₀ 3 →
+  ∀ c X₀ : ℝ, 5 ≤ c → c ≤ Real.log X₀ → IEANTN.HasPrimeInInterval.logPower X₀ 3 →
     ∀ n : ℕ, X₀ ^ 2 ≤ (n : ℝ) → ¬ HighlyAbundant (Nat.lcmUpto n)
 ```
 
-Step 2 determined the side condition: `log X₀ > 11.4`, and nothing else.
+Step 2 determined the side condition: a lower bound on `log X₀`, and nothing else.
+
+**The first attempt carried the wrong constant, and carrying it as a parameter is what exposed
+that.** It initially read `11.4 < Real.log X₀`, lifted from the development. But `11.4` is not a
+property of the argument — it is `log 89693` rounded down, which is to say it came from the very
+threshold this version exists to abstract away. Abstracting a number without asking what constrains
+it just relocates it.
+
+Reading the constraint out of `Criterion.h_crit` and the chain that discharges it
+(`prod_epsilon_le` → `final_comparison` → `prod_epsilon_ge`), and evaluating it, gives a genuine
+threshold near `c > 4.12` in the worst permitted case `X₀ = eᶜ`, and near `3.6` at `X₀ = 89693`.
+The stated `5` is that with margin. The gain is not the parameter, which is logically eliminable
+since the conclusion never mentions `c`; it is that a prime-gap result at any threshold above
+`e⁵ ≈ 149` now feeds this node where `11.4` demanded one above `89000`.
+
+The general lesson, and it is the same one as the `log 7` scouting below: **a constant in a
+statement of record should be traced to the inequality that forces it.** Until it is, nobody can
+tell whether it is a fact about the mathematics or a fossil of one instance.
 
 **The bridge** discharges `Lcm.v1`'s conclusion from `Lcm.v2`'s by instantiating `X₀ := 89693`,
 verifying the side condition, and handling the ℕ→ℝ cast — three lines. It is a bridge, not an

--- a/fingerprints.json
+++ b/fingerprints.json
@@ -1,5 +1,5 @@
 {
   "Dusart2018.v1.proposition_5_4": "a2a27b8382fc7657f765de82fb89561e797db20370d0375e1114b2a5b943b134",
   "Lcm.v1.lcmUpto_not_highlyAbundant": "7dd7914d659103ca6fef5fa518d4db55a8372b9161fd3e2966f1772976cdf4f0",
-  "Lcm.v2.lcmUpto_not_highlyAbundant_of_primeGap": "3d50f1279299b797895bb7ae73546f02676b67fabe3764b78fa5a6b1416f5323"
+  "Lcm.v2.lcmUpto_not_highlyAbundant_of_primeGap": "90d4cacf4a5de6e381f02cabdb5b8d6b5f8bf442a7ce3f5197fefda84c80ee7a"
 }


### PR DESCRIPTION
`11.4` is no longer hardcoded in `Lcm.v2`'s conclusion. It is a parameter `c` with `5 ≤ c ≤ log X₀`:

```lean
def lcmUpto_not_highlyAbundant_of_primeGap : Prop :=
  ∀ c X₀ : ℝ, 5 ≤ c → c ≤ Real.log X₀ → IEANTN.HasPrimeInInterval.logPower X₀ 3 →
    ∀ n : ℕ, X₀ ^ 2 ≤ (n : ℝ) → ¬ HighlyAbundant (Nat.lcmUpto n)
```

## What the constant had to obey

Locating it turned up the more interesting half: **`11.4` is not a property of the argument.** It is
`log 89693` rounded down — it came from the very threshold this version exists to abstract away.
Abstracting a number without asking what constrains it just relocates it.

`c` enters `LcmDev.lean` in exactly one way: as a lower bound for `log √n`, bounding the relative
gap `ε = 1/(log √n)³ ≤ 1/c³`. The other two places it appears — `(1+1/c³)³ ≤ 2` at `h1ε3_le_2`,
`(1+1/c³)⁶ < 2` at `hmid` — are slack by orders of magnitude.

The binding constraint is the final product comparison, `Criterion.h_crit`, discharged through
`prod_epsilon_le` → `final_comparison` → `prod_epsilon_ge`. Reconstructing that chain as a function
of `c` and `X₀` and evaluating it:

| `c` | worst permitted `X₀ = eᶜ` | closes? |
|---|---|---|
| 4 | 54.6 | no |
| 4.5 | 90.0 | yes |
| 5 | 148.4 | yes |
| 11.4 | 89322 | yes |

Threshold `c > 4.1163` at `X₀ = eᶜ`; `c > 3.5937` at `X₀ = 89693`. I checked the reconstruction
against `Criterion`'s actual `h_crit` before trusting it — the products, the `3/(8n)` term and the
`4∏p/∏q` term all line up with `prod_p_ge` / `prod_q_ge`.

**`5` is that threshold with margin, and is deliberately not sharp.** The node's metadata says so,
and says that if the generalised proof will not close at 5 the right response is to raise it and say
why — not to weaken anything else.

## The parameter is eliminable, and I kept it anyway

The conclusion never mentions `c`, so `∀ c, 5 ≤ c → c ≤ log X₀ → …` is equivalent to
`5 ≤ log X₀ → …`. The docstring states this plainly rather than leaving a reader to notice it and
distrust the node. It earns its place as documentation: it names the quantity the numerics
constrain, so a sharper analysis lowers a stated bound instead of silently editing a magic number.

**The gain is the corrected bound, not the parameter.** A prime-gap result at any threshold above
`e⁵ ≈ 149` now feeds this node; `11.4` demanded one above `89000`.

## Checks

- The bridge instantiates `c := 11.4` — the value `Lcm.v1`'s development actually establishes — and
  **still compiles**. That is the check that the generalisation is faithful rather than plausible.
- `Lcm.v1`'s fingerprint is unchanged, so its receipt still stands and `status` still reports green.
- `Lcm.v2`'s fingerprint moved, as it should. `diff` reports it as informational: nothing imports
  it and it has no receipt, which is exactly the case where editing in place is allowed.
- `lake build` clean, `ieantn.py check` all six green, 97 tests pass.

Issue #10 (solve `Lcm.v2`) is unchanged in scope but now has a harder and more useful target — I'll
update its body once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)