### PR TITLE
Add Tables.lean, and fix new-version dropping node files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,8 @@ Nodes import each other's *statements*, never each other's *proofs*.
 | Layer | May import |
 |---|---|
 | `IEANTN/Vocabulary/` | Mathlib only. **Definitions only — no theorems, no `sorry`.** |
-| `IEANTN/Nodes/<Family>/<version>/Conclusions.lean` | Mathlib, Vocabulary, other nodes' `Conclusions.lean` |
+| `IEANTN/Nodes/<Family>/<version>/Conclusions.lean` | Mathlib, Vocabulary, other nodes' `Conclusions.lean`, any node's `Tables.lean` |
+| `IEANTN/Nodes/<Family>/<version>/Tables.lean` | optional; Mathlib, Vocabulary, other `Tables.lean`. **Data only — no theorems, no `sorry`.** |
 | `IEANTN/Nodes/<Family>/<version>/Challenge.lean` | its own and imported `Conclusions.lean` — **generated, do not hand-edit** |
 | `IEANTN/Bridges/<Family>/` | Mathlib, Vocabulary, `Conclusions.lean`, other bridges. **No `sorry`.** In the core build, so it is checked on every push. |
 | `Solutions/<Family>.<version>/` | anything. Separate Lake project; takes the core as a path dependency, must not import the node's `Challenge`. **Not in the core build.** |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,7 +35,8 @@ Three consequences follow, and they are the whole design:
 | Layer | Hand-written? | In the core build? | May import | Purpose |
 |---|---|---|---|---|
 | **Vocabulary** | yes | yes | Mathlib only | The shared language. Definitions only. |
-| **Conclusions** | yes | yes | Mathlib, Vocabulary, other Conclusions | Each node's claims, as named `Prop`s. |
+| **Conclusions** | yes | yes | Mathlib, Vocabulary, other Conclusions, any `Tables` | Each node's claims, as named `Prop`s. |
+| **Tables** | yes | yes | Mathlib, Vocabulary, other Tables | Optional. A paper's bulk data, so that Conclusions stays short. No theorems. |
 | **Challenge** | **generated** | yes | its own and imported Conclusions | The conditional theorems, sorried. |
 | **Solution** | generated / AI | **no** | anything at all | The proof. Verified once, then frozen. |
 

--- a/docs/NODES.md
+++ b/docs/NODES.md
@@ -29,6 +29,7 @@ IEANTN/Nodes/<Family>/<version>/
   formalization.yaml     metadata: imports, justification, sources, receipts
   README.md              optional prose
   Examples.lean          optional — consequences, to show what the node buys
