### PR TITLE
Add the Palomar spin-off generator, and the missing LICENSE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ python scripts/ieantn.py report         # what each conclusion rests on
 python scripts/ieantn.py status         # green / yellow / orange / BROKEN per conclusion
 python scripts/ieantn.py diff           # what your branch degrades, and for whom
 python scripts/ieantn.py housekeeping   # the derived task queue
+python scripts/ieantn.py spinoff <conclusion> --out <dir> --compile   # Palomar submission
 ```
 
 `Challenge.lean` files are generated: after editing a `Conclusions.lean` or a

--- a/IEANTN/Nodes/Lcm/v1/formalization.yaml
+++ b/IEANTN/Nodes/Lcm/v1/formalization.yaml
@@ -62,11 +62,12 @@ conclusions:
     bridge: IEANTN/Bridges/Lcm/V2ToV1.lean
     note: >-
       A second, independent ground: this conclusion is the instance of Lcm.v2 at X0 = 89693. The bridge
-      discharges the side condition log X0 > 11.4 and instantiates. It is compiled by the core build,
-      so it cannot silently stop being a proof. Recorded but NOT designated: Lcm.v2 is itself unjustified,
-      so this ground currently transports nothing, and the direct Comparator receipt is the better designation
-      anyway -- it depends on no other node. The value of recording it now is that the moment Lcm.v2 acquires
-      a solution, this node has a second path to trust, and `report` can see it.
+      discharges the side condition and instantiates, and is compiled by the core build, so it cannot
+      silently stop being a proof. Lcm.v2 now carries its own Comparator receipt, so this ground is live
+      rather than pending. It is still NOT designated, and should stay that way: the direct receipt below
+      rests on no other node, while this one would route trust through Lcm.v2. Its value is redundancy
+      -- if the direct receipt ever goes BROKEN, re-designating here is a one-line change rather than
+      a re-verification.
   designated: comparator-2026-08
 
 sources:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 IEANTN contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ all exist and run in CI.
 **The Comparator path works end to end**: `Lcm.v1` carries a receipt written by the verification
 workflow, and `ieantn.py status` grades it against the current environment.
 
-Outstanding: visualisation, the `/verify` comment trigger, and the Palomar spin-off generator.
-[docs/ROADMAP.md](docs/ROADMAP.md) tracks what is deliberately not built and why; [SECURITY.md](SECURITY.md)
-states the trust model.
+Outstanding: visualisation, the `/verify` comment trigger, and the composing half of the
+Palomar spin-off generator. [docs/ROADMAP.md](docs/ROADMAP.md) tracks what is deliberately not built
+and why; [SECURITY.md](SECURITY.md) states the trust model.
 
 This work grows out of the IEANTN subproject of
 [PNT+](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd), whose blueprint-based structure

--- a/Solutions/Lcm.v1/LcmDev.lean
+++ b/Solutions/Lcm.v1/LcmDev.lean
@@ -2,6 +2,20 @@
 Copyright (c) 2026 IEANTN contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Terence Tao
+
+This file is a modified copy of `PrimeNumberTheoremAnd/IEANTN/Lcm.lean` from
+https://github.com/AlexKontorovich/PrimeNumberTheoremAnd at commit
+ae881f2e2b3acefc9b92f8d4dda7c2b8f6e8f5fe, which is licensed under Apache 2.0.
+
+Changes from that original:
+
+* the LeanArchitect blueprint metadata is removed -- 35 `@[blueprint]` attributes and 18
+  `blueprint_comment` blocks -- since this repository records the informal statement in the node's
+  `Conclusions.lean` docstrings instead;
+* Dusart's Proposition 5.4 is taken as an explicit hypothesis `hd` rather than called as
+  `Dusart.proposition_5_4`. In PNT+ that declaration is itself unproved, so the original
+  `L_not_HA_of_ge` depends on `sorryAx` and could not pass Comparator; threading it as a hypothesis
+  is what makes this a genuine conditional proof of exactly what the node claims.
 -/
 import Mathlib.NumberTheory.Chebyshev
 import Mathlib.Analysis.Complex.ExponentialBounds

--- a/Solutions/Lcm.v2/LcmDev.lean
+++ b/Solutions/Lcm.v2/LcmDev.lean
@@ -2,6 +2,23 @@
 Copyright (c) 2026 IEANTN contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Terence Tao
+
+This file is a modified copy of `Solutions/Lcm.v1/LcmDev.lean` in this repository, which is in turn
+a modified copy of `PrimeNumberTheoremAnd/IEANTN/Lcm.lean` from
+https://github.com/AlexKontorovich/PrimeNumberTheoremAnd at commit
+ae881f2e2b3acefc9b92f8d4dda7c2b8f6e8f5fe, licensed under Apache 2.0. See that file's header for
+the changes made there.
+
+Changes from `Solutions/Lcm.v1/LcmDev.lean`:
+
+* the threshold is a parameter. `abbrev X₀ := 89693` and the literal `11.4` are replaced by
+  variables `X₀ c : ℝ` with `5 ≤ c` and `c ≤ Real.log X₀`, and the section that produces the two
+  triples of primes is rewritten accordingly -- roughly 430 lines. The `Criterion` machinery above
+  it is unchanged, having never mentioned the threshold;
+* the numerical endgame runs at the worst cases those hypotheses allow, `1/125` and `148`, in place
+  of `v1`'s `0.000675` and `89693`;
+* `0 < X₀` is derived from the prime-gap hypothesis rather than from `c ≤ Real.log X₀`, which does
+  not imply it -- `Real.log` of a negative number is `log |x|`.
 -/
 import Mathlib.NumberTheory.Chebyshev
 import Mathlib.Analysis.Complex.ExponentialBounds

--- a/Tools/Spinoff.lean
+++ b/Tools/Spinoff.lean
@@ -1,0 +1,164 @@
+/-
+Copyright (c) 2026 IEANTN contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Tao
+-/
+import IEANTN
+import Lean
+
+/-!
+# Spin-off support: locating the definitions a conclusion rests on
+
+Emits, for one or more named conclusions, every IEANTN-local constant they transitively mention, in
+dependency order, with the exact source range of each. `scripts/ieantn.py spinoff` slices those
+ranges out of the source files and assembles a self-contained Challenge.
+
+## Why this exists
+
+A Palomar Challenge's transitive import closure must be Lean core and Mathlib only -- it may not
+import the submitter's own library. IEANTN's conclusions do import one: `IEANTN.Vocabulary`, and
+sometimes another node's `Conclusions`. Spinning a node off therefore means **inlining** those
+definitions into the Challenge, which is the operation `docs/ARCHITECTURE.md` section 7 calls
+generating a self-contained challenge "by substitution", and the reason Vocabulary is held to a
+Mathlib-only closure in the first place.
+
+## Why source ranges rather than pretty-printing
+
+Pretty-printing the elaborated definitions is the obvious approach and was tried first. It produces
+correct but unreadable output -- `LE.le 5 c` for `5 ≤ c`, `Exists fun p ↦ …` for `∃ p, …` -- because
+a standalone executable's environment has none of the notation delaborators registered, and the
+usual remedies (`pp.notation`, `enableInitializersExecution`) do not bring them back. The output is
+*correct* either way, which is exactly what makes that failure easy to ship by accident.
+
+The Challenge is the small file a mathematical reader audits. A Challenge nobody can read has
+failed at its job even if Comparator accepts it. So the text comes from the source files, which
+were written to be read, docstrings and all.
+
+## The namespace problem, and how the selection range solves it
+
+Sliced source cannot simply be concatenated: a definition's body refers to its neighbours by
+whatever short name was in scope where it was written -- `HighlyAbundant`, not
+`Lcm.v2.HighlyAbundant` -- and those names stop resolving once the surrounding `namespace` is gone.
+
+Rather than reconstruct namespaces by parsing Lean, ask Lean. `findDeclarationRanges?` gives two
+spans: `range` covers the whole declaration *including its docstring*, and `selectionRange` covers
+just the declared name as written. Slicing the second gives the source-level name, and the
+namespace is the full name with that suffix removed. The generator re-emits each declaration inside
+its own `namespace`, so every short name resolves exactly as it did originally.
+
+## What is not assumed
+
+That the slicing is faithful. `ieantn.py spinoff` compiles the Challenge it assembles, so a
+mis-sliced declaration fails there rather than silently producing a Challenge that states something
+other than the node does.
+-/
+
+open Lean
+
+namespace IEANTN.Spinoff
+
+/-- Is this constant defined by this project rather than by Lean core or Mathlib?
+
+Decided by module provenance, as in `Tools/Hash.lean`. Unknown provenance counts as local for the
+same reason it does there: over-including a definition costs a few lines in the Challenge, while
+under-including one produces a Challenge that does not compile. -/
+def isLocal (env : Environment) (n : Name) : Bool :=
+  match env.getModuleFor? n with
+  | some m => (`IEANTN).isPrefixOf m
+  | none => true
+
+/-- Elaboration artifacts, which must not be inlined: they are proofs, not statements. -/
+def isArtifact (n : Name) : Bool :=
+  n.hasMacroScopes ||
+    match n.components.getLast? with
+    | some c => c.toString.startsWith "_proof_" || c.toString.startsWith "_example"
+    | none => false
+
+/-- Every constant a term mentions. -/
+partial def constantsIn (e : Expr) (acc : NameSet := {}) : NameSet :=
+  match e with
+  | .const n _ => if isArtifact n then acc else acc.insert n
+  | .app f a => constantsIn a (constantsIn f acc)
+  | .lam _ t b _ => constantsIn b (constantsIn t acc)
+  | .forallE _ t b _ => constantsIn b (constantsIn t acc)
+  | .letE _ t v b _ => constantsIn b (constantsIn v (constantsIn t acc))
+  | .mdata _ e => constantsIn e acc
+  | .proj _ _ e => constantsIn e acc
+  | _ => acc
+
+/-- The local constants `n` rests on, in dependency order, `n` itself last.
+
+A post-order walk, so a definition always appears after everything it mentions. Names are visited
+in sorted order at each step, which is what keeps the output stable between runs -- a generator
+whose output reshuffles cannot be reviewed by diffing. -/
+partial def collect (env : Environment) (n : Name) (seen : NameSet) (out : Array Name) :
+    NameSet × Array Name :=
+  if seen.contains n then (seen, out)
+  else
+    let seen := seen.insert n
+    match env.find? n with
+    | none => (seen, out)
+    | some info =>
+      let deps := match info with
+        | .defnInfo d => constantsIn d.value (constantsIn d.type)
+        | other => constantsIn other.type
+      let locals := deps.toList.filter (fun d => isLocal env d && d != n)
+      let sorted := (locals.map Name.toString).toArray.qsort (· < ·) |>.toList
+      let (seen, out) := sorted.foldl
+        (fun (acc : NameSet × Array Name) s => collect env s.toName acc.1 acc.2) (seen, out)
+      (seen, out.push n)
+
+/-- Where one local constant is written, and what kind of declaration it is. -/
+def locate (n : Name) : CoreM (Option Json) := do
+  let env ← getEnv
+  let some info := env.find? n | return none
+  let some ranges ← findDeclarationRanges? n | return none
+  let full : DeclarationRange := Lean.DeclarationRanges.range ranges
+  let sel : DeclarationRange := Lean.DeclarationRanges.selectionRange ranges
+  let kind := match info with
+    | .defnInfo _ => "def"
+    | .axiomInfo _ => "axiom"
+    | .thmInfo _ => "theorem"
+    | _ => "other"
+  return some <| Json.mkObj [
+    ("name", Json.str n.toString),
+    ("module", Json.str ((env.getModuleFor? n).map Name.toString |>.getD "")),
+    ("kind", Json.str kind),
+    ("startLine", Json.num full.pos.line), ("startCol", Json.num full.pos.column),
+    ("endLine", Json.num full.endPos.line), ("endCol", Json.num full.endPos.column),
+    ("nameStartLine", Json.num sel.pos.line), ("nameStartCol", Json.num sel.pos.column),
+    ("nameEndLine", Json.num sel.endPos.line), ("nameEndCol", Json.num sel.endPos.column)]
+
+end IEANTN.Spinoff
+
+open IEANTN.Spinoff in
+/-- Emit the inlining plan for the declarations named on the command line. -/
+def main (args : List String) : IO UInt32 := do
+  if args.isEmpty then
+    IO.eprintln "usage: ieantn_spinoff <declaration>..."
+    return 1
+  initSearchPath (← findSysroot)
+  let env ← importModules #[{ module := `IEANTN }] {}
+  let mut order : Array Name := #[]
+  let mut seen : NameSet := {}
+  let mut failed := false
+  for a in args do
+    let n := a.toName
+    if env.find? n |>.isNone then
+      IO.eprintln s!"error: unknown declaration `{a}`"
+      failed := true
+    else
+      let (s, o) := collect env n seen order
+      seen := s
+      order := o
+  if failed then return 1
+  let act : CoreM (Array Json) := do
+    let mut acc : Array Json := #[]
+    for n in order do
+      match ← locate n with
+      | some j => acc := acc.push j
+      | none => throwError "no source range for `{n}`; it cannot be inlined"
+    return acc
+  let (located, _) ← (act.toIO { fileName := "<spinoff>", fileMap := default } { env := env })
+  IO.println (Json.mkObj [("declarations", Json.arr located)]).compress
+  return 0

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -444,7 +444,25 @@ Because imports are per-conclusion and the graph is deterministic, the generator
 single conclusion, a challenge whose hypotheses are the **transitive unjustified leaves**, with a
 solution composing the per-node solutions along the way — *"the main results of paper X hold given
 this RH verification, this table computation, and this folklore lemma."* That is the artifact worth
