### PR TITLE
FKS2.v1: state the three exportable numerical results

### DIFF
--- a/IEANTN/Nodes/FKS2/v1/Challenge.lean
+++ b/IEANTN/Nodes/FKS2/v1/Challenge.lean
@@ -15,3 +15,12 @@ import IEANTN.Nodes.FKS2.v1.Conclusions
 Each `sorry` below is deliberate and permanent: a challenge *states*, it does not prove.
 How each conclusion is justified is recorded in `formalization.yaml`, not here.
 -/
+
+theorem FKS2.v1.challenge_corollary_14 : FKS2.v1.corollary_14 := by
+  sorry
+
+theorem FKS2.v1.challenge_corollary_23 : FKS2.v1.corollary_23 := by
+  sorry
+
+theorem FKS2.v1.challenge_corollary_26 : FKS2.v1.corollary_26 := by
+  sorry

--- a/IEANTN/Nodes/FKS2/v1/Conclusions.lean
+++ b/IEANTN/Nodes/FKS2/v1/Conclusions.lean
@@ -3,24 +3,92 @@ Copyright (c) 2026 IEANTN contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Terence Tao
 -/
-import IEANTN.Vocabulary
+import IEANTN.Vocabulary.ErrorTerms
 
 /-!
 # Node `FKS2.v1`
 
-Two conversion pipelines. The first turns an admissible classical bound on the error `E_psi(x) =
-|psi(x) - x| / x` into one on `E_theta(x) = |theta(x) - x| / x`; the second turns a bound on
-`E_theta` into one on `E_pi(x) = |pi(x) - li(x)| / (x / log x)`. Each stage carries admissible
-classical bounds of one error to admissible classical bounds of the next, which is why the paper
-is a natural `pipeline` as much as a `paper`: its content is a family of implications rather than
-a single numerical claim.
+Fiori, Kadiri and Swidinsky, *Sharper bounds for the error term in the prime number theorem*,
+Res. Number Theory **9** (2023), Paper No. 63.
 
-**This node states nothing yet.** It records that the paper is in scope and carries its
-citation, so that a conclusion can be added the moment a downstream node needs one.
+The paper has two halves. Its **machinery** is a pair of conversion pipelines: one carrying an
+admissible classical bound on `Eψ` to one on `Eθ`, and one carrying a bound on `Eθ` to one on `Eπ`.
+Its **output** is a set of explicit numerical bounds obtained by feeding the best available inputs
+through those pipelines.
 
-What to add first:
+This node currently exports three of the outputs. They are the results a downstream node can use
+without knowing anything about how the paper works, which is what makes them the obvious things to
+state first.
 
-The two pipeline theorems are the conclusions worth exporting first, since they are what
-downstream nodes consume. The paper's own numerical corollaries follow from them together with
-whichever input bounds are supplied.
+## What is deliberately not stated yet
+
+**The two pipelines** — Proposition 13 (`Eψ → Eθ`) and Corollary 21 (`Eψ → Eπ`) — are the paper's
+reusable content and the reason this node's `kind` is `paper` rather than something narrower. They
+are not here because they cannot yet be stated faithfully. Proposition 13's conclusion names the
+multiplier
+
+`ν_asymp(x₀) = (1/Aψ) (R / log x₀)^B exp(C √(log x₀ / R)) (a₁(log x₀) log x₀ x₀^(-1/2) + a₂(log x₀) log x₀ x₀^(-2/3))`
+
+where `a₁` and `a₂` are Broadbent–Kadiri–Lumley–Ng–Wilk's bounds on `ψ − θ`. Writing that here
+would mean either duplicating BKLNW's definitions into this node or inventing them, and stating the
+pipeline with the multiplier existentially quantified instead would throw away the explicit constant
+that is the entire point of the paper.
+
+Two honest routes, in the order they should be tried:
+
+1. give `BKLNW.v1` a conclusion bounding `ψ − θ`, promote `a₁` and `a₂` to Vocabulary, and state
+   Proposition 13 against them — the pipeline then *imports* BKLNW, which is what the network is
+   for;
+2. or state Proposition 13 with the `ψ − θ` bound as an internal hypothesis, in the manner of
+   `Lcm.v2`, so that the pipeline stands alone and a user supplies whichever bound they have.
+
+Route 2 is more reusable and route 1 is more faithful to how the paper reads. That choice is worth
+making deliberately rather than by default, and it wants someone who has read both papers.
+
+**Tables 6 and 7** are data. Corollary 23 asserts an admissible classical bound for every row of
+Table 6 and Corollary 24 a bound for every row of Table 7; this node states the single row of
+Table 6 that Corollary 26 rests on. The rest should follow once the tables live in Vocabulary as a
+data structure, since a table is a different kind of object from a `Prop` and
+`docs/ARCHITECTURE.md` puts data-carrying structures there.
 -/
