### PR TITLE
Correct two citation records against the papers

### DIFF
--- a/IEANTN/Nodes/Kadiri2005/v1/formalization.yaml
+++ b/IEANTN/Nodes/Kadiri2005/v1/formalization.yaml
@@ -33,27 +33,27 @@ classification:
 conclusions: []
 
 sources:
-  - title: "Une region explicite sans zeros pour la fonction zeta de Riemann"
-    authors: ["Habiba Kadiri"]
-    type: "paper"
-    id: "Acta Arith. 117 (2005), no. 4, 303-339"
-    location: "Acta Arith. 117 (2005), no. 4, 303-339"
-    relationship: formalizes
-    note: >-
-      PNT+'s bibliography records no DOI for this paper, so the journal reference stands as the
-      identifier. Confirm one against the publisher before this node is used as the basis for any
-      external submission. The title is in French and is transcribed here without diacritics;
-      check it against the printed paper.
+- title: "Une region explicite sans zeros pour la fonction zeta de Riemann"
+  authors: ["Habiba Kadiri"]
+  type: "paper"
+  id: "https://arxiv.org/abs/math/0401238"
+  location: "Acta Arith. 117 (2005), no. 4, 303-339"
+  relationship: formalizes
+  note: >-
+    PNT+'s bibliography records no DOI for this paper. The arXiv preprint math/0401238 (19 January 2004)
+    is the same work and is used as the identifier; the journal reference above is the version of record.
+    Confirm a publisher DOI before this node is used as the basis for any external submission. The title
+    is in French and is transcribed here without diacritics.
 
 automation:
   methods:
-    - method: agent
-      models: ["Claude Opus 5 (Anthropic)"]
-      framework: "Claude Code"
-      role: >-
-        Created this stub and transcribed its bibliographic record from the PNT+
-        bibliography, under the direction of the maintainer. No mathematical claim is
-        made and no statement has been transcribed from the paper.
+  - method: agent
+    models: ["Claude Opus 5 (Anthropic)"]
+    framework: "Claude Code"
+    role: >-
+      Created this stub and transcribed its bibliographic record from the PNT+
+      bibliography, under the direction of the maintainer. No mathematical claim is
+      made and no statement has been transcribed from the paper.
 
 review:
   status: self-assessed
@@ -64,8 +64,8 @@ review:
     cited externally or used as the basis for a submission.
 
 limitations:
-  - >-
-    This node states nothing. It exists so that the network records the paper as in scope,
-    and so that the housekeeping queue asks for conclusions.
-  - >-
-    No novelty is claimed. The results are the cited authors'.
+- >-
+  This node states nothing. It exists so that the network records the paper as in scope,
+  and so that the housekeeping queue asks for conclusions.
+- >-
+  No novelty is claimed. The results are the cited authors'.

--- a/IEANTN/Nodes/MTY/v1/formalization.yaml
+++ b/IEANTN/Nodes/MTY/v1/formalization.yaml
@@ -33,25 +33,30 @@ classification:
 conclusions: []
 
 sources:
-  - title: "Explicit zero-free regions for the Riemann zeta-function"
-    authors: ["Michael J. Mossinghoff", "Timothy S. Trudgian", "Andrew Yang"]
-    type: "paper"
-    id: "https://arxiv.org/abs/2212.06867"
-    location: "Res. Number Theory 10 (2024), no. 1, Paper No. 11, 27 pp."
-    relationship: formalizes
-    note: >-
-      PNT+'s bibliography records the arXiv identifier and no DOI, so the arXiv entry is the
-      identifier here. Confirm the published version's DOI before any external submission.
+- title: "Explicit zero-free regions for the Riemann zeta-function"
+  authors: ["Michael J. Mossinghoff", "Timothy S. Trudgian", "Andrew Yang"]
+  type: "paper"
+  id: "https://arxiv.org/abs/2212.06867"
+  location: "Res. Number Theory 10 (2024), no. 1, Paper No. 11, 27 pp."
+  relationship: formalizes
+  note: >-
+    Identifier is the arXiv entry; PNT+'s bibliography records no DOI and the published version's should
+    be confirmed before external use. The title above was checked against the preprint itself: note that
+    FKS2's reference [12] gives this paper the title of Mossinghoff and Trudgian's 2015 paper instead,
+    which is an error in that bibliography rather than here. Substantively, this paper improves the classical
+    zero-free region constant to R = 5.558691; FKS2 and FKS use R = 5.5666305 from Mossinghoff and Trudgian,
+    J. Number Theory 157 (2015), and state explicitly that their numerics do not reflect this improvement.
+    So this node is a future sharpening of the chain, not an input to its current constants.
 
 automation:
   methods:
-    - method: agent
-      models: ["Claude Opus 5 (Anthropic)"]
-      framework: "Claude Code"
-      role: >-
-        Created this stub and transcribed its bibliographic record from the PNT+
-        bibliography, under the direction of the maintainer. No mathematical claim is
-        made and no statement has been transcribed from the paper.
+  - method: agent
+    models: ["Claude Opus 5 (Anthropic)"]
+    framework: "Claude Code"
+    role: >-
+      Created this stub and transcribed its bibliographic record from the PNT+
+      bibliography, under the direction of the maintainer. No mathematical claim is
+      made and no statement has been transcribed from the paper.
 
 review:
   status: self-assessed
@@ -62,8 +67,8 @@ review:
     cited externally or used as the basis for a submission.
 
 limitations:
-  - >-
-    This node states nothing. It exists so that the network records the paper as in scope,
-    and so that the housekeeping queue asks for conclusions.
-  - >-
-    No novelty is claimed. The results are the cited authors'.
+- >-
+  This node states nothing. It exists so that the network records the paper as in scope,
+  and so that the housekeeping queue asks for conclusions.
+- >-
+  No novelty is claimed. The results are the cited authors'.


### PR DESCRIPTION
Reading the three papers settled two things the stubs had explicitly flagged for confirmation.

**Kadiri 2005** is on arXiv as `math/0401238`, so the node carries an identifier rather than a bare
journal reference. Publisher DOI still worth confirming.

**MTY**'s title is right as recorded — checked against the preprint. Worth noting because **FKS2's
own reference [12] gives it the title of Mossinghoff–Trudgian 2015 instead**, an error in that
bibliography rather than ours.

More substantively: MTY improves the classical zero-free region constant to `R = 5.558691`, while
FKS2 and FKS use `R = 5.5666305` from **Mossinghoff–Trudgian, J. Number Theory 157 (2015)**, and say
explicitly that their numerics do not reflect the improvement. So MTY is a *future sharpening* of
this chain, not an input to its present constants — and the node now says so, which matters because
someone reading the stub list would otherwise reasonably assume it was the zero-free region FKS2
rests on.