-registering. *(planned)*
+registering.
+
+`python scripts/ieantn.py spinoff <conclusion> --out <dir>` builds it, for the **one-level** case:
+a conclusion whose unjustified leaves are all among its own direct imports. Deeper graphs need the
+per-node solutions composed, which is not implemented; the command refuses rather than emitting
+something that looks complete. *(planned: the composing case.)*
+
+What it does is inline. A Palomar Challenge's import closure must be Lean core and Mathlib only, so
+the emitted Challenge cannot `import IEANTN.Vocabulary`; instead `Tools/Spinoff.lean` walks the
+conclusion's local constants, and the generator slices each one's source — docstring and all —
+straight out of the file it was written in, re-emitting it inside its own `namespace` with its
+module's `open` directives so that every short name resolves as it did. That is the operation this
+section calls "substitution", and it is the reason Vocabulary is held to a Mathlib-only closure.
+
+The inlined definitions keep their original names. The Solution obtains the identical constants by
+depending on this repository, and Comparator compares the two exported environments — so a
+divergence between an inlined copy and the real definition is precisely what it is built to catch,
+not a gap it would miss. `--compile` elaborates the assembled Challenge against Mathlib before you
+trust any of it.
 
 ## 8. What exists today
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,6 +24,13 @@ kind of change it deliberately cannot see.
 `ieantn.py record-receipt` (workflow-only) and `ieantn.py status` grading them green / yellow /
 orange / BROKEN. `check-graph` refuses a `lean-comparator` justification with no matching receipt.
 