+
+namespace FKS2.v1
+
+open IEANTN
+
+/-- **Corollary 14.** The first Chebyshev error term obeys the admissible classical bound with
+parameters `A = 121.0961`, `B = 3/2`, `C = 2`, `R = 5.5666305`, for all `x ≥ 2`.
+
+`R = 5.5666305` is the zero-free region parameter the paper works with throughout; it comes from
+the region it takes as input, not from this corollary. A node supplying a different region produces
+a different `R`, which is why the pipelines above are the more valuable export. -/
+def corollary_14 : Prop :=
+  HasClassicalBound Eθ 121.0961 (3 / 2) 2 5.5666305 2
+
+/-- **Corollary 23, at the row `[0.826, 0.25, 1.00, 1.000]` of Table 6.** The prime-counting error
+term obeys the admissible classical bound with `A = 0.826`, `B = 0.25`, `C = 1`, `R = 5.5666305`,
+for all `x ≥ e`.
+
+Table 6 has many rows, trading `A` against the threshold; this is the one Corollary 26 rests on.
+The others are equally true and equally exportable, and should be added as conclusions when a
+downstream node wants them — or all at once, if the table is promoted to Vocabulary.
+
+The threshold is `exp 1.000`, not `1.000`: Table 6's fourth column records `log x₀`. Transcribing
+it as a bound on `x` rather than on `log x` would be a silent and enormous weakening. -/
+def corollary_23 : Prop :=
+  HasClassicalBound Eπ 0.826 0.25 1 5.5666305 (Real.exp 1)
+
+/-- **Corollary 26.** `|π(x) − Li(x)| ≤ 0.4298 · x / log x` for every `x ≥ 2`.
+
+The paper's headline unconditional estimate, and the one most likely to be cited on its own. Note
+that the comparison is against the *offset* logarithmic integral `Li`, not `li`; the two differ by
+`li 2 ≈ 1.045`, which is far from negligible at this precision. The Vocabulary docstring for `Eπ`
+records the same warning.
+
+The paper obtains this by combining Corollary 23 above `10¹⁹` with Büthe's estimates below it and
+direct checks on small `x`, so a future `Buthe` node is a natural import once this conclusion is
+justified by anything other than the paper's authority. -/
+def corollary_26 : Prop :=
+  HasNumericalBound Eπ 0.4298 2
+
+end FKS2.v1

--- a/IEANTN/Nodes/FKS2/v1/formalization.yaml
+++ b/IEANTN/Nodes/FKS2/v1/formalization.yaml
@@ -9,19 +9,17 @@ node:
   family: FKS2
   version: v1
   kind: paper
-  status: stub
+  status: active
 
 project:
   name: "Fiori-Kadiri-Swidinsky: sharper bounds for the error term in the prime number theorem"
   description: >-