+  Tables.lean            optional — the paper's bulk data, and nothing else
 Solutions/<Family>.<version>/    optional; separate Lake project, toolchain pinned equal
 IEANTN/Bridges/<Family>/         short proofs that one version implies another
 ```
@@ -182,6 +183,36 @@ Notes:
 - **Never claim novelty without a documented search.** "Unknown" is acceptable and safe; an
   unsupported novelty claim is a finding under Palomar review and a liability here too.
 - **Check citations.** Authors, title, identifier, and which name is a given name.
+
+## `Tables.lean`, for a paper that carries data
+
+Some explicit results are stated against a paper's numeric tables — rows of constants, parameter
+sets, thresholds. Those go in an optional `Tables.lean` beside the conclusions, **not inside them**.
+
+The reason is the one thing `Conclusions.lean` is for: it is the file a human audits, and its
+shortness is a feature. A reviewer checking three claims should not have to scroll past two hundred
+rows of data to reach them. Anything that would make them scroll belongs next door. A definition or
+two the conclusions need — `Lcm.v2`'s `HighlyAbundant`, say — is not data in this sense and stays
+where it is; the test is bulk, not kind.
+
+**Data only.** A `Tables.lean` may not declare a `theorem` or a `lemma`, and CI enforces it:
+
+- a *statement* about a table is a **conclusion**, where it becomes a claim of record with a
+  fingerprint and a justification;
+- a *proof* about one — the numerical verification that a table's rows satisfy what the paper says
+  they do — belongs in a **solution**, unless it is somehow needed in order to state an exportable
+  result at all. That should be rare, and is worth resisting when it is not.
+
+**Any node's conclusions may import any node's tables**, not only its own. A table is data, and the
+node that computed it is often not the node that states a claim about it — FKS2's conversion
+pipelines are stated in terms of quantities BKLNW tabulates. Forcing a copy would create a second
+source of truth, which is the thing this repository exists to avoid.
+
+**Keep the import list very short.** A table file may import only Mathlib, Vocabulary and other
+table files; CI enforces that much, which rules out the case that matters — a table that needs a
+*conclusion* in order to be stated is not data. Beyond that it is guidance rather than a rule: a
+table wanting a long list of imports is usually a computation wearing a table's clothes, and
+probably wants to be its own node.
 
 ## Step 3: generate `Challenge.lean`
 

--- a/scripts/ieantn.py
+++ b/scripts/ieantn.py
@@ -476,12 +476,18 @@ def check_closure() -> bool:
                     under(module, "Mathlib")
                     or under(module, "IEANTN.Vocabulary")
                     or (under(module, "IEANTN.Nodes") and module.endswith(".Conclusions"))
+                    # Any node's `Tables`, not only this node's. A table is data, and the node that
+                    # computed it is not always the node that states a claim about it -- FKS2's
+                    # pipelines are stated in terms of quantities BKLNW tabulates. Restricting
+                    # tables to their own node would force a copy, and a copied table is a second
+                    # source of truth.
+                    or (under(module, "IEANTN.Nodes") and module.endswith(".Tables"))
                 )
                 if not ok:
                     problems.add(
                         rel(conclusions),
-                        "a Conclusions file may import only Mathlib, Vocabulary and other "
-                        f"Conclusions; found `{module}`",
+                        "a Conclusions file may import only Mathlib, Vocabulary, other "
+                        f"Conclusions and any node's Tables; found `{module}`",
                     )
         # A node may carry `Examples.lean`: consequences drawn from its conclusions, to show what
         # the node actually buys. They make no claims of record, so they are not fingerprinted --
@@ -548,6 +554,42 @@ def check_closure() -> bool:
             )
 
     for directory in node_dirs():
+        # `Tables.lean` is the optional home for a paper's bulk data -- the numeric tables and
+        # parameter sets that some explicit results are stated against. It exists so that
+        # `Conclusions.lean` stays the short file a human audits: a reviewer checking three claims
+        # should not have to scroll past two hundred rows to reach them.
+        #
+        # Pure data, so no theorems: a *statement* about a table belongs in Conclusions, where it
+        # becomes a claim of record with a fingerprint, and a *proof* about one belongs in a
+        # solution. Held to the same import closure as Conclusions for the usual reason -- a
+        # challenge transitively imports this, so anything it reaches must be spin-off-able.
+        tables = directory / "Tables.lean"
+        if tables.is_file():
+            for module in imports_of(tables):
+                ok = (
+                    under(module, "Mathlib")
+                    or under(module, "IEANTN.Vocabulary")
+                    or (under(module, "IEANTN.Nodes") and module.endswith(".Tables"))
+                )
+                if not ok:
+                    problems.add(
+                        rel(tables),
+                        "a Tables file may import only Mathlib, Vocabulary and other Tables; "
+                        f"found `{module}`. Keep the import list short -- a table that needs a "
+                        "conclusion to state it is not data.",
+                    )
+            code = strip_lean_comments(tables.read_text(encoding="utf-8"))
+            for keyword in ("theorem", "lemma"):
+                if re.search(rf"\b{keyword}\s", code):
+                    problems.add(
+                        rel(tables),
+                        f"a Tables file may not declare a `{keyword}`: it holds data, not claims. "
+                        "A statement about a table is a conclusion; a proof about one belongs in a "
+                        "solution.",
+                    )
+            if re.search(r"\bsorry\b", code):
+                problems.add(rel(tables), "a Tables file may not contain `sorry`")
+
         challenge = directory / "Challenge.lean"
         if challenge.is_file():
             for module in imports_of(challenge):
@@ -966,6 +1008,11 @@ def render_umbrella(nodes: dict[str, dict]) -> str:
     """
     modules = []
     for node_id, node in sorted(nodes.items()):
+        # Tables before the challenge, and listed even though `Conclusions` usually imports them:
+        # a table no conclusion mentions yet is still data of record, and leaving it out of the
+        # umbrella would mean nothing compiled it.
+        if (node["_dir"] / "Tables.lean").is_file():
+            modules.append(f"IEANTN.Nodes.{node_id}.Tables")
         modules.append(f"IEANTN.Nodes.{node_id}.Challenge")
         if (node["_dir"] / "Examples.lean").is_file():
             modules.append(f"IEANTN.Nodes.{node_id}.Examples")
@@ -2386,7 +2433,12 @@ def new_version(family: str) -> bool:
 
     old_id, new_id = f"{family}.v{latest_n}", f"{family}.v{new_n}"
     target.mkdir(parents=True)
-    for name in ("Conclusions.lean", "formalization.yaml"):
+    # Every Lean file in the node, not just `Conclusions.lean`. A node may carry `Tables.lean`
+    # and `Examples.lean` too, and copying only the conclusions left the new version silently
+    # missing them -- which compiled, because the old version's copies were still there to satisfy
+    # the imports, and so would have been noticed only when the old version was deleted.
+    for name in ["formalization.yaml"] + sorted(
+            path.name for path in latest.glob("*.lean") if path.name != "Challenge.lean"):
         text = (latest / name).read_text(encoding="utf-8")
         # Only this family's own version references may be bumped. A blanket `v1` -> `v2`
         # would also rewrite the *imported* nodes' versions, silently repointing the new node

--- a/tests/test_ieantn.py
+++ b/tests/test_ieantn.py
@@ -660,6 +660,117 @@ class TestDeprecateGuards(FixtureRepo):
             self.assertFalse(ieantn.deprecate("A.v1", "A.v2"))
 
 
+class TestTablesFile(FixtureRepo):
+    """`Tables.lean`: a node's bulk data, kept out of the file a human audits.
+
+    Some explicit results are stated against a paper's numeric tables. Those belong beside the
+    conclusions rather than inside them, because `Conclusions.lean` is the short file a reviewer
+    reads and its shortness is the point -- checking three claims should not mean scrolling past
+    two hundred rows to reach them.
+    """
+
+    def write_tables(self, node_id: str, body: str) -> pathlib.Path:
+        directory = self.root / "IEANTN" / "Nodes" / node_id.replace(".", "/")
+        directory.mkdir(parents=True, exist_ok=True)
+        written = directory / "Tables.lean"
+        written.write_text(body, encoding="utf-8")
+        return written
+
+    def test_conclusions_may_import_its_own_tables(self) -> None:
+        self.write_node("A.v1", LITERATURE)
+        self.write_tables("A.v1", "import IEANTN.Vocabulary\ndef t : List ℝ := [1]\n")
+        directory = self.root / "IEANTN" / "Nodes" / "A" / "v1"
+        (directory / "Conclusions.lean").write_text(
+            "import IEANTN.Vocabulary\nimport IEANTN.Nodes.A.v1.Tables\n", encoding="utf-8")
+        self.assertTrue(ieantn.check_closure())
+
+    def test_conclusions_may_import_another_nodes_tables(self) -> None:
+        """A table is data, and the node that computed it is not always the node that states a
+        claim about it. Forcing a copy would create a second source of truth."""
+        self.write_node("A.v1", LITERATURE)
+        self.write_tables("B.v1", "import IEANTN.Vocabulary\ndef t : List ℝ := [1]\n")
+        directory = self.root / "IEANTN" / "Nodes" / "A" / "v1"
+        (directory / "Conclusions.lean").write_text(
+            "import IEANTN.Vocabulary\nimport IEANTN.Nodes.B.v1.Tables\n", encoding="utf-8")
+        self.assertTrue(ieantn.check_closure())
+
+    def test_a_table_may_not_declare_a_theorem(self) -> None:
+        """Data, not claims. A statement about a table is a conclusion, with a fingerprint and a
+        justification; a proof about one belongs in a solution."""
+        self.write_node("A.v1", LITERATURE)
+        self.write_tables(
+            "A.v1", "import IEANTN.Vocabulary\ntheorem t : True := trivial\n")
+        printed = io.StringIO()
+        with contextlib.redirect_stdout(printed):
+            passed = ieantn.check_closure()
+        self.assertFalse(passed)
+        self.assertIn("may not declare a `theorem`", printed.getvalue())
+
+    def test_a_table_may_not_declare_a_lemma(self) -> None:
+        self.write_node("A.v1", LITERATURE)
+        self.write_tables("A.v1", "import IEANTN.Vocabulary\nlemma t : True := trivial\n")
+        self.assertFalse(ieantn.check_closure())
+
+    def test_a_table_may_not_import_a_conclusion(self) -> None:
+        """The guidance is that a table has very few imports; the rule is that it has no claims
+        upstream of it. A table needing a conclusion in order to be stated is not data."""
+        self.write_node("A.v1", LITERATURE)
+        self.write_tables("A.v1", "import IEANTN.Nodes.A.v1.Conclusions\ndef t : List ℝ := [1]\n")
+        self.assertFalse(ieantn.check_closure())
+
+    def test_a_table_may_not_contain_sorry(self) -> None:
+        self.write_node("A.v1", LITERATURE)
+        self.write_tables("A.v1", "import IEANTN.Vocabulary\ndef t : List ℝ := sorry\n")
+        self.assertFalse(ieantn.check_closure())
+
+    def test_the_umbrella_imports_tables(self) -> None:
+        """A table no conclusion mentions yet is still data of record; leaving it out of the
+        umbrella would mean nothing compiled it."""
+        self.write_node("A.v1", LITERATURE)
+        self.write_tables("A.v1", "import IEANTN.Vocabulary\ndef t : List ℝ := [1]\n")
+        self.generate()
+        umbrella = (self.root / "IEANTN" / "Nodes.lean").read_text(encoding="utf-8")
+        self.assertIn("import IEANTN.Nodes.A.v1.Tables\n".replace("\n", chr(10)), umbrella)
+
+
+class TestNewVersionClonesTheNode(FixtureRepo):
+    """Branching a version must carry the whole node, not just its conclusions.
+
+    Copying only `Conclusions.lean` left the new version missing `Tables.lean` and
+    `Examples.lean` -- and it still compiled, because the old version's copies were there to
+    satisfy the imports. It would have failed only when the old version was finally deleted.
+    """
+
+    def test_tables_and_examples_are_copied(self) -> None:
+        try:
+            import ruamel.yaml  # noqa: F401
+        except ImportError:
+            self.skipTest("ruamel.yaml not installed")
+        directory = self.write_node("A.v1", LITERATURE)
+        (directory / "Tables.lean").write_text(
+            "import IEANTN.Vocabulary\ndef t : List ℝ := [1]\n", encoding="utf-8")
+        (directory / "Examples.lean").write_text(
+            "import IEANTN.Nodes.A.v1.Conclusions\n", encoding="utf-8")
+        self.assertTrue(ieantn.new_version("A"))
+        fresh = self.root / "IEANTN" / "Nodes" / "A" / "v2"
+        self.assertTrue((fresh / "Tables.lean").is_file(), "Tables.lean was not carried over")
+        self.assertTrue((fresh / "Examples.lean").is_file(), "Examples.lean was not carried over")
+
+    def test_the_copies_are_repointed_at_the_new_version(self) -> None:
+        """`Examples.lean` imports its own node's conclusions by name, so a copy that still names
+        `A.v1` would quietly demonstrate things about the version it was branched from."""
+        try:
+            import ruamel.yaml  # noqa: F401
+        except ImportError:
+            self.skipTest("ruamel.yaml not installed")
+        directory = self.write_node("A.v1", LITERATURE)
+        (directory / "Examples.lean").write_text(
+            "import IEANTN.Nodes.A.v1.Conclusions\n", encoding="utf-8")
+        self.assertTrue(ieantn.new_version("A"))
+        fresh = (self.root / "IEANTN" / "Nodes" / "A" / "v2" / "Examples.lean")
+        self.assertIn("A.v2.Conclusions", fresh.read_text(encoding="utf-8"))
+
+
 class TestBridgeClosure(FixtureRepo):
     """A bridge is held to the closure rule a Conclusions file is held to, and then some.
 


### PR DESCRIPTION
Implements the design we settled on, plus a bug it exposed.

## `Tables.lean`

An optional file beside `Conclusions.lean` holding a paper's bulk data. The reason is the one thing
`Conclusions.lean` is for: **it is the file a human audits, and its shortness is a feature.** A
reviewer checking three claims should not scroll past two hundred rows to reach them. A definition
or two that the conclusions need — `Lcm.v2`'s `HighlyAbundant` — is not data in this sense and stays
put. The test is bulk, not kind.

**Data only, enforced:** no `theorem`, no `lemma`, no `sorry`. A *statement* about a table is a
conclusion, where it gains a fingerprint and a justification; a *proof* about one belongs in a
solution — exactly as you put it.

**Any node's conclusions may import any node's tables.** A table is data, and the node that computed
it is often not the node stating a claim about it. Forcing a copy would create a second source of
truth.

**Import closure:** Mathlib, Vocabulary and other table files. That enforces the case that matters —
a table needing a *conclusion* to be stated is not data. Beyond that I left "very few imports" as
guidance rather than a rule, since the honest signal is qualitative: a table wanting a long import
list is usually a computation wearing a table's clothes, and wants to be its own node.

## A bug this exposed

`new-version` copied only `Conclusions.lean` and `formalization.yaml`. So branching a version
**silently dropped `Examples.lean`** — and would have dropped `Tables.lean`. Worse, it compiled: the
old version's copies were still there to satisfy the imports, so it would have failed only when the
old version was finally deleted, long after the cause. Now copies every `.lean` in the node
directory and repoints them all.

## Two things that already worked

Checked rather than assumed: the spin-off generator walks **constants and their modules**, not
files, so a table's definitions inline into a Challenge the same way; and `Tools/Hash.lean` follows
any constant whose module is under `IEANTN`, so editing a table moves the fingerprint of every
conclusion mentioning it. Both are the behaviour you'd want and neither needed changing.

## Checks

121 tests, up from 112 — **all nine new ones fail against the unpatched script**. `check` green,
`lake build` clean, pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)