+`status` also notes when a *solution* has been edited since the verification that attested to it.
+The fingerprints catch a statement moving out from under a receipt; nothing caught the solution
+moving, and after an edit the receipt has accepted something other than what is on disk. It is a
+note rather than a failure because the common case really is a comment — but the receipt cannot
+tell you which case you are in, so it says so and leaves the judgement where it belongs. Only
+`"schema": 2` receipts record the commit this needs; older ones are skipped rather than guessed at.
+
 **The intended `receipts/` path ruleset is impossible here, and provenance replaced it.** GitHub
 refuses push rulesets on a public repository *and* on any repository not owned by an organisation,
 and separately refuses to make the Actions app a bypass actor outside an organisation -- so a rule

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -58,8 +58,8 @@ tools pinned, and `.github/workflows/verify.yml` splitting the run in two: `comp
 contributor code with **no write access and no secrets**, and `receipt` holds write access but runs
 no contributor code and recomputes the fingerprints itself from the core library.
 
-Comparator accepts `Solutions/Lcm.v1` -- both the Lean kernel and NanoDa -- in about 50 seconds
-locally. Getting there took four fixes, all recorded in the code audit below, and the most
+Comparator accepts `Solutions/Lcm.v1` and `Solutions/Lcm.v2` -- both the Lean kernel and
+NanoDa -- in about 50 seconds locally. Getting there took four fixes, all recorded in the code audit below, and the most
 instructive of them is that a solution must carry a `lean-toolchain` *equal* to the repository's:
 Mathlib's `cache` reads it from the project directory, and the rule that briefly forbade the file
 is what caused the 64-minute first run.
@@ -72,7 +72,7 @@ its own dispatch; there, the controls are cost visibility and keeping dispatch a
 **6. Staleness and the housekeeping queue's time-sensitive half.** Green / yellow / orange against
 the Mathlib cache window (CONTRIBUTING §8).
 
-**7. Unit tests for the tooling.** *Done* -- 73 tests in `tests/`, run against a fixture
+**7. Unit tests for the tooling.** *Done* -- 97 tests in `tests/`, run against a fixture
 repository the real functions are pointed at, and mutation-checked rather than merely passing.
 Several are regression tests for defects that shipped.
 
@@ -81,6 +81,25 @@ is the silent-no-op class in the code audit below and the one unit tests would c
 
 **8. Visualisation.** A rendered graph over the receipts and metadata, computed rather than
 re-running any verification.
+
+**9. The Palomar spin-off generator.** *Partly done* -- `ieantn.py spinoff <conclusion> --out <dir>`
+emits a self-contained submission for the one-level case, where every transitive unjustified leaf is
+also a direct import. It inlines the node's definitions so the Challenge's closure is Mathlib-only,
+takes each leaf as a hypothesis, and vendors the node's solution.
+
+Two things it deliberately does not do. It refuses the multi-level case rather than emitting
+something incomplete: composing several nodes' solutions into one is the harder half of section 7
+and is still open. And it stops short of `lakefile.toml`, `lake-manifest.json` and
+`formalization.yaml`, printing what remains -- those need a pinned dependency on a *published*
+commit and a limitations section naming the hypotheses, neither of which a generator should invent.
+
+The route not taken is worth recording. Pretty-printing the elaborated definitions is the obvious
+way to inline them and produces correct, unreadable output -- `LE.le 5 c` for `5 ≤ c` -- because a
+standalone executable has no notation delaborators registered, and `pp.notation` and
+`enableInitializersExecution` do not bring them back. Correct-but-unreadable is the dangerous
+failure here, because nothing downstream complains: Comparator would accept such a Challenge
+happily. The Challenge is the one file a mathematical reader audits, so the text now comes from the
+source files, which were written to be read.
 
 ## Considered and dropped: tiered verification levels
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -22,3 +22,8 @@ name = "IEANTN"
 [[lean_exe]]
 name = "ieantn_hash"
 root = "Tools.Hash"
+
+# Not in defaultTargets either: only needed when generating a Palomar spin-off.
+[[lean_exe]]
+name = "ieantn_spinoff"
+root = "Tools.Spinoff"

--- a/scripts/ieantn.py
+++ b/scripts/ieantn.py
@@ -1204,6 +1204,40 @@ def assess(conclusion_key: str, receipt: dict, fingerprints: dict[str, str]) -> 
     return "yellow", detail
 
 
+def solution_drift(receipt: dict) -> str | None:
+    """Whether the solution has been edited since the verification that attested to it.
+
+    `assess` compares statement fingerprints, so it catches a *statement* moving out from under a
+    receipt. Nothing caught the *solution* moving. The receipt says Comparator accepted that
+    solution, and after an edit it has accepted something else -- possibly a comment, possibly not,
+    and the receipt cannot tell you which.
+
+    Reported rather than fatal, because the common case really is a comment. What makes it
+    detectable at all is `repository.commit`, which schema 2 records and schema 1 does not; older
+    receipts are skipped rather than guessed at. A commit that is not present locally -- a shallow
+    clone, or one written on a branch since deleted -- is also skipped.
+    """
+    commit = (receipt.get("repository") or {}).get("commit")
+    project = (receipt.get("solution") or {}).get("project")
+    if not commit or not project:
+        return None
+    known = subprocess.run(
+        ["git", "cat-file", "-e", f"{commit}^{{commit}}"],
+        cwd=ROOT, capture_output=True, text=True, encoding="utf-8")
+    if known.returncode != 0:
+        return None
+    changed = subprocess.run(
+        ["git", "diff", "--name-only", commit, "--", project],
+        cwd=ROOT, capture_output=True, text=True, encoding="utf-8")
+    if changed.returncode != 0:
+        return None
+    files = [line for line in changed.stdout.splitlines() if line.strip()]
+    if not files:
+        return None
+    return (f"{project} has changed in {len(files)} file(s) since the verification at "
+            f"{commit[:12]}; the receipt attests to that commit, not to what is there now")
+
+
 def status() -> bool:
     """The traffic light for every conclusion."""
     nodes = load_nodes()
@@ -1231,6 +1265,9 @@ def status() -> bool:
             lights[light] += 1
             print(f"  {light:<7} {key}")
             print(f"          {detail}")
+            drift = solution_drift(receipt)
+            if drift is not None:
+                print(f"          note: {drift}")
 
     print("\n" + "=" * 78)
     print(

--- a/scripts/ieantn.py
+++ b/scripts/ieantn.py
@@ -58,6 +58,16 @@ RECEIPTS = ROOT / "receipts"
 CHANGES = ROOT / "changes"
 SOLUTIONS = ROOT / "Solutions"
 
+#: Where a spun-off Challenge says it came from.
+REPOSITORY_URL = "https://github.com/teorth/IEANTN"
+
+#: The four-line header every Lean file in this repository carries.
+LICENCE_HEADER = (
+    "/-\nCopyright (c) 2026 IEANTN contributors. All rights reserved.\n"
+    "Released under Apache 2.0 license as described in the file LICENSE.\n"
+    "Authors: IEANTN contributors\n-/\n"
+)
+
 #: Toolchain minor releases behind current, past which a refresh is assumed to fall outside the
 #: Mathlib cache window and cost many times the per-node budget. A heuristic, not a measurement.
 CACHE_WINDOW_RELEASES = 2
@@ -1908,6 +1918,281 @@ def diff(base: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# spinoff: emit one conclusion as a standalone Palomar submission
+# ---------------------------------------------------------------------------
+
+#: The namespace the emitted Challenge declares its compared theorem in. Anything but the node's
+#: own, which the library already uses for the generated challenge.
+SPINOFF_NAMESPACE = "Spinoff"
+
+
+def unjustified_leaves(index: dict, key: str, seen: set[str] | None = None) -> list[str]:
+    """The conclusion keys `key` transitively rests on that Lean has not checked here.
+
+    The same walk `report` prints, returning keys rather than prose. These become the emitted
+    Challenge's hypotheses: a Palomar submission cannot assert what this network is content to
+    take on a citation's authority, so it must say what it is assuming.
+    """
+    seen = set() if seen is None else seen
+    if key in seen or key not in index:
+        return []
+    seen.add(key)
+    _, conclusion = index[key]
+    justification = designated_of(conclusion) or {}
+    found: list[str] = []
+    if justification.get("kind") == "bridged":
+        for source in bridge_sources(justification):
+            found += unjustified_leaves(index, source, seen)
+    elif justification.get("kind") not in VERIFIED_KINDS:
+        found.append(key)
+    for dependency in conclusion.get("imports") or []:
+        found += unjustified_leaves(
+            index, f"{dependency.get('node')}.{dependency.get('conclusion')}", seen)
+    return found
+
+
+def opens_of(path: pathlib.Path) -> list[str]:
+    """The module-level `open` directives of a Lean file.
+
+    `open ... in` is excluded: it scopes to the single declaration that follows, so it is
+    already inside whatever text gets sliced.
+    """
+    code = strip_lean_comments(path.read_text(encoding="utf-8"))
+    return [line.rstrip() for line in code.splitlines()
+            if re.match(r"^open\s", line) and not line.rstrip().endswith(" in")]
+
+
+def module_path(module: str) -> pathlib.Path:
+    return ROOT / pathlib.PurePosixPath(module.replace(".", "/") + ".lean")
+
+
+def slice_source(text: str, decl: dict, prefix: str) -> tuple[str, str]:
+    """The source of one declaration, and the namespace it must be re-emitted inside.
+
+    Lean reports 1-based lines and 0-based columns. The `range` spans the whole declaration
+    including its docstring; the `selectionRange` spans just the declared name as written, and the
+    namespace is the full name with that suffix removed -- see Tools/Spinoff.lean.
+    """
+    lines = text.splitlines()
+
+    def cut(sl: int, sc: int, el: int, ec: int) -> str:
+        if sl == el:
+            return lines[sl - 1][sc:ec]
+        out = [lines[sl - 1][sc:]] + lines[sl:el - 1] + [lines[el - 1][:ec]]
+        return "\n".join(out)
+
+    body = cut(decl["startLine"], decl["startCol"], decl["endLine"], decl["endCol"])
+    written = cut(decl["nameStartLine"], decl["nameStartCol"],
+                  decl["nameEndLine"], decl["nameEndCol"])
+    full = decl["name"]
+    if not full.endswith(written):
+        raise SystemExit(
+            f"error: {full} is written as `{written}`, which is not a suffix of its full name. "
+            "The namespace cannot be recovered; refusing to guess.")
+    namespace = full[: len(full) - len(written)].rstrip(".")
+    del prefix
+    return body, namespace
+
+
+def spinoff(key: str, out: str, compile_check: bool) -> bool:
+    """Emit one conclusion as a self-contained Palomar submission.
+
+    See docs/ARCHITECTURE.md section 7. The Challenge inlines every IEANTN definition the statement
+    needs, so its import closure is Mathlib-only as Palomar requires; the Solution reaches the real
+    proof by depending on this repository.
+    """
+    nodes = load_nodes()
+    index = index_conclusions(nodes)
+    if key not in index:
+        print(f"error: unknown conclusion `{key}`; try `python scripts/ieantn.py report`")
+        return False
+    node_id, conclusion = index[key]
+    cid = conclusion.get("id")
+
+    designated = designated_of(conclusion) or {}
+    if designated.get("kind") not in VERIFIED_KINDS:
+        print(f"error: `{key}` designates `{designated.get('kind')}`, so there is no Lean proof to "
+              "submit. Palomar records a verified formalization, not a claim.")
+        return False
+
+    # Multi-level composition -- chaining several nodes' solutions into one -- is the part of
+    # ARCHITECTURE section 7 that is not built. Refuse rather than emit something that looks
+    # complete and is not.
+    leaves = sorted(set(unjustified_leaves(index, key)))
+    direct = {f"{d.get('node')}.{d.get('conclusion')}" for d in (conclusion.get("imports") or [])}
+    deeper = [leaf for leaf in leaves if leaf not in direct]
+    if deeper:
+        print(f"error: `{key}` rests on {', '.join(deeper)}, which are not among its direct "
+              "imports. Emitting that needs the per-node solutions composed along the way, which "
+              "is not implemented; only a one-level spin-off is supported today.")
+        return False
+
+    solution_dir = SOLUTIONS / node_id
+    if not (solution_dir / "Solution.lean").is_file():
+        print(f"error: no solution at {rel(solution_dir)}")
+        return False
+
+    wanted = [conclusion.get("declaration")] + [index[leaf][1].get("declaration") for leaf in leaves]
+    finished = subprocess.run(
+        ["lake", "exe", "ieantn_spinoff", *[w for w in wanted if w]],
+        cwd=ROOT, capture_output=True, text=True, encoding="utf-8")
+    if finished.returncode != 0:
+        sys.exit("error: could not locate the definitions to inline. Is `ieantn_spinoff` built?\n"
+                 "       try `lake build ieantn_spinoff`\n" + (finished.stderr or "").strip())
+    payload = next(
+        (line for line in reversed(finished.stdout.splitlines()) if line.startswith("{")), None)
+    if payload is None:
+        sys.exit("error: ieantn_spinoff produced no output")
+    declarations = json.loads(payload)["declarations"]
+
+    target = ROOT / out
+    target.mkdir(parents=True, exist_ok=True)
+
+    # --- Challenge: the inlined definitions, then the compared theorem -----------------------
+    sources = {d["module"]: module_path(d["module"]).read_text(encoding="utf-8")
+               for d in declarations}
+    mathlib_imports = sorted({
+        module for path in {module_path(m) for m in sources}
+        for module in imports_of(path) if under(module, "Mathlib")})
+
+    blocks: list[str] = []
+    current: tuple[str, str] | None = None
+    for decl in declarations:
+        body, namespace = slice_source(sources[decl["module"]], decl, decl["name"])
+        here = (decl["module"], namespace)
+        if here != current:
+            if current is not None:
+                blocks.append(f"end {current[1]}\n\n")
+            blocks.append(f"namespace {namespace}\n" if namespace else "")
+            # A definition body uses whatever its own file had `open`. `log x` and
+            # `sigma 1 m` below mean `Real.log` and `ArithmeticFunction.sigma` only because
+            # their source files open those namespaces; without this the inlined text does
+            # not resolve. Scoped inside the namespace rather than unioned at the top, so two
+            # modules cannot make each other's names ambiguous.
+            for directive in opens_of(module_path(decl["module"])):
+                blocks.append(directive + "\n")
+            current = here
+        blocks.append("\n" + body + "\n")
+    if current:
+        blocks.append(f"end {current[1]}\n")
+
+    binders = "".join(
+        f"\n    ({hypothesis_name({'node': leaf.rsplit('.', 1)[0], 'conclusion': leaf.rsplit('.', 1)[1]})} : "
+        f"{index[leaf][1].get('declaration')})"
+        for leaf in leaves)
+    statement = conclusion.get("declaration")
+    theorem = (f"theorem {SPINOFF_NAMESPACE}.main{binders} :\n    {statement} := by\n  sorry\n"
+               if binders else
+               f"theorem {SPINOFF_NAMESPACE}.main : {statement} := by\n  sorry\n")
+
+    rests_on = ("\n".join(f"* `{leaf}`, taken as a hypothesis." for leaf in leaves)
+                or "* nothing. Every definition it needs is inlined below and the statement is "
+                   "unconditional.")
+    challenge = (
+        LICENCE_HEADER
+        + "".join(f"import {module}\n" for module in mathlib_imports)
+        + f"""
+/-!
+# Challenge: `{key}`
+
+Spun off from the IEANTN network ({REPOSITORY_URL}), node `{node_id}`.
+**Generated file** -- regenerated by `python scripts/ieantn.py spinoff {key}`.
+
+The definitions below are inlined from that repository's `IEANTN/Vocabulary/` and the node's
+`Conclusions.lean`, verbatim and with their docstrings, so that this file's import closure is Lean
+core and Mathlib only. They keep their original names: the Solution obtains the identical constants
+by depending on the repository, and Comparator compares the two exported environments, so a
+divergence between an inlined copy and the real definition is exactly what it would catch.
+
+What the statement rests on:
+
+{rests_on}
+-/
+
+"""
+        + "".join(blocks)
+        + "\n"
+        + theorem)
+    (target / "Challenge.lean").write_text(challenge, encoding="utf-8", newline="\n")
+
+    # --- Solution --------------------------------------------------------------------------
+    vendored = sorted(path.stem for path in solution_dir.glob("*.lean"))
+    arguments = " ".join(
+        hypothesis_name({"node": leaf.rsplit(".", 1)[0], "conclusion": leaf.rsplit(".", 1)[1]})
+        for leaf in leaves)
+    solution = (
+        LICENCE_HEADER
+        + "".join(f"import {stem}\n" for stem in vendored)
+        + f"""
+/-!
+# Solution: `{key}`
+
+**Generated file** -- regenerated by `python scripts/ieantn.py spinoff {key}`.
+
+The proof is `{node_id}.challenge_{cid}`, vendored from the node's solution project unchanged. This
+file only renames it into the namespace the Challenge uses, which exists so that the compared name
+does not collide with the sorried challenge the source repository generates for its own build.
+-/
+
+theorem {SPINOFF_NAMESPACE}.main{binders} :
+    {statement} :=
+  {node_id}.challenge_{cid}{(' ' + arguments) if arguments else ''}
+""")
+    (target / "Solution.lean").write_text(solution, encoding="utf-8", newline="\n")
+
+    for path in solution_dir.glob("*.lean"):
+        if path.name != "Solution.lean":
+            (target / path.name).write_text(path.read_text(encoding="utf-8"),
+                                            encoding="utf-8", newline="\n")
+    vendor = solution_dir / "Solution.lean"
+    (target / "NodeSolution.lean").write_text(vendor.read_text(encoding="utf-8"),
+                                              encoding="utf-8", newline="\n")
+
+    (target / "comparator.json").write_text(
+        json.dumps({
+            "challenge_module": "Challenge",
+            "solution_module": "Solution",
+            "theorem_names": [f"{SPINOFF_NAMESPACE}.main"],
+            "permitted_axioms": ["propext", "Quot.sound", "Classical.choice"],
+        }, indent=2) + "\n", encoding="utf-8", newline="\n")
+
+    (target / "lean-toolchain").write_text(
+        (ROOT / "lean-toolchain").read_text(encoding="utf-8"), encoding="utf-8", newline="\n")
+    for name in ("LICENSE", "LICENCE"):
+        if (ROOT / name).is_file():
+            (target / name).write_text((ROOT / name).read_text(encoding="utf-8"),
+                                       encoding="utf-8", newline="\n")
+            break
+    else:
+        print("warning: no LICENSE at the repository root; Palomar requires exactly one")
+
+    inside = target.is_relative_to(ROOT)
+    print(f"wrote {rel(target) if inside else target}")
+    print("\nstill to do by hand, and deliberately not guessed at:")
+    print("  1. lakefile.toml -- this needs a pinned git dependency on the source repository")
+    print("  2. lake-manifest.json -- commit the one Lake resolves")
+    print("  3. formalization.yaml -- start from the node's, drop `node` and `conclusions`, and")
+    print("     add a limitation naming each hypothesis above")
+    print("  4. validate: see the `palomar-submission` skill for running Palomar's own validator")
+    if compile_check:
+        # The Challenge imports Mathlib and nothing else, so this repository's own
+        # environment can elaborate it as-is -- the assembled Lake project is not needed.
+        # This is the check that the inlining is faithful rather than merely plausible.
+        print("\nchecking the assembled Challenge elaborates...")
+        built = subprocess.run(
+            ["lake", "env", "lean", str(target / "Challenge.lean")],
+            cwd=ROOT, capture_output=True, text=True, encoding="utf-8")
+        noise = [line for line in (built.stdout + built.stderr).splitlines()
+                 if "declaration uses" not in line and line.strip()]
+        if built.returncode != 0 or noise:
+            print("FAIL: the inlined Challenge does not compile cleanly")
+            print("\n".join(noise[:20]))
+            return False
+        print("ok  the Challenge elaborates, with only the deliberate `sorry`")
+    return True
+
+
+# ---------------------------------------------------------------------------
 # new-version / deprecate
 # ---------------------------------------------------------------------------
 
@@ -2140,6 +2425,10 @@ def main() -> int:
     fresh.add_argument(
         "--kind", default="paper", choices=["paper", "pipeline", "folklore", "computation"]
     )
+    spun = sub.add_parser("spinoff")
+    spun.add_argument("conclusion", help="e.g. Lcm.v2.lcmUpto_not_highlyAbundant_of_primeGap")
+    spun.add_argument("--out", required=True, help="directory to write the submission into")
+    spun.add_argument("--compile", action="store_true", help="build the assembled project")
     version = sub.add_parser("new-version")
     version.add_argument("family", help="e.g. Lcm")
     changed = sub.add_parser("diff")
@@ -2184,6 +2473,8 @@ def main() -> int:
         return 0 if housekeeping() else 1
     if args.command == "new-node":
         return 0 if new_node(args.family, args.kind) else 1
+    if args.command == "spinoff":
+        return 0 if spinoff(args.conclusion, args.out, args.compile) else 1
     if args.command == "new-version":
         return 0 if new_version(args.family) else 1
     if args.command == "deprecate":

--- a/tests/test_ieantn.py
+++ b/tests/test_ieantn.py
@@ -382,6 +382,33 @@ class TestGraphChecks(FixtureRepo):
         self.assertFalse(ieantn.check_graph())
 
 
+class TestSolutionDrift(FixtureRepo):
+    """A receipt attests to the solution as it was, not as it is.
+
+    `assess` catches a *statement* moving out from under a receipt. Nothing caught the *solution*
+    moving, and after an edit the receipt has accepted something other than what is on disk. What
+    makes it detectable is `repository.commit`, which schema 2 records.
+    """
+
+    def test_a_schema_one_receipt_is_skipped(self) -> None:
+        """Receipts written before the commit was recorded cannot be checked, and are not guessed
+        at -- reporting drift that may not exist would train people to ignore the note."""
+        self.assertIsNone(ieantn.solution_drift(
+            {"schema": 1, "solution": {"project": "Solutions/A.v1"}}))
+
+    def test_a_receipt_with_no_solution_project_is_skipped(self) -> None:
+        self.assertIsNone(ieantn.solution_drift(
+            {"schema": 2, "repository": {"commit": "a" * 40}}))
+
+    def test_an_unknown_commit_is_skipped(self) -> None:
+        """A shallow clone, or a branch since deleted, leaves nothing to diff against."""
+        self.assertIsNone(ieantn.solution_drift({
+            "schema": 2,
+            "repository": {"commit": "0" * 40},
+            "solution": {"project": "Solutions/A.v1"},
+        }))
+
+
 class TestSpinoffSlicing(unittest.TestCase):
     """Turning a declaration's source range back into text that still resolves.
 

--- a/tests/test_ieantn.py
+++ b/tests/test_ieantn.py
@@ -382,6 +382,107 @@ class TestGraphChecks(FixtureRepo):
         self.assertFalse(ieantn.check_graph())
 
 
+class TestSpinoffSlicing(unittest.TestCase):
+    """Turning a declaration's source range back into text that still resolves.
+
+    The generator inlines IEANTN's own definitions into a Palomar Challenge, because a Challenge
+    may not import the submitter's library. Lean supplies the ranges; these test what is done with
+    them.
+    """
+
+    SOURCE = (
+        "import Mathlib.Foo\n"          # 1
+        "\n"                            # 2
+        "namespace IEANTN\n"            # 3
+        "open Real\n"                   # 4
+        "\n"                            # 5
+        "/-- Doc. -/\n"                 # 6
+        "def Wrapper.thing (x : ℝ) : Prop :=\n"   # 7
+        "  log x > 0\n"                 # 8
+        "\n"                            # 9
+        "end IEANTN\n"                  # 10
+    )
+
+    def _decl(self, **over):
+        base = dict(name="IEANTN.Wrapper.thing", module="IEANTN.Vocabulary.X", kind="def",
+                    startLine=6, startCol=0, endLine=8, endCol=12,
+                    nameStartLine=7, nameStartCol=4, nameEndLine=7, nameEndCol=17)
+        base.update(over)
+        return base
+
+    def test_the_slice_carries_the_docstring(self) -> None:
+        """The range Lean reports starts at the docstring, which is most of why this is worth
+        doing: the docstring is the informal statement a Palomar reviewer reads."""
+        body, _ = ieantn.slice_source(self.SOURCE, self._decl(), "")
+        self.assertTrue(body.startswith("/-- Doc. -/"))
+        self.assertIn("log x > 0", body)
+
+    def test_the_namespace_comes_from_the_written_name(self) -> None:
+        """`IEANTN.Wrapper.thing` written as `Wrapper.thing` means the namespace is `IEANTN`.
+
+        Recovering it any other way means parsing Lean; the selection range makes it arithmetic.
+        """
+        _, namespace = ieantn.slice_source(self.SOURCE, self._decl(), "")
+        self.assertEqual(namespace, "IEANTN")
+
+    def test_a_name_that_is_not_a_suffix_is_refused(self) -> None:
+        """If the written name is not a suffix of the full name the namespace cannot be recovered.
+
+        Guessing would produce a Challenge that compiles and states something else, which is the
+        one outcome worth refusing outright.
+        """
+        with self.assertRaises(SystemExit):
+            ieantn.slice_source(self.SOURCE, self._decl(name="Other.entirely"), "")
+
+
+class TestSpinoffOpens(unittest.TestCase):
+    def test_module_level_opens_are_collected(self) -> None:
+        """`log x` in an inlined body means `Real.log` only because its file opened `Real`."""
+        with tempfile.TemporaryDirectory() as tmp:
+            f = pathlib.Path(tmp) / "X.lean"
+            f.write_text(
+                "import Mathlib\nopen Real ArithmeticFunction\nopen scoped Nat\n"
+                "open Finset in\ndef a := 1\n-- open Commented\n",
+                encoding="utf-8")
+            self.assertEqual(
+                ieantn.opens_of(f), ["open Real ArithmeticFunction", "open scoped Nat"])
+
+    def test_open_in_is_excluded_and_comments_ignored(self) -> None:
+        """`open X in` scopes to the next declaration, so it is already inside the sliced text."""
+        with tempfile.TemporaryDirectory() as tmp:
+            f = pathlib.Path(tmp) / "X.lean"
+            f.write_text("open Finset in\ndef a := 1\n-- open Nope\n", encoding="utf-8")
+            self.assertEqual(ieantn.opens_of(f), [])
+
+
+class TestUnjustifiedLeaves(FixtureRepo):
+    """What a spun-off Challenge must take as hypotheses.
+
+    Palomar records a verified formalization; anything this network is content to accept on a
+    citation's authority has to appear in the statement as an assumption rather than be silently
+    absorbed.
+    """
+
+    def test_a_verified_conclusion_rests_on_nothing(self) -> None:
+        self.write_node("A.v1", LITERATURE.replace("kind: literature", "kind: lean-comparator"))
+        self._receipt_for("A.v1.main")
+        index = ieantn.index_conclusions(ieantn.load_nodes())
+        self.assertEqual(ieantn.unjustified_leaves(index, "A.v1.main"), [])
+
+    def test_an_imported_citation_becomes_a_leaf(self) -> None:
+        self.write_node("Upstream.v1", LITERATURE)
+        self.write_node(
+            "A.v1", importing("Upstream.v1").replace("kind: none-yet", "kind: lean-comparator"))
+        self._receipt_for("A.v1.main")
+        index = ieantn.index_conclusions(ieantn.load_nodes())
+        self.assertEqual(ieantn.unjustified_leaves(index, "A.v1.main"), ["Upstream.v1.main"])
+
+    def _receipt_for(self, key: str) -> None:
+        (self.root / "receipts").mkdir(exist_ok=True)
+        (self.root / "receipts" / f"{key}.json").write_text(
+            json.dumps({"conclusion": key}), encoding="utf-8")
+
+
 class TestImportParsing(FixtureRepo):
     """What counts as an import, and what does not.
 


### PR DESCRIPTION
`python scripts/ieantn.py spinoff <conclusion> --out <dir> --compile` emits a conclusion as a
self-contained Palomar submission — the last unbuilt piece of [ARCHITECTURE §7](docs/ARCHITECTURE.md),
which the docs have asserted throughout without it ever having been done once.

## How it inlines

A Palomar Challenge's import closure must be Lean core and Mathlib only, so the emitted Challenge
cannot `import IEANTN.Vocabulary`. `Tools/Spinoff.lean` walks the conclusion's IEANTN-local
constants in dependency order and reports each one's **source range**; the generator slices those
out of the files they were written in — docstrings and all — and re-emits each inside its own
`namespace`, with that module's `open` directives, so every short name resolves as it did.

Transitive unjustified leaves become **hypotheses**. Palomar records a verified formalization, so
anything this network is content to accept on a citation's authority has to appear in the statement
rather than be quietly absorbed. Spinning off `Lcm.v1` produces:

```lean
theorem Spinoff.main
    (dusart2018_v1_proposition_5_4 : Dusart2018.v1.proposition_5_4) :
    Lcm.v1.lcmUpto_not_highlyAbundant := by
  sorry