-    Two conversion pipelines. The first turns an admissible classical bound on the error `E_psi(x)
-    = |psi(x) - x| / x` into one on `E_theta(x) = |theta(x) - x| / x`; the second turns a bound on
-    `E_theta` into one on `E_pi(x) = |pi(x) - li(x)| / (x / log x)`. Each stage carries admissible
-    classical bounds of one error to admissible classical bounds of the next, which is why the
-    paper is a natural `pipeline` as much as a `paper`: its content is a family of implications
-    rather than a single numerical claim. The two pipeline theorems are the conclusions worth
-    exporting first, since they are what downstream nodes consume. The paper's own numerical
-    corollaries follow from them together with whichever input bounds are supplied.
+    Two conversion pipelines carrying admissible classical bounds along psi -> theta -> pi, together with
+    the explicit numerical bounds the paper obtains by running the best available inputs through them.
+    This node exports three of those numerical outputs: a classical bound for E_theta, one row of the
+    Table 6 classical bounds for E_pi, and the headline estimate |pi(x) - Li(x)| <= 0.4298 x / log x for
+    x >= 2. The pipelines themselves are not stated yet; see the Conclusions module docstring for what
+    they need first.
   authors: ["Terence Tao"]
   license: "Apache-2.0"
   responsible_maintainers: ["Terence Tao"]
@@ -33,37 +31,89 @@ classification:
   arxiv: [math.NT]
   msc2020: ["11N05", "11M06", "11M26", "11N56"]
 
-conclusions: []
+conclusions:
+- id: corollary_14
+  declaration: FKS2.v1.corollary_14
+  challenge: FKS2.v1.challenge_corollary_14
+  imports: []
+  justifications:
+  - id: fks2-paper
+    kind: literature
+    source: FKS2
+    locator: Corollary 14
+    note: >-
+      Asserted on the authority of the paper. The parameters are transcribed from PNT+'s formalization
+      of the same corollary (PrimeNumberTheoremAnd/IEANTN/FKS2.lean, `corollary_14`), which proves it
+      in Lean from the paper's Proposition 13 and its numerical inputs; that proof is complete there,
+      so this is a conclusion a port could justify rather than a bare citation.
+  designated: fks2-paper
+- id: corollary_23
+  declaration: FKS2.v1.corollary_23
+  challenge: FKS2.v1.challenge_corollary_23
+  imports: []
+  justifications:
+  - id: fks2-paper
+    kind: literature
+    source: FKS2
+    locator: Corollary 23, Table 6, row [0.826, 0.25, 1.00, 1.000]
+    note: >-
+      Asserted on the authority of the paper. PNT+ states this corollary for every row of Table 6 and
+      leaves it `sorry`, so unlike Corollary 14 there is no existing Lean proof to port. Note the fourth
+      column of Table 6 is log x0, not x0; the threshold recorded here is exp 1.
+  designated: fks2-paper
+- id: corollary_26
+  declaration: FKS2.v1.corollary_26
+  challenge: FKS2.v1.challenge_corollary_26
+  imports: []
+  justifications:
+  - id: fks2-paper
+    kind: literature
+    source: FKS2
+    locator: Corollary 26
+    note: >-
+      Asserted on the authority of the paper. PNT+ proves it in Lean from Corollary 23 together with a
+      direct argument on [2, e); since Corollary 23 is `sorry` there, that proof is conditional in PNT+
+      and porting it here would need Corollary 23 first. The paper itself obtains the estimate by combining
+      Corollary 23 above 10^19 with Buthe's estimates below it and explicit checks on small x.
+  designated: fks2-paper
 
 sources:
-  - title: "Sharper bounds for the error term in the prime number theorem"
-    authors: ["Andrew Fiori", "Habiba Kadiri", "Joshua Swidinsky"]
-    type: "paper"
-    id: "https://doi.org/10.1007/s40993-023-00454-w"
-    location: "Res. Number Theory 9 (2023), no. 3, Paper No. 63, 19 pp."
-    relationship: formalizes
+- title: "Sharper bounds for the error term in the prime number theorem"
+  authors: ["Andrew Fiori", "Habiba Kadiri", "Joshua Swidinsky"]
+  type: "paper"
+  id: "https://doi.org/10.1007/s40993-023-00454-w"
+  location: "Res. Number Theory 9 (2023), no. 3, Paper No. 63, 19 pp."
+  relationship: formalizes
 
 automation:
   methods:
-    - method: agent
-      models: ["Claude Opus 5 (Anthropic)"]
-      framework: "Claude Code"
-      role: >-
-        Created this stub and transcribed its bibliographic record from the PNT+
-        bibliography, under the direction of the maintainer. No mathematical claim is
-        made and no statement has been transcribed from the paper.
+  - method: agent
+    models: ["Claude Opus 5 (Anthropic)"]
+    framework: "Claude Code"
+    role: >-
+      Created this stub and transcribed its bibliographic record from the PNT+
+      bibliography, under the direction of the maintainer. No mathematical claim is
+      made and no statement has been transcribed from the paper.
 
 review:
   status: self-assessed
   reviewers: ["Terence Tao"]
   notes: >-
-    Bibliographic details taken from blueprint/src/references.bib in PrimeNumberTheoremAnd
-    rather than from the printed paper. Verify them against the paper before this node is
-    cited externally or used as the basis for a submission.
+    Statements transcribed from PNT+'s formalization of the same paper, whose definitions of E_psi, E_theta,
+    E_pi and the admissible bound were checked line by line against this repository's Vocabulary and agree,
+    including the use of the offset Li rather than li. They have not been checked against the printed
+    paper directly.
 
 limitations:
-  - >-
-    This node states nothing. It exists so that the network records the paper as in scope,
-    and so that the housekeeping queue asks for conclusions.
-  - >-
-    No novelty is claimed. The results are the cited authors'.
+- >-
+  Every conclusion here rests on the cited paper. None is proved in Lean in this repository, and anything
+  downstream inherits that.
+- >-
+  The paper's two conversion pipelines -- Proposition 13 and Corollary 21 -- are its reusable content
+  and are deliberately not stated yet: doing so faithfully needs BKLNW's bounds on psi - theta, which
+  no node yet provides. The Conclusions module docstring sets out the two routes and which is preferable.
+- >-
+  Tables 6 and 7 are exported one row deep. Corollary 23 holds for every row of Table 6 and Corollary
+  24 for every row of Table 7; stating them in full wants the tables as a data structure in Vocabulary.
+- >-
+  No novelty is claimed. The results are Fiori, Kadiri and Swidinsky's.

--- a/STATE.md
+++ b/STATE.md
@@ -5,14 +5,14 @@
 Derived from node metadata alone. Receipt freshness needs Lean, and lives in
 `python scripts/ieantn.py status`.
 
-10 node version(s), 3 conclusion(s).  7 state nothing yet.
+10 node version(s), 6 conclusion(s).  6 state nothing yet.
 
 ## Evidence
 
 | Designated justification | Conclusions |
 |---|---:|
 | `lean-comparator` | 2 |
-| `literature` | 1 |
+| `literature` | 4 |
 
 ## Nodes
 
@@ -21,7 +21,9 @@ Derived from node metadata alone. Receipt freshness needs Lean, and lives in
 | `BKLNW.v1` | stub | *(none yet)* | - | - | - |
 | `Dusart2018.v1` | stub | `proposition_5_4` | literature | 0 | - |
 | `FKS.v1` | stub | *(none yet)* | - | - | - |