```

with Dusart's definition and its docstring inlined above it. Spinning off `Lcm.v2` produces an
unconditional statement, since it rests on nothing.

The inlined definitions keep their **original names**. The Solution gets the identical constants by
depending on this repository, and Comparator compares the two exported environments — so a
divergence between an inlined copy and the real definition is precisely what it is built to catch,
not a gap it would miss.

`--compile` elaborates the assembled Challenge against Mathlib. That is the check that the inlining
is faithful rather than merely plausible, and both nodes pass it.

## Two deliberate refusals

- **Multi-level composition** — chaining several nodes' solutions into one — is the harder half of
  §7 and is not implemented. The command *refuses* a conclusion whose leaves are not among its
  direct imports, rather than emitting something that looks complete.
- It stops before `lakefile.toml`, `lake-manifest.json` and `formalization.yaml`, printing what
  remains. Those need a pinned dependency on a *published* commit and a limitations section naming
  the hypotheses; a generator should not invent either.

## The route not taken

Pretty-printing the elaborated definitions is the obvious way to inline them, and it produces
correct, **unreadable** output — `LE.le 5 c` for `5 ≤ c`, `Exists fun p ↦ …` for `∃ p, …` — because
a standalone executable has no notation delaborators registered, and neither `pp.notation` nor
`enableInitializersExecution` brings them back. Correct-but-unreadable is the dangerous failure
here: nothing downstream complains, and Comparator would accept such a Challenge happily. The
Challenge is the one file a mathematical reader audits. Recorded in the roadmap so it isn't retried.

## This repository had no LICENSE

Every Lean file says "as described in the file LICENSE" and there was none. The generator found it
— it copies the licence into the submission and warned that there was nothing to copy. Apache-2.0
now, matching the headers and every node's `project.license`. The `palomar-submission` skill flags
this exact trap; it had already caught `teorth/sendov`.

## Also

- `Lcm.v1`'s bridge note said "Lcm.v2 is itself unjustified, so this ground currently transports
  nothing" — false since yesterday's verification. Now records that the bridge is live, and why it
  still should not be designated.
- `docs/ROADMAP.md` said 73 tests and that Comparator accepts only `Solutions/Lcm.v1`.

## Checks

104 tests (up from 97), `ieantn.py check` all six green, pyright clean, `lake build` clean.
Generated and compiled for both `Lcm.v1` and `Lcm.v2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)