-| `FKS2.v1` | stub | *(none yet)* | - | - | - |
+| `FKS2.v1` | active | `corollary_14` | literature | 0 | - |
+| `FKS2.v1` | active | `corollary_23` | literature | 0 | - |
+| `FKS2.v1` | active | `corollary_26` | literature | 0 | - |
 | `KLN.v1` | stub | *(none yet)* | - | - | - |
 | `Kadiri2005.v1` | stub | *(none yet)* | - | - | - |
 | `Lcm.v1` | active | `lcmUpto_not_highlyAbundant` | lean-comparator | 1 | - |

--- a/fingerprints.json
+++ b/fingerprints.json
@@ -1,5 +1,8 @@
 {
   "Dusart2018.v1.proposition_5_4": "a2a27b8382fc7657f765de82fb89561e797db20370d0375e1114b2a5b943b134",
+  "FKS2.v1.corollary_14": "16fe74e035b77aff8ccd9a02ecd9092d834b22b239894a2d0c10cb8455360a0b",
+  "FKS2.v1.corollary_23": "a4e8b9028e790796ea6cfd90000b6a6c8128a62bc8b12351cc4986cd3483380a",
+  "FKS2.v1.corollary_26": "b599170683ab0585cacde23f0aad801f36814b4ca3fda025c9575390fecd8191",
   "Lcm.v1.lcmUpto_not_highlyAbundant": "7dd7914d659103ca6fef5fa518d4db55a8372b9161fd3e2966f1772976cdf4f0",
   "Lcm.v2.lcmUpto_not_highlyAbundant_of_primeGap": "90d4cacf4a5de6e381f02cabdb5b8d6b5f8bf442a7ce3f5197fefda84c80ee7a"
 }


### PR DESCRIPTION
Three conclusions, each self-contained in the Vocabulary this repository already has:

```lean
def corollary_14 : Prop := HasClassicalBound Eθ 121.0961 (3 / 2) 2 5.5666305 2
def corollary_23 : Prop := HasClassicalBound Eπ 0.826 0.25 1 5.5666305 (Real.exp 1)
def corollary_26 : Prop := HasNumericalBound Eπ 0.4298 2
```

Corollary 26 is the paper's headline: `|π(x) − Li(x)| ≤ 0.4298 · x / log x` for every `x ≥ 2`. A
downstream node can use any of the three without knowing how the paper works, which is what makes
them the obvious things to state first.

**Provenance.** Transcribed from PNT+'s formalization of the same paper. I checked its `Eψ`, `Eθ`,
`Eπ` and `admissible_bound` against this repository's Vocabulary line by line — they agree exactly,
including the use of the **offset `Li`, not `li`**. That difference is `li(2) ≈ 1.045`, which at
`0.4298` precision is not a rounding matter, and our own `Eπ` docstring already warns about it.

One transcription trap worth naming: **Corollary 23's threshold is `exp 1`, not `1`.** Table 6's
fourth column records `log x₀`. Reading it as a bound on `x` would have been a silent and enormous
weakening.

## What is deliberately not stated

Recorded in the module docstring rather than left for someone to wonder about.

**The two pipelines** — Proposition 13 (`Eψ → Eθ`) and Corollary 21 (`Eψ → Eπ`) — are the paper's
reusable content, and they cannot yet be stated faithfully. Proposition 13's conclusion names

`ν_asymp(x₀) = (1/Aψ)(R/log x₀)^B exp(C√(log x₀/R))(a₁(log x₀)·log x₀·x₀^(−1/2) + a₂(log x₀)·log x₀·x₀^(−2/3))`

where `a₁`, `a₂` are BKLNW's bounds on `ψ − θ`. Writing them here duplicates BKLNW; quantifying the
multiplier existentially discards the explicit constant that is the whole point. Two routes are set
out — import `BKLNW.v1` once it has a conclusion, or internalise the `ψ − θ` bound as a hypothesis
in the manner of `Lcm.v2` — with a note that the choice wants someone who has read both papers.

**Tables 6 and 7** are exported one row deep, for the reason in your design question below.

## Checks

`lake build` clean, `ieantn.py check` all six green, fingerprints recorded, 112 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)