### PR TITLE
Draw bridges as nodes, and continue tracing the network backwards

### DIFF
--- a/GRAPH.md
+++ b/GRAPH.md
@@ -15,12 +15,23 @@ not a claim that the box rests on nothing; it is an admission that the question 
 been asked. A solid border means someone has traced it to its sources, and the arrows
 into it are the answer.
 
+A **hexagon** is a *bridge*, and the thick arrows around it are a different relation from
+the thin ones. A thin arrow into a box means the box **assumes** what the arrow comes
+from, and nothing here checks the step. A bridge is the step itself, proved in Lean and
+recompiled on every push. It is drawn as a box rather than an arrow because a bridge may
+have several premises at once, which an arrow cannot say. A bridge marked *spare* is a
+second ground for a claim that is currently justified some other way.
+
 ## The network at a glance
 
-One box per node, so this stays readable as the network grows. The number on an arrow is
-how many separate claims cross it. A node is coloured by its **weakest** conclusion,
+One box per node, so this stays readable as the network grows. The number on a thin arrow
+is how many separate claims cross it. A node is coloured by its **weakest** conclusion,
 since that is what someone importing the whole node is relying on, and dashed if any of
 its claims has not been traced to its own sources.
+
+A thick **bridge** arrow is a Lean-checked implication rather than an assumption. At this
+resolution it says only that some bridge crosses between the two nodes; which premises a
+bridge needed together is in the detailed picture below.
 
 ```mermaid
 graph LR
@@ -48,6 +59,7 @@ graph LR
   NMT_v1 -->|2| NFKS_v1
   NPlattTrudgian_v1 -->|2| NFKS_v1
   NPlattTrudgian_v1 --> NMT_v1
+  NLcm_v2 ==>|bridge| NLcm_v1
   style NBKLNW_v1 stroke-dasharray: 6 4;
   style NDusart2018_v1 stroke-dasharray: 6 4;
   style NFKBJ_v1 stroke-dasharray: 6 4;
@@ -139,6 +151,9 @@ graph LR
   Buthe_v1_theorem_2_li_gt_pi --> FKS2_v1_corollary_26
   Dusart2018_v1_proposition_5_4 --> Lcm_v1_lcmUpto_not_highlyAbundant
   PlattTrudgian_v1_rh_up_to --> MT_v1_zero_free_region_sharpened
+  BRLcm_v1_lcmUpto_not_highlyAbundant__bridge_from_v2{{"<b>V2ToV1</b><br/><i>spare</i>"}}
+  Lcm_v2_lcmUpto_not_highlyAbundant_of_primeGap ==> BRLcm_v1_lcmUpto_not_highlyAbundant__bridge_from_v2
+  BRLcm_v1_lcmUpto_not_highlyAbundant__bridge_from_v2 ==> Lcm_v1_lcmUpto_not_highlyAbundant
   style BKLNW_v1_table8_psi_bound stroke-dasharray: 6 4;
   style BKLNW_v1_table8_psi_bound_above stroke-dasharray: 6 4;
   style BKLNW_v1_theta_error_le_one stroke-dasharray: 6 4;
@@ -152,6 +167,8 @@ graph LR
   classDef asserted fill:#fff1e5,stroke:#bc4c00,color:#1f2328;
   classDef bridged fill:#fbefff,stroke:#8250df,color:#1f2328;
   classDef none_yet fill:#ffebe9,stroke:#cf222e,color:#1f2328;
+  classDef bridge fill:#fbefff,stroke:#8250df,color:#1f2328,stroke-width:2px;
+  class BRLcm_v1_lcmUpto_not_highlyAbundant__bridge_from_v2 bridge;
   class Lcm_v1_lcmUpto_not_highlyAbundant,Lcm_v2_lcmUpto_not_highlyAbundant_of_primeGap lean_comparator;
   class BKLNW_v1_corollary_5_1,BKLNW_v1_table8_psi_bound,BKLNW_v1_table8_psi_bound_above,BKLNW_v1_theta_error_le_one,Buthe_v1_theorem_2_li_gt_pi,Buthe_v1_theorem_2_li_minus_pi,Buthe_v1_theorem_2_li_minus_riemann_pi,Buthe_v1_theorem_2_psi,Buthe_v1_theorem_2_theta,Buthe_v1_theorem_2_theta_lower,Dusart2018_v1_proposition_5_4,FKS_v1_psi_bound_all_x,FKS_v1_psi_classical_bound,FKS2_v1_corollary_14,FKS2_v1_corollary_23,FKS2_v1_corollary_26,KLN_v1_subconvexity_bound,MT_v1_zero_free_region,MT_v1_zero_free_region_sharpened,PlattTrudgian_v1_rh_up_to literature;
   class FKBJ_v1_rh_up_to numerical;

--- a/GRAPH.md
+++ b/GRAPH.md
@@ -42,7 +42,7 @@ graph LR
   NFKS_v1["<b>FKS.v1</b><br/>2 claims<br/><i>weakest: cited</i>"]
   NFKS2_v1["<b>FKS2.v1</b><br/>3 claims<br/><i>weakest: cited</i>"]
   NKLN_v1["<b>KLN.v1</b><br/>1 claim<br/><i>weakest: cited</i>"]
-  NKadiri2005_v1["<b>Kadiri2005.v1</b><br/><i>nothing stated yet</i>"]
+  NKadiri2005_v1["<b>Kadiri2005.v1</b><br/>1 claim<br/><i>weakest: cited</i>"]
   NLcm_v1["<b>Lcm.v1</b><br/>1 claim<br/><i>weakest: verified</i>"]
   NLcm_v2["<b>Lcm.v2</b><br/>1 claim<br/><i>weakest: verified</i>"]
   NMT_v1["<b>MT.v1</b><br/>2 claims<br/><i>weakest: cited</i>"]
@@ -56,6 +56,7 @@ graph LR
   NFKBJ_v1 -->|6| NButhe_v1
   NFKS_v1 -->|2| NFKS2_v1
   NKLN_v1 -->|2| NFKS_v1
+  NKadiri2005_v1 -->|2| NMT_v1
   NMT_v1 -->|2| NFKS_v1
   NPlattTrudgian_v1 -->|2| NFKS_v1
   NPlattTrudgian_v1 --> NMT_v1
@@ -64,9 +65,11 @@ graph LR
   style NDusart2018_v1 stroke-dasharray: 6 4;
   style NFKBJ_v1 stroke-dasharray: 6 4;
   style NKLN_v1 stroke-dasharray: 6 4;
+  style NKadiri2005_v1 stroke-dasharray: 6 4;
+  style NMT_v1 stroke-dasharray: 6 4;
   style NPlattTrudgian_v1 stroke-dasharray: 6 4;
-  class NKadiri2005_v1,NMTY_v1,NRosserSchoenfeld_v1 none_yet;
-  class NBKLNW_v1,NButhe_v1,NDusart2018_v1,NFKS_v1,NFKS2_v1,NKLN_v1,NMT_v1,NPlattTrudgian_v1 literature;
+  class NMTY_v1,NRosserSchoenfeld_v1 none_yet;
+  class NBKLNW_v1,NButhe_v1,NDusart2018_v1,NFKS_v1,NFKS2_v1,NKLN_v1,NKadiri2005_v1,NMT_v1,NPlattTrudgian_v1 literature;
   class NFKBJ_v1 numerical;
   class NLcm_v1,NLcm_v2 lean_comparator;
   classDef lean_comparator fill:#dafbe1,stroke:#1a7f37,color:#1f2328;
@@ -116,6 +119,9 @@ graph LR
   subgraph sgKLN_v1["KLN.v1"]
     KLN_v1_subconvexity_bound["<b>subconvexity_bound</b><br/><i>cited</i>"]
   end
+  subgraph sgKadiri2005_v1["Kadiri2005.v1"]
+    Kadiri2005_v1_zero_free_region["<b>zero_free_region</b><br/><i>cited</i>"]
+  end
   subgraph sgLcm_v1["Lcm.v1"]
     Lcm_v1_lcmUpto_not_highlyAbundant["<b>lcmUpto_not_highlyAbundant</b><br/><i>verified</i>"]
   end
@@ -150,6 +156,8 @@ graph LR
   Buthe_v1_theorem_2_li_minus_pi --> FKS2_v1_corollary_26
   Buthe_v1_theorem_2_li_gt_pi --> FKS2_v1_corollary_26
   Dusart2018_v1_proposition_5_4 --> Lcm_v1_lcmUpto_not_highlyAbundant
+  Kadiri2005_v1_zero_free_region --> MT_v1_zero_free_region
+  Kadiri2005_v1_zero_free_region --> MT_v1_zero_free_region_sharpened
   PlattTrudgian_v1_rh_up_to --> MT_v1_zero_free_region_sharpened
   BRLcm_v1_lcmUpto_not_highlyAbundant__bridge_from_v2{{"<b>V2ToV1</b><br/><i>spare</i>"}}
   Lcm_v2_lcmUpto_not_highlyAbundant_of_primeGap ==> BRLcm_v1_lcmUpto_not_highlyAbundant__bridge_from_v2
@@ -160,6 +168,8 @@ graph LR
   style Dusart2018_v1_proposition_5_4 stroke-dasharray: 6 4;
   style FKBJ_v1_rh_up_to stroke-dasharray: 6 4;
   style KLN_v1_subconvexity_bound stroke-dasharray: 6 4;
+  style Kadiri2005_v1_zero_free_region stroke-dasharray: 6 4;
+  style MT_v1_zero_free_region stroke-dasharray: 6 4;
   style PlattTrudgian_v1_rh_up_to stroke-dasharray: 6 4;
   classDef lean_comparator fill:#dafbe1,stroke:#1a7f37,color:#1f2328;
   classDef numerical fill:#fff8c5,stroke:#9a6700,color:#1f2328;
@@ -170,7 +180,7 @@ graph LR
   classDef bridge fill:#fbefff,stroke:#8250df,color:#1f2328,stroke-width:2px;
   class BRLcm_v1_lcmUpto_not_highlyAbundant__bridge_from_v2 bridge;
   class Lcm_v1_lcmUpto_not_highlyAbundant,Lcm_v2_lcmUpto_not_highlyAbundant_of_primeGap lean_comparator;
-  class BKLNW_v1_corollary_5_1,BKLNW_v1_table8_psi_bound,BKLNW_v1_table8_psi_bound_above,BKLNW_v1_theta_error_le_one,Buthe_v1_theorem_2_li_gt_pi,Buthe_v1_theorem_2_li_minus_pi,Buthe_v1_theorem_2_li_minus_riemann_pi,Buthe_v1_theorem_2_psi,Buthe_v1_theorem_2_theta,Buthe_v1_theorem_2_theta_lower,Dusart2018_v1_proposition_5_4,FKS_v1_psi_bound_all_x,FKS_v1_psi_classical_bound,FKS2_v1_corollary_14,FKS2_v1_corollary_23,FKS2_v1_corollary_26,KLN_v1_subconvexity_bound,MT_v1_zero_free_region,MT_v1_zero_free_region_sharpened,PlattTrudgian_v1_rh_up_to literature;
+  class BKLNW_v1_corollary_5_1,BKLNW_v1_table8_psi_bound,BKLNW_v1_table8_psi_bound_above,BKLNW_v1_theta_error_le_one,Buthe_v1_theorem_2_li_gt_pi,Buthe_v1_theorem_2_li_minus_pi,Buthe_v1_theorem_2_li_minus_riemann_pi,Buthe_v1_theorem_2_psi,Buthe_v1_theorem_2_theta,Buthe_v1_theorem_2_theta_lower,Dusart2018_v1_proposition_5_4,FKS_v1_psi_bound_all_x,FKS_v1_psi_classical_bound,FKS2_v1_corollary_14,FKS2_v1_corollary_23,FKS2_v1_corollary_26,KLN_v1_subconvexity_bound,Kadiri2005_v1_zero_free_region,MT_v1_zero_free_region,MT_v1_zero_free_region_sharpened,PlattTrudgian_v1_rh_up_to literature;
   class FKBJ_v1_rh_up_to numerical;
 ```
 
@@ -195,6 +205,7 @@ A line is one claim, indented under whatever assumes it.
 - `FKS.v1.psi_bound_all_x` — cited
   - `KLN.v1.subconvexity_bound` — cited — *sources not traced*
   - `MT.v1.zero_free_region_sharpened` — cited
+    - `Kadiri2005.v1.zero_free_region` — cited — *sources not traced*
     - `PlattTrudgian.v1.rh_up_to` — cited — *sources not traced*
   - `PlattTrudgian.v1.rh_up_to` — cited *(above)* — *sources not traced*
 
@@ -202,6 +213,7 @@ A line is one claim, indented under whatever assumes it.
   - `FKS.v1.psi_classical_bound` — cited
     - `KLN.v1.subconvexity_bound` — cited — *sources not traced*
     - `MT.v1.zero_free_region_sharpened` — cited
+      - `Kadiri2005.v1.zero_free_region` — cited — *sources not traced*
       - `PlattTrudgian.v1.rh_up_to` — cited — *sources not traced*
     - `PlattTrudgian.v1.rh_up_to` — cited *(above)* — *sources not traced*
   - `BKLNW.v1.corollary_5_1` — cited
@@ -213,6 +225,7 @@ A line is one claim, indented under whatever assumes it.
   - `FKS.v1.psi_classical_bound` — cited
     - `KLN.v1.subconvexity_bound` — cited — *sources not traced*
     - `MT.v1.zero_free_region_sharpened` — cited
+      - `Kadiri2005.v1.zero_free_region` — cited — *sources not traced*
       - `PlattTrudgian.v1.rh_up_to` — cited — *sources not traced*
     - `PlattTrudgian.v1.rh_up_to` — cited *(above)* — *sources not traced*
   - `Buthe.v1.theorem_2_li_minus_pi` — cited
@@ -229,7 +242,8 @@ A line is one claim, indented under whatever assumes it.
 
 - `Lcm.v2.lcmUpto_not_highlyAbundant_of_primeGap` — verified
 
-- `MT.v1.zero_free_region` — cited
+- `MT.v1.zero_free_region` — cited — *sources not traced*
+  - `Kadiri2005.v1.zero_free_region` — cited — *sources not traced*
 
 ## What the network takes on trust
 
@@ -244,6 +258,7 @@ rather than maintained.
 | `Buthe.v1.theorem_2_li_minus_pi` | cited | 2 | traced |
 | `FKS.v1.psi_classical_bound` | cited | 2 | traced |
 | `KLN.v1.subconvexity_bound` | cited | 2 | **not yet traced** |
+| `Kadiri2005.v1.zero_free_region` | cited | 2 | **not yet traced** |
 | `MT.v1.zero_free_region_sharpened` | cited | 2 | traced |
 | `BKLNW.v1.corollary_5_1` | cited | 1 | traced |
 | `BKLNW.v1.theta_error_le_one` | cited | 1 | **not yet traced** |
@@ -259,14 +274,13 @@ rather than maintained.
 | `FKS2.v1.corollary_14` | cited | 0 | traced |
 | `FKS2.v1.corollary_23` | cited | 0 | traced |
 | `FKS2.v1.corollary_26` | cited | 0 | traced |
-| `MT.v1.zero_free_region` | cited | 0 | traced |
+| `MT.v1.zero_free_region` | cited | 0 | **not yet traced** |
 
 ## Nodes that state nothing yet
 
 A paper recorded as in scope, before anyone has transcribed a claim from it. These are
 the network's open invitations.
 
-- `Kadiri2005.v1`
 - `MTY.v1`
 - `RosserSchoenfeld.v1`
 

--- a/GRAPH.md
+++ b/GRAPH.md
@@ -15,6 +15,8 @@ not a claim that the box rests on nothing; it is an admission that the question 
 been asked. A solid border means someone has traced it to its sources, and the arrows
 into it are the answer.
 
+Every box and every claim named below links to the line of Lean that states it.
+
 A **hexagon** is a *bridge*, and the thick arrows around it are a different relation from
 the thin ones. A thin arrow into a box means the box **assumes** what the arrow comes
 from, and nothing here checks the step. A bridge is the step itself, proved in Lean and
@@ -72,6 +74,18 @@ graph LR
   class NBKLNW_v1,NButhe_v1,NDusart2018_v1,NFKS_v1,NFKS2_v1,NKLN_v1,NKadiri2005_v1,NMT_v1,NPlattTrudgian_v1 literature;
   class NFKBJ_v1 numerical;
   class NLcm_v1,NLcm_v2 lean_comparator;
+  click NBKLNW_v1 href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/BKLNW/v1/Conclusions.lean#L63" _blank
+  click NButhe_v1 href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L73" _blank
+  click NDusart2018_v1 href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Dusart2018/v1/Conclusions.lean#L36" _blank
+  click NFKBJ_v1 href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKBJ/v1/Conclusions.lean#L43" _blank
+  click NFKS_v1 href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L44" _blank
+  click NFKS2_v1 href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS2/v1/Conclusions.lean#L65" _blank
+  click NKLN_v1 href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/KLN/v1/Conclusions.lean#L65" _blank
+  click NKadiri2005_v1 href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Kadiri2005/v1/Conclusions.lean#L42" _blank
+  click NLcm_v1 href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Lcm/v1/Conclusions.lean#L42" _blank
+  click NLcm_v2 href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Lcm/v2/Conclusions.lean#L71" _blank
+  click NMT_v1 href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/MT/v1/Conclusions.lean#L33" _blank
+  click NPlattTrudgian_v1 href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/PlattTrudgian/v1/Conclusions.lean#L35" _blank
   classDef lean_comparator fill:#dafbe1,stroke:#1a7f37,color:#1f2328;
   classDef numerical fill:#fff8c5,stroke:#9a6700,color:#1f2328;
   classDef literature fill:#ddf4ff,stroke:#0969da,color:#1f2328;
@@ -182,6 +196,30 @@ graph LR
   class Lcm_v1_lcmUpto_not_highlyAbundant,Lcm_v2_lcmUpto_not_highlyAbundant_of_primeGap lean_comparator;
   class BKLNW_v1_corollary_5_1,BKLNW_v1_table8_psi_bound,BKLNW_v1_table8_psi_bound_above,BKLNW_v1_theta_error_le_one,Buthe_v1_theorem_2_li_gt_pi,Buthe_v1_theorem_2_li_minus_pi,Buthe_v1_theorem_2_li_minus_riemann_pi,Buthe_v1_theorem_2_psi,Buthe_v1_theorem_2_theta,Buthe_v1_theorem_2_theta_lower,Dusart2018_v1_proposition_5_4,FKS_v1_psi_bound_all_x,FKS_v1_psi_classical_bound,FKS2_v1_corollary_14,FKS2_v1_corollary_23,FKS2_v1_corollary_26,KLN_v1_subconvexity_bound,Kadiri2005_v1_zero_free_region,MT_v1_zero_free_region,MT_v1_zero_free_region_sharpened,PlattTrudgian_v1_rh_up_to literature;
   class FKBJ_v1_rh_up_to numerical;
+  click BKLNW_v1_corollary_5_1 href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/BKLNW/v1/Conclusions.lean#L63" _blank
+  click BKLNW_v1_table8_psi_bound href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/BKLNW/v1/Conclusions.lean#L78" _blank
+  click BKLNW_v1_table8_psi_bound_above href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/BKLNW/v1/Conclusions.lean#L94" _blank
+  click BKLNW_v1_theta_error_le_one href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/BKLNW/v1/Conclusions.lean#L107" _blank
+  click Buthe_v1_theorem_2_li_gt_pi href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L73" _blank
+  click Buthe_v1_theorem_2_li_minus_pi href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L63" _blank
+  click Buthe_v1_theorem_2_li_minus_riemann_pi href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L53" _blank
+  click Buthe_v1_theorem_2_psi href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L31" _blank
+  click Buthe_v1_theorem_2_theta href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L38" _blank
+  click Buthe_v1_theorem_2_theta_lower href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L45" _blank
+  click Dusart2018_v1_proposition_5_4 href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Dusart2018/v1/Conclusions.lean#L36" _blank
+  click FKBJ_v1_rh_up_to href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKBJ/v1/Conclusions.lean#L43" _blank
+  click FKS_v1_psi_bound_all_x href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L44" _blank
+  click FKS_v1_psi_classical_bound href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L63" _blank
+  click FKS2_v1_corollary_14 href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS2/v1/Conclusions.lean#L65" _blank
+  click FKS2_v1_corollary_23 href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS2/v1/Conclusions.lean#L78" _blank
+  click FKS2_v1_corollary_26 href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS2/v1/Conclusions.lean#L91" _blank
+  click KLN_v1_subconvexity_bound href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/KLN/v1/Conclusions.lean#L65" _blank
+  click Kadiri2005_v1_zero_free_region href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Kadiri2005/v1/Conclusions.lean#L42" _blank
+  click Lcm_v1_lcmUpto_not_highlyAbundant href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Lcm/v1/Conclusions.lean#L42" _blank
+  click Lcm_v2_lcmUpto_not_highlyAbundant_of_primeGap href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Lcm/v2/Conclusions.lean#L71" _blank
+  click MT_v1_zero_free_region href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/MT/v1/Conclusions.lean#L33" _blank
+  click MT_v1_zero_free_region_sharpened href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/MT/v1/Conclusions.lean#L48" _blank
+  click PlattTrudgian_v1_rh_up_to href "https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/PlattTrudgian/v1/Conclusions.lean#L35" _blank
 ```
 
 ## What each result rests on
@@ -189,61 +227,61 @@ graph LR
 Only the conclusions nothing else imports are listed; the rest appear inside them.
 A line is one claim, indented under whatever assumes it.
 
-- `BKLNW.v1.table8_psi_bound` — cited — *sources not traced*
+- [`BKLNW.v1.table8_psi_bound`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/BKLNW/v1/Conclusions.lean#L78) — cited — *sources not traced*
 
-- `BKLNW.v1.table8_psi_bound_above` — cited — *sources not traced*
+- [`BKLNW.v1.table8_psi_bound_above`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/BKLNW/v1/Conclusions.lean#L94) — cited — *sources not traced*
 
-- `Buthe.v1.theorem_2_li_minus_riemann_pi` — cited
-  - `FKBJ.v1.rh_up_to` — computation — *sources not traced*
+- [`Buthe.v1.theorem_2_li_minus_riemann_pi`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L53) — cited
+  - [`FKBJ.v1.rh_up_to`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKBJ/v1/Conclusions.lean#L43) — computation — *sources not traced*
 
-- `Buthe.v1.theorem_2_psi` — cited
-  - `FKBJ.v1.rh_up_to` — computation — *sources not traced*
+- [`Buthe.v1.theorem_2_psi`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L31) — cited
+  - [`FKBJ.v1.rh_up_to`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKBJ/v1/Conclusions.lean#L43) — computation — *sources not traced*
 
-- `Buthe.v1.theorem_2_theta` — cited
-  - `FKBJ.v1.rh_up_to` — computation — *sources not traced*
+- [`Buthe.v1.theorem_2_theta`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L38) — cited
+  - [`FKBJ.v1.rh_up_to`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKBJ/v1/Conclusions.lean#L43) — computation — *sources not traced*
 
-- `FKS.v1.psi_bound_all_x` — cited
-  - `KLN.v1.subconvexity_bound` — cited — *sources not traced*
-  - `MT.v1.zero_free_region_sharpened` — cited
-    - `Kadiri2005.v1.zero_free_region` — cited — *sources not traced*
-    - `PlattTrudgian.v1.rh_up_to` — cited — *sources not traced*
-  - `PlattTrudgian.v1.rh_up_to` — cited *(above)* — *sources not traced*
+- [`FKS.v1.psi_bound_all_x`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L44) — cited
+  - [`KLN.v1.subconvexity_bound`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/KLN/v1/Conclusions.lean#L65) — cited — *sources not traced*
+  - [`MT.v1.zero_free_region_sharpened`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/MT/v1/Conclusions.lean#L48) — cited
+    - [`Kadiri2005.v1.zero_free_region`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Kadiri2005/v1/Conclusions.lean#L42) — cited — *sources not traced*
+    - [`PlattTrudgian.v1.rh_up_to`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/PlattTrudgian/v1/Conclusions.lean#L35) — cited — *sources not traced*
+  - [`PlattTrudgian.v1.rh_up_to`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/PlattTrudgian/v1/Conclusions.lean#L35) — cited *(above)* — *sources not traced*
 
-- `FKS2.v1.corollary_14` — cited
-  - `FKS.v1.psi_classical_bound` — cited
-    - `KLN.v1.subconvexity_bound` — cited — *sources not traced*
-    - `MT.v1.zero_free_region_sharpened` — cited
-      - `Kadiri2005.v1.zero_free_region` — cited — *sources not traced*
-      - `PlattTrudgian.v1.rh_up_to` — cited — *sources not traced*
-    - `PlattTrudgian.v1.rh_up_to` — cited *(above)* — *sources not traced*
-  - `BKLNW.v1.corollary_5_1` — cited
-    - `Buthe.v1.theorem_2_theta_lower` — cited
-      - `FKBJ.v1.rh_up_to` — computation — *sources not traced*
-  - `BKLNW.v1.theta_error_le_one` — cited — *sources not traced*
+- [`FKS2.v1.corollary_14`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS2/v1/Conclusions.lean#L65) — cited
+  - [`FKS.v1.psi_classical_bound`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L63) — cited
+    - [`KLN.v1.subconvexity_bound`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/KLN/v1/Conclusions.lean#L65) — cited — *sources not traced*
+    - [`MT.v1.zero_free_region_sharpened`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/MT/v1/Conclusions.lean#L48) — cited
+      - [`Kadiri2005.v1.zero_free_region`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Kadiri2005/v1/Conclusions.lean#L42) — cited — *sources not traced*
+      - [`PlattTrudgian.v1.rh_up_to`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/PlattTrudgian/v1/Conclusions.lean#L35) — cited — *sources not traced*
+    - [`PlattTrudgian.v1.rh_up_to`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/PlattTrudgian/v1/Conclusions.lean#L35) — cited *(above)* — *sources not traced*
+  - [`BKLNW.v1.corollary_5_1`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/BKLNW/v1/Conclusions.lean#L63) — cited
+    - [`Buthe.v1.theorem_2_theta_lower`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L45) — cited
+      - [`FKBJ.v1.rh_up_to`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKBJ/v1/Conclusions.lean#L43) — computation — *sources not traced*
+  - [`BKLNW.v1.theta_error_le_one`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/BKLNW/v1/Conclusions.lean#L107) — cited — *sources not traced*
 
-- `FKS2.v1.corollary_23` — cited
-  - `FKS.v1.psi_classical_bound` — cited
-    - `KLN.v1.subconvexity_bound` — cited — *sources not traced*
-    - `MT.v1.zero_free_region_sharpened` — cited
-      - `Kadiri2005.v1.zero_free_region` — cited — *sources not traced*
-      - `PlattTrudgian.v1.rh_up_to` — cited — *sources not traced*
-    - `PlattTrudgian.v1.rh_up_to` — cited *(above)* — *sources not traced*
-  - `Buthe.v1.theorem_2_li_minus_pi` — cited
-    - `FKBJ.v1.rh_up_to` — computation — *sources not traced*
+- [`FKS2.v1.corollary_23`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS2/v1/Conclusions.lean#L78) — cited
+  - [`FKS.v1.psi_classical_bound`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L63) — cited
+    - [`KLN.v1.subconvexity_bound`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/KLN/v1/Conclusions.lean#L65) — cited — *sources not traced*
+    - [`MT.v1.zero_free_region_sharpened`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/MT/v1/Conclusions.lean#L48) — cited
+      - [`Kadiri2005.v1.zero_free_region`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Kadiri2005/v1/Conclusions.lean#L42) — cited — *sources not traced*
+      - [`PlattTrudgian.v1.rh_up_to`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/PlattTrudgian/v1/Conclusions.lean#L35) — cited — *sources not traced*
+    - [`PlattTrudgian.v1.rh_up_to`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/PlattTrudgian/v1/Conclusions.lean#L35) — cited *(above)* — *sources not traced*
+  - [`Buthe.v1.theorem_2_li_minus_pi`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L63) — cited
+    - [`FKBJ.v1.rh_up_to`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKBJ/v1/Conclusions.lean#L43) — computation — *sources not traced*
 
-- `FKS2.v1.corollary_26` — cited
-  - `Buthe.v1.theorem_2_li_minus_pi` — cited
-    - `FKBJ.v1.rh_up_to` — computation — *sources not traced*
-  - `Buthe.v1.theorem_2_li_gt_pi` — cited
-    - `FKBJ.v1.rh_up_to` — computation *(above)* — *sources not traced*
+- [`FKS2.v1.corollary_26`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS2/v1/Conclusions.lean#L91) — cited
+  - [`Buthe.v1.theorem_2_li_minus_pi`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L63) — cited
+    - [`FKBJ.v1.rh_up_to`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKBJ/v1/Conclusions.lean#L43) — computation — *sources not traced*
+  - [`Buthe.v1.theorem_2_li_gt_pi`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L73) — cited
+    - [`FKBJ.v1.rh_up_to`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKBJ/v1/Conclusions.lean#L43) — computation *(above)* — *sources not traced*
 
-- `Lcm.v1.lcmUpto_not_highlyAbundant` — verified
-  - `Dusart2018.v1.proposition_5_4` — cited — *sources not traced*
+- [`Lcm.v1.lcmUpto_not_highlyAbundant`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Lcm/v1/Conclusions.lean#L42) — verified
+  - [`Dusart2018.v1.proposition_5_4`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Dusart2018/v1/Conclusions.lean#L36) — cited — *sources not traced*
 
-- `Lcm.v2.lcmUpto_not_highlyAbundant_of_primeGap` — verified
+- [`Lcm.v2.lcmUpto_not_highlyAbundant_of_primeGap`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Lcm/v2/Conclusions.lean#L71) — verified
 
-- `MT.v1.zero_free_region` — cited — *sources not traced*
-  - `Kadiri2005.v1.zero_free_region` — cited — *sources not traced*
+- [`MT.v1.zero_free_region`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/MT/v1/Conclusions.lean#L33) — cited — *sources not traced*
+  - [`Kadiri2005.v1.zero_free_region`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Kadiri2005/v1/Conclusions.lean#L42) — cited — *sources not traced*
 
 ## What the network takes on trust
 
@@ -253,28 +291,28 @@ rather than maintained.
 
 | Claim | Evidence | Depended on by | Its own sources |
 |---|---|---:|---|
-| `FKBJ.v1.rh_up_to` | computation | 6 | **not yet traced** |
-| `PlattTrudgian.v1.rh_up_to` | cited | 3 | **not yet traced** |
-| `Buthe.v1.theorem_2_li_minus_pi` | cited | 2 | traced |
-| `FKS.v1.psi_classical_bound` | cited | 2 | traced |
-| `KLN.v1.subconvexity_bound` | cited | 2 | **not yet traced** |
-| `Kadiri2005.v1.zero_free_region` | cited | 2 | **not yet traced** |
-| `MT.v1.zero_free_region_sharpened` | cited | 2 | traced |
-| `BKLNW.v1.corollary_5_1` | cited | 1 | traced |
-| `BKLNW.v1.theta_error_le_one` | cited | 1 | **not yet traced** |
-| `Buthe.v1.theorem_2_li_gt_pi` | cited | 1 | traced |
-| `Buthe.v1.theorem_2_theta_lower` | cited | 1 | traced |
-| `Dusart2018.v1.proposition_5_4` | cited | 1 | **not yet traced** |
-| `BKLNW.v1.table8_psi_bound` | cited | 0 | **not yet traced** |
-| `BKLNW.v1.table8_psi_bound_above` | cited | 0 | **not yet traced** |
-| `Buthe.v1.theorem_2_li_minus_riemann_pi` | cited | 0 | traced |
-| `Buthe.v1.theorem_2_psi` | cited | 0 | traced |
-| `Buthe.v1.theorem_2_theta` | cited | 0 | traced |
-| `FKS.v1.psi_bound_all_x` | cited | 0 | traced |
-| `FKS2.v1.corollary_14` | cited | 0 | traced |
-| `FKS2.v1.corollary_23` | cited | 0 | traced |
-| `FKS2.v1.corollary_26` | cited | 0 | traced |
-| `MT.v1.zero_free_region` | cited | 0 | **not yet traced** |
+| [`FKBJ.v1.rh_up_to`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKBJ/v1/Conclusions.lean#L43) | computation | 6 | **not yet traced** |
+| [`PlattTrudgian.v1.rh_up_to`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/PlattTrudgian/v1/Conclusions.lean#L35) | cited | 3 | **not yet traced** |
+| [`Buthe.v1.theorem_2_li_minus_pi`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L63) | cited | 2 | traced |
+| [`FKS.v1.psi_classical_bound`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L63) | cited | 2 | traced |
+| [`KLN.v1.subconvexity_bound`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/KLN/v1/Conclusions.lean#L65) | cited | 2 | **not yet traced** |
+| [`Kadiri2005.v1.zero_free_region`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Kadiri2005/v1/Conclusions.lean#L42) | cited | 2 | **not yet traced** |
+| [`MT.v1.zero_free_region_sharpened`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/MT/v1/Conclusions.lean#L48) | cited | 2 | traced |
+| [`BKLNW.v1.corollary_5_1`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/BKLNW/v1/Conclusions.lean#L63) | cited | 1 | traced |
+| [`BKLNW.v1.theta_error_le_one`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/BKLNW/v1/Conclusions.lean#L107) | cited | 1 | **not yet traced** |
+| [`Buthe.v1.theorem_2_li_gt_pi`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L73) | cited | 1 | traced |
+| [`Buthe.v1.theorem_2_theta_lower`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L45) | cited | 1 | traced |
+| [`Dusart2018.v1.proposition_5_4`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Dusart2018/v1/Conclusions.lean#L36) | cited | 1 | **not yet traced** |
+| [`BKLNW.v1.table8_psi_bound`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/BKLNW/v1/Conclusions.lean#L78) | cited | 0 | **not yet traced** |
+| [`BKLNW.v1.table8_psi_bound_above`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/BKLNW/v1/Conclusions.lean#L94) | cited | 0 | **not yet traced** |
+| [`Buthe.v1.theorem_2_li_minus_riemann_pi`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L53) | cited | 0 | traced |
+| [`Buthe.v1.theorem_2_psi`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L31) | cited | 0 | traced |
+| [`Buthe.v1.theorem_2_theta`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L38) | cited | 0 | traced |
+| [`FKS.v1.psi_bound_all_x`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L44) | cited | 0 | traced |
+| [`FKS2.v1.corollary_14`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS2/v1/Conclusions.lean#L65) | cited | 0 | traced |
+| [`FKS2.v1.corollary_23`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS2/v1/Conclusions.lean#L78) | cited | 0 | traced |
+| [`FKS2.v1.corollary_26`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS2/v1/Conclusions.lean#L91) | cited | 0 | traced |
+| [`MT.v1.zero_free_region`](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/MT/v1/Conclusions.lean#L33) | cited | 0 | **not yet traced** |
 
 ## Nodes that state nothing yet
 

--- a/IEANTN/Nodes/Kadiri2005/v1/Challenge.lean
+++ b/IEANTN/Nodes/Kadiri2005/v1/Challenge.lean
@@ -15,3 +15,6 @@ import IEANTN.Nodes.Kadiri2005.v1.Conclusions
 Each `sorry` below is deliberate and permanent: a challenge *states*, it does not prove.
 How each conclusion is justified is recorded in `formalization.yaml`, not here.
 -/
+
+theorem Kadiri2005.v1.challenge_zero_free_region : Kadiri2005.v1.zero_free_region := by
+  sorry

--- a/IEANTN/Nodes/Kadiri2005/v1/Conclusions.lean
+++ b/IEANTN/Nodes/Kadiri2005/v1/Conclusions.lean
@@ -12,12 +12,34 @@ An explicit zero-free region of classical de la Vallee Poussin shape: zeta has n
 region defined by an explicit constant. The other analytic input, alongside a zero density
 estimate, to explicit bounds on the Chebyshev functions.
 
-**This node states nothing yet.** It records that the paper is in scope and carries its
-citation, so that a conclusion can be added the moment a downstream node needs one.
+Kadiri's value `R = 5.69693` is the one `MT` starts from: its Section 3 selects `R = 5.7` as the
+already-established region before iterating, and `5.7` is `Kadiri`'s value rounded off in the safe
+direction.
 
-What to add first:
+## The value, and which version of the paper it comes from
 
-The zero-free region, stated with its constant as a parameter rather than baked in, so that a
-later sharpening -- `MTY`, for instance -- can be swapped in by a downstream node without
-restating anything.
+The published paper (Acta Arith. **117** (2005), 303-339) gives `5.69693`, which is the value the
+whole subsequent literature cites and the one stated below. The arXiv preprint held in the local
+library, `math/0401238`, gives `5.70176` in its abstract -- a slightly weaker value that the
+published version improved. The published paper has not been obtained; `5.69693` is recorded here
+at second hand from `MT`, which states it twice (its Table 1 and its Section 2, where it also
+records the parameters Kadiri chose). See `docs/SOURCES.md`.
 -/
+
+namespace Kadiri2005.v1
+
+open IEANTN
+
+/-- **The zero-free region.** The classical zero-free region holds with `R = 5.69693`.
+
+`ζ` has no zeroes with `Re s ≥ 1 - 1/(R log |Im s|)` and `Im s ≥ 3`. Kadiri obtained this by
+an iterative procedure starting from Rosser and Schoenfeld's region and a height to which the
+Riemann hypothesis had been verified; `MT` Section 2 records the parameters.
+
+Note the shape. Kadiri states the region for `|Im s| ≥ 2`, and the vocabulary here requires
+`Im s ≥ 3`, so this conclusion is weaker than the paper on `2 ≤ |Im s| < 3`. That is the common
+denominator across the nodes that state a classical region, not a limitation of this paper. -/
+def zero_free_region : Prop :=
+  ClassicalZeroFreeRegion 5.69693
+
+end Kadiri2005.v1

--- a/IEANTN/Nodes/Kadiri2005/v1/formalization.yaml
+++ b/IEANTN/Nodes/Kadiri2005/v1/formalization.yaml
@@ -30,7 +30,27 @@ classification:
   arxiv: [math.NT]
   msc2020: ["11M26"]
 
-conclusions: []
+conclusions:
+- id: zero_free_region
+  declaration: Kadiri2005.v1.zero_free_region
+  challenge: Kadiri2005.v1.challenge_zero_free_region
+  imports: []
+  imports_status: undetermined
+  justifications:
+  - id: kadiri-paper
+    kind: literature
+    source: Kadiri2005
+    locator: the paper's main theorem, as reported by MT Table 1 and Section 2
+    note: >-
+      Recorded at second hand. The arXiv preprint held in the library, math/0401238, states 5.70176; the
+      published Acta Arith. version states 5.69693, which is what the subsequent literature cites and
+      what is stated here, on the authority of MT, which gives it twice. Obtaining the published paper
+      would move this to first hand. Imports: traced but not yet edges. MT Section 2 records that Kadiri
+      started from Rosser and Schoenfeld's R = 9.645908801 and the height T0 = 3330657430.697 established
+      by Wedeniwski's ZetaGrid computation. Rosser-Schoenfeld is a node but states nothing yet, and --
+      see that node -- its Theorem 1 is not of the shape ClassicalZeroFreeRegion, so the edge cannot be
+      drawn by restating it; Wedeniwski is not a node at all.
+  designated: kadiri-paper
 
 sources:
 - title: "Une region explicite sans zeros pour la fonction zeta de Riemann"
@@ -65,7 +85,13 @@ review:
 
 limitations:
 - >-
-  This node states nothing. It exists so that the network records the paper as in scope,
-  and so that the housekeeping queue asks for conclusions.
+  The conclusion rests on the cited paper, and on MT's report of it rather than on the paper itself; it
+  is not proved in Lean here.
 - >-
-  No novelty is claimed. The results are the cited authors'.
+  The value stated is the published one, 5.69693. The version held locally is the arXiv preprint, which
+  gives the weaker 5.70176.
+- >-
+  Kadiri states the region for |Im s| >= 2 and the vocabulary requires Im s >= 3, so real content is discarded
+  on 2 <= |Im s| < 3.
+- >-
+  No novelty is claimed. The result is Kadiri's.

--- a/IEANTN/Nodes/MT/v1/Challenge.lean
+++ b/IEANTN/Nodes/MT/v1/Challenge.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 IEANTN contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Terence Tao
 -/
+import IEANTN.Nodes.Kadiri2005.v1.Conclusions
 import IEANTN.Nodes.MT.v1.Conclusions
 import IEANTN.Nodes.PlattTrudgian.v1.Conclusions
 
@@ -17,10 +18,13 @@ Each `sorry` below is deliberate and permanent: a challenge *states*, it does no
 How each conclusion is justified is recorded in `formalization.yaml`, not here.
 -/
 
-theorem MT.v1.challenge_zero_free_region : MT.v1.zero_free_region := by
+theorem MT.v1.challenge_zero_free_region
+    (kadiri2005_v1_zero_free_region : Kadiri2005.v1.zero_free_region) :
+    MT.v1.zero_free_region := by
   sorry
 
 theorem MT.v1.challenge_zero_free_region_sharpened
+    (kadiri2005_v1_zero_free_region : Kadiri2005.v1.zero_free_region)
     (platttrudgian_v1_rh_up_to : PlattTrudgian.v1.rh_up_to) :
     MT.v1.zero_free_region_sharpened := by
   sorry

--- a/IEANTN/Nodes/MT/v1/formalization.yaml
+++ b/IEANTN/Nodes/MT/v1/formalization.yaml
@@ -33,23 +33,31 @@ conclusions:
 - id: zero_free_region
   declaration: MT.v1.zero_free_region
   challenge: MT.v1.challenge_zero_free_region
-  imports: []
+  imports:
+  - node: Kadiri2005.v1
+    conclusion: zero_free_region
   justifications:
   - id: mt-paper
     kind: literature
     source: MT
     locator: Theorem 1
     note: >-
-      Asserted on the authority of the paper. The unconditional headline value. Imports: none. Theorem
-      1 is the paper's unconditional value, established from nonnegative trigonometric polynomials without
-      a verification height -- unlike the Section 6.1 value below it, which is sharpened using one and
-      does import PlattTrudgian.v1.
+      Asserted on the authority of the paper. The unconditional headline value. Imports: this conclusion
+      previously recorded `none`, which was wrong -- an affirmative claim that Theorem 1 rests on nothing.
+      Section 3 says plainly: 'We select T0 = 3.06e10 as established in [10], t0 = 10^5, theta = 1.85573,
+      r = 5, and R = 5.7.' So Theorem 1 consumes both a height to which the Riemann hypothesis has been
+      verified and an already-established zero-free region, and then iterates. R = 5.7 is Kadiri's 5.69693
+      rounded off in the safe direction, so Kadiri2005.v1 is a genuine edge. The height is Platt, 'Computing
+      pi(x) analytically', the paper's [10], which is not held and not a node; that is why this is marked
+      undetermined rather than identified, one input of two being unrepresentable as an edge.
   designated: mt-paper
-  imports_status: none
+  imports_status: undetermined
 - id: zero_free_region_sharpened
   declaration: MT.v1.zero_free_region_sharpened
   challenge: MT.v1.challenge_zero_free_region_sharpened
   imports:
+  - node: Kadiri2005.v1
+    conclusion: zero_free_region
   - node: PlattTrudgian.v1
     conclusion: rh_up_to
   justifications:
@@ -58,12 +66,19 @@ conclusions:
     source: MT
     locator: Section 6.1
     note: >-
-      Asserted on the authority of the paper. FKS cites '[20, Theorem 1 and Section 6.1]' for R = 5.5666305
-      alongside the verification height H0 = 3 x 10^12, and Section 6.1 is where the constant is sharpened
-      using a partial verification of the Riemann hypothesis. Recorded separately from Theorem 1 because
-      it is a different claim resting on a different input. The dependence on the height is recorded as
-      an import rather than as a hypothesis in the statement; if the height ever changes this conclusion
-      should become a new version rather than be edited.
+      Asserted on the authority of the paper. Section 6.1 states: 'if T0 = 3e11, then by choosing theta
+      = 1.85567 with F16(phi), we obtain that R0 = 5.5666305 is permissible', and its footnote 1 reads
+      'The value T0 = 3e11 has been announced by Jan Buthe and Jens Franke in a personal communication.'
+      So the height this conclusion needs is 3e11, not the 3e12 that FKS quotes alongside it, and at the
+      time of publication that height rested on a personal communication -- the weakest provenance in
+      the network's vocabulary. The import of PlattTrudgian.v1 is therefore valid but not for the reason
+      previously recorded here: MT did not use Platt-Trudgian, which is six years later. What has happened
+      is that the hypothesis MT took on a private announcement is now implied by a published verification,
+      3e12 being comfortably past 3e11. Recording it this way is the point of the network: the claim's
+      real requirement is RiemannHypothesisUpTo 3e11, and any node meeting that discharges it. Kadiri2005.v1
+      is the second edge, as for Theorem 1. The dependence on the height is recorded as an import rather
+      than as a hypothesis in the statement; if the requirement ever changes this conclusion should become
+      a new version rather than be edited.
   designated: mt-paper
   imports_status: identified
 sources:
@@ -103,10 +118,21 @@ review:
 
 limitations:
 - >-
-  Both conclusions rest on the cited paper, which has not been read directly; the constants are transcribed
-  from FKS's citation of it.
+  Both conclusions rest on the cited paper; neither is proved in Lean here.
 - >-
-  The sharpened value of Section 6.1 is conditional on a verification height, recorded here as an import
-  of PlattTrudgian.v1. Whether the paper states it in exactly that form has not been checked.
+  The paper proves its region for |t| >= 2 and the vocabulary's ClassicalZeroFreeRegion requires Im s
+  >= 3, so real content is discarded on 2 <= |t| < 3. The same applies to MTY and Kadiri2005; 3 is the
+  common denominator, not any paper's own threshold.
 - >-
-  No novelty is claimed.
+  The paper is internally inconsistent about the boundary. Its abstract claims the closed region, 'no
+  zeros in the region sigma >= 1 - 1/(5.573412 log|t|)', while its Theorem 1 claims only the open one,
+  'sigma > 1 - ...'. The vocabulary states the closed form, which matches the abstract and matches both
+  Kadiri before it and MTY after it, each of which states >=. The strict inequality in Theorem 1 looks
+  like the anomaly, but it is the paper's own theorem statement, and a node that wanted to be certain
+  of the boundary case should not lean on this one.
+- >-
+  zero_free_region is marked undetermined although its inputs are known, because one of the two -- Platt,
+  'Computing pi(x) analytically' -- is not a node and so cannot be an edge. The vocabulary has no value
+  for 'traced, but not fully representable'.
+- >-
+  No novelty is claimed. The results are the paper's.

--- a/IEANTN/Nodes/RosserSchoenfeld/v1/Conclusions.lean
+++ b/IEANTN/Nodes/RosserSchoenfeld/v1/Conclusions.lean
@@ -2,6 +2,19 @@
 Copyright (c) 2026 IEANTN contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Terence Tao
+
+## A trap for whoever states the zero-free region
+
+Theorem 1 of the paper is **not** of the shape `ClassicalZeroFreeRegion R`. It reads: there are no
+zeros of `ζ` in the region `σ > 1 − 1/(R log|t/17|)` for `|t| ≥ 21`, with
+`R = 9.645908801`. Two differences matter. The denominator is `log|t/17|`, not `log|t|`, which
+makes the region *wider*; and the threshold is `|t| ≥ 21`, not `3`.
+
+So restating it as `ClassicalZeroFreeRegion 9.645908801` would be an over-claim: it would assert
+something on `3 ≤ t < 21` that the paper does not prove. Whoever states this conclusion should add
+the `log|t/17|` shape to Vocabulary rather than force it into the existing one. `Kadiri2005.v1`
+consumes exactly this theorem, so the shape is load-bearing, not cosmetic.
+
 -/
 import IEANTN.Vocabulary
 

--- a/STATE.md
+++ b/STATE.md
@@ -5,14 +5,14 @@
 Derived from node metadata alone. Receipt freshness needs Lean, and lives in
 `python scripts/ieantn.py status`.
 
-14 node version(s), 23 conclusion(s).  3 state nothing yet.
+14 node version(s), 24 conclusion(s).  2 state nothing yet.
 
 ## Evidence
 
 | Designated justification | Conclusions |
 |---|---:|
 | `lean-comparator` | 2 |
-| `literature` | 20 |
+| `literature` | 21 |
 | `numerical` | 1 |
 
 ## Nodes
@@ -37,11 +37,11 @@ Derived from node metadata alone. Receipt freshness needs Lean, and lives in
 | `FKS2.v1` | active | `corollary_23` | literature | 2 | - |
 | `FKS2.v1` | active | `corollary_26` | literature | 2 | - |
 | `KLN.v1` | active | `subconvexity_bound` | literature | 0 | - |
-| `Kadiri2005.v1` | stub | *(none yet)* | - | - | - |
+| `Kadiri2005.v1` | stub | `zero_free_region` | literature | 0 | - |
 | `Lcm.v1` | active | `lcmUpto_not_highlyAbundant` | lean-comparator | 1 | - |
 | `Lcm.v2` | active | `lcmUpto_not_highlyAbundant_of_primeGap` | lean-comparator | 0 | #10 |
-| `MT.v1` | active | `zero_free_region` | literature | 0 | - |
-| `MT.v1` | active | `zero_free_region_sharpened` | literature | 1 | - |
+| `MT.v1` | active | `zero_free_region` | literature | 1 | - |
+| `MT.v1` | active | `zero_free_region_sharpened` | literature | 2 | - |
 | `MTY.v1` | stub | *(none yet)* | - | - | - |
 | `PlattTrudgian.v1` | active | `rh_up_to` | literature | 0 | - |
 | `RosserSchoenfeld.v1` | stub | *(none yet)* | - | - | - |
@@ -56,6 +56,7 @@ downstream.
 | `FKBJ.v1.rh_up_to` | 6 |
 | `PlattTrudgian.v1.rh_up_to` | 3 |
 | `MT.v1.zero_free_region_sharpened` | 2 |
+| `Kadiri2005.v1.zero_free_region` | 2 |
 | `KLN.v1.subconvexity_bound` | 2 |
 | `FKS.v1.psi_classical_bound` | 2 |
 | `Buthe.v1.theorem_2_li_minus_pi` | 2 |

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -32,6 +32,7 @@ Mossinghoff–Trudgian's title, and BKLNW's own proof contradicts its displayed 
 | — | Johnston, *Improving bounds … by partial verification of RH* | [arXiv:2109.02249](https://arxiv.org/abs/2109.02249) | `Johnston2022-partial-verification.pdf` |
 | `FKBJ.v1` | Franke–Kleinjung–Büthe–Jost, *A practical analytic method for calculating π(x)* | Math. Comp. **86** (2017) no. 308, 2889–2909 | `FKBJ-practical-analytic-pi.pdf` |
 | — | Platt, *Isolating some non-trivial zeros of zeta* | Math. Comp. **86** (2017) 2449–2467 | `Platt2017-isolating-zeros.pdf` |
+| — | Platt–Trudgian, *The error term in the prime number theorem* | Math. Comp. **90** (2021) no. 328, 871–881 | `PlattTrudgian2021-error-term-PNT.pdf` |
 | `RosserSchoenfeld.v1` | Rosser–Schoenfeld, *Sharper bounds for θ(x) and ψ(x)* | Math. Comp. **29** (1975) 243–269 | `RosserSchoenfeld1975-sharper-bounds.pdf` |
 | `Dusart2018.v1` | Dusart, *Explicit estimates of some functions over primes* | [doi:10.1007/s11139-016-9839-4](https://doi.org/10.1007/s11139-016-9839-4) | `Dusart2018-explicit-estimates-published.pdf` |
 | — | Cheng–Graham, *Explicit estimates for the Riemann zeta function* | Rocky Mt. J. Math. **34** (2004) 1261–1280 | `ChengGraham2004-explicit-zeta.pdf` |
@@ -48,7 +49,9 @@ Not on arXiv, or not found there. Each blocks a specific piece of work.
 
 | Paper | Why it is needed | Blocks |
 |---|---|---|
-| Platt–Trudgian, *The error term in the prime number theorem*, Math. Comp. **90** (2021) no. 328, 871–881 | BKLNW's [37]. Supplies the `b ≥ 2500` half of BKLNW's Table 8. Distinct from BKLNW's [38], *The Riemann hypothesis is true up to 3·10¹²*, which is `PlattTrudgian.v1`. | `BKLNW.v1`'s Table 8 `imports_status` |
+| Platt, *Computing π(x) analytically*, Math. Comp. **84** (2015) | MT's [10]. The verification height `T₀ = 3.06·10¹⁰` that MT's Theorem 1 consumes. | `MT.v1.zero_free_region`'s `imports_status` |
+| Kadiri, *Une région explicite sans zéros pour ζ*, **published** Acta Arith. **117** (2005) 303–339 | We hold the arXiv preprint, which gives the weaker `5.70176`; the published version gives the `5.69693` everyone cites, and `Kadiri2005.v1` records it at second hand from MT. | moving `Kadiri2005.v1` to first hand |
+| Wedeniwski, *ZetaGrid* — the height `T₀ = 3 330 657 430.697` | Kadiri's verification height, per MT §2. A website rather than a paper, which is itself worth recording. | `Kadiri2005.v1`'s `imports_status` |
 | Kadiri–Lumley–Ng, *Bounding ψ(x) with zero-density*, preprint | Cited by FKS as [19]. Appears not to be publicly available, and not listed on the authors' pages. **Not** an input — the lemma attributed to it is proved in FKS itself — so this is for completeness rather than to unblock anything. | nothing |
 
 ## Adding to the library

--- a/fingerprints.json
+++ b/fingerprints.json
@@ -17,6 +17,7 @@
   "FKS2.v1.corollary_23": "a4e8b9028e790796ea6cfd90000b6a6c8128a62bc8b12351cc4986cd3483380a",
   "FKS2.v1.corollary_26": "b599170683ab0585cacde23f0aad801f36814b4ca3fda025c9575390fecd8191",
   "KLN.v1.subconvexity_bound": "7bf4e09385b1b412844527a59bcdae81b3b6e03790530cda3f0d09a154245647",
+  "Kadiri2005.v1.zero_free_region": "70d086ff86e52c2580350bdd5707dec2a93216ba2dfee58acb2abff79582157a",
   "Lcm.v1.lcmUpto_not_highlyAbundant": "7dd7914d659103ca6fef5fa518d4db55a8372b9161fd3e2966f1772976cdf4f0",
   "Lcm.v2.lcmUpto_not_highlyAbundant_of_primeGap": "90d4cacf4a5de6e381f02cabdb5b8d6b5f8bf442a7ce3f5197fefda84c80ee7a",
   "MT.v1.zero_free_region": "99f7229632e0e97ee79938750de57d42360efb8ba5d31d71de651927088657cd",

--- a/scripts/ieantn.py
+++ b/scripts/ieantn.py
@@ -1863,6 +1863,37 @@ EVIDENCE_STYLE = {
 }
 
 
+#: The hexagon a bridge is drawn as, and the arrows into and out of it.
+BRIDGE_STYLE = ("#8250df", "#fbefff")
+
+
+def bridges_in(nodes: dict) -> list[dict]:
+    """Every bridge in the network, as premises -> conclusion.
+
+    A bridge is *not* an edge. `from` may name several conclusions, so a bridge is a many-to-one
+    relation -- an implication with more than one hypothesis -- and an edge cannot carry that
+    without lying about which premises were needed together. Drawing the bridge itself as a node,
+    with an arrow in from each premise and one arrow out, is the ordinary way to draw a hyperedge
+    and costs nothing when there is only one premise.
+    """
+    found = []
+    for node_id, node in sorted(nodes.items()):
+        for conclusion in conclusions_of(node):
+            target = f"{node_id}.{conclusion.get('id')}"
+            designated = conclusion.get("designated")
+            for justification in conclusion.get("justifications") or []:
+                if justification.get("kind") != "bridged":
+                    continue
+                found.append({
+                    "id": f"{target}::{justification.get('id')}",
+                    "file": str(justification.get("bridge") or ""),
+                    "premises": bridge_sources(justification),
+                    "conclusion": target,
+                    "designated": justification.get("id") == designated,
+                })
+    return found
+
+
 #: Evidence kinds from weakest to strongest. A node is summarised by its *weakest* conclusion,
 #: because that is what a reader of the whole node is actually relying on: a node with nine
 #: verified claims and one bare assertion is, for anyone importing all ten, an assertion.
@@ -1907,6 +1938,15 @@ def render_node_overview(nodes: dict[str, dict], index: dict) -> list[str]:
         arrow = f"-->|{count}|" if count > 1 else "-->"
         lines.append(f"  N{mermaid_id(source_node)} {arrow} N{mermaid_id(target_node)}")
 
+    # Bridges are collapsed to node-to-node arrows here. The premises of one bridge may sit in
+    # different nodes, so this loses the "needed together" that the hexagon carries -- which is
+    # why the detailed picture keeps the hexagon and this one says only that a bridge exists.
+    crossings = {(premise.rsplit(".", 1)[0], bridge["conclusion"].rsplit(".", 1)[0])
+                 for bridge in bridges_in(nodes) for premise in bridge["premises"]}
+    for source_node, target_node in sorted(crossings):
+        if source_node != target_node and source_node in nodes and target_node in nodes:
+            lines.append(f"  N{mermaid_id(source_node)} ==>|bridge| N{mermaid_id(target_node)}")
+
     for node_id in sorted(nodes):
         cs = conclusions_of(nodes[node_id])
         if cs and any(import_status(c) == "undetermined" for c in cs):
@@ -1922,8 +1962,13 @@ def render_node_overview(nodes: dict[str, dict], index: dict) -> list[str]:
 
 
 def mermaid_id(key: str) -> str:
-    """Mermaid node ids may not contain dots."""
-    return key.replace(".", "_").replace("-", "_")
+    """A Mermaid node id: letters, digits and underscores only.
+
+    Dots, dashes and colons all appear in the keys this is called on -- `Lcm.v1.main`, the
+    `bridged` justification ids, the evidence kind `lean-comparator` -- and every one of them
+    ends a node id early in Mermaid, which fails at render time rather than here.
+    """
+    return re.sub(r"[^0-9A-Za-z_]", "_", key)
 
 
 def render_graph(nodes: dict[str, dict]) -> str:
@@ -1955,20 +2000,33 @@ def render_graph(nodes: dict[str, dict]) -> str:
         "been asked. A solid border means someone has traced it to its sources, and the arrows",
         "into it are the answer.",
         "",
+        "A **hexagon** is a *bridge*, and the thick arrows around it are a different relation from",
+        "the thin ones. A thin arrow into a box means the box **assumes** what the arrow comes",
+        "from, and nothing here checks the step. A bridge is the step itself, proved in Lean and",
+        "recompiled on every push. It is drawn as a box rather than an arrow because a bridge may",
+        "have several premises at once, which an arrow cannot say. A bridge marked *spare* is a",
+        "second ground for a claim that is currently justified some other way.",
+        "",
     ]
 
     # --- the two pictures ----------------------------------------------------------------
     class_defs = [
         f"  classDef {mermaid_id(kind)} fill:{fill},stroke:{stroke},color:#1f2328;"
         for kind, (_, stroke, fill) in EVIDENCE_STYLE.items()]
+    bridge_class_def = (f"  classDef bridge fill:{BRIDGE_STYLE[1]},stroke:{BRIDGE_STYLE[0]},"
+                        "color:#1f2328,stroke-width:2px;")
 
     lines += [
         "## The network at a glance",
         "",
-        "One box per node, so this stays readable as the network grows. The number on an arrow is",
-        "how many separate claims cross it. A node is coloured by its **weakest** conclusion,",
+        "One box per node, so this stays readable as the network grows. The number on a thin arrow",
+        "is how many separate claims cross it. A node is coloured by its **weakest** conclusion,",
         "since that is what someone importing the whole node is relying on, and dashed if any of",
         "its claims has not been traced to its own sources.",
+        "",
+        "A thick **bridge** arrow is a Lean-checked implication rather than an assumption. At this",
+        "resolution it says only that some bridge crosses between the two nodes; which premises a",
+        "bridge needed together is in the detailed picture below.",
         "",
     ]
     overview = render_node_overview(nodes, index)
@@ -2000,11 +2058,27 @@ def render_graph(nodes: dict[str, dict]) -> str:
             source = f"{dependency.get('node')}.{dependency.get('conclusion')}"
             if source in index:
                 lines.append(f"  {mermaid_id(source)} --> {mermaid_id(key)}")
+    bridges = bridges_in(nodes)
+    for bridge in bridges:
+        if bridge["conclusion"] not in index:
+            continue
+        stem = pathlib.PurePosixPath(bridge["file"]).stem or "bridge"
+        role = "" if bridge["designated"] else "<br/><i>spare</i>"
+        bid = "BR" + mermaid_id(bridge["id"])
+        lines.append(f'  {bid}{{{{"<b>{stem}</b>{role}"}}}}')
+        for premise in bridge["premises"]:
+            if premise in index:
+                lines.append(f"  {mermaid_id(premise)} ==> {bid}")
+        lines.append(f"  {bid} ==> {mermaid_id(bridge['conclusion'])}")
+
     for key in sorted(index):
         if import_status(index[key][1]) == "undetermined":
             lines.append(f"  style {mermaid_id(key)} stroke-dasharray: 6 4;")
     seen_kinds = {designated_kind(c) or "none-yet" for _, c in index.values()}
-    lines += class_defs
+    lines += class_defs + [bridge_class_def]
+    bridge_ids = ["BR" + mermaid_id(b["id"]) for b in bridges if b["conclusion"] in index]
+    if bridge_ids:
+        lines.append(f"  class {','.join(bridge_ids)} bridge;")
     for kind in sorted(seen_kinds):
         members = [mermaid_id(k) for k in sorted(index)
                    if (designated_kind(index[k][1]) or "none-yet") == kind]

--- a/scripts/ieantn.py
+++ b/scripts/ieantn.py
@@ -1863,6 +1863,31 @@ EVIDENCE_STYLE = {
 }
 
 
+def declaration_url(key: str) -> str | None:
+    """Where a reader can go to read the claim itself.
+
+    A graph of claims whose boxes cannot be clicked makes the reader take the node id, guess the
+    path, and search the file. This resolves the id to the exact line of the exact file.
+
+    Source links rather than generated documentation, for now, deliberately: they need no hosting,
+    no Pages, and no second build, and they cannot go stale relative to a commit. When doc-gen is
+    published this is the one function to change -- the URL becomes
+    `<pages>/docs/IEANTN/Nodes/<Family>/<version>/Conclusions.html#<declaration>` -- and every
+    caller follows.
+    """
+    node_id, _, cid = key.rpartition(".")
+    relative = pathlib.PurePosixPath("IEANTN/Nodes") / node_id.replace(".", "/") / "Conclusions.lean"
+    path = ROOT / relative
+    if not path.is_file():
+        return None
+    for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = line.lstrip()
+        for prefix in ("def ", "noncomputable def ", "abbrev "):
+            if stripped.startswith(prefix) and stripped[len(prefix):].split()[:1] == [cid]:
+                return f"{REPOSITORY_URL}/blob/main/{relative}#L{number}"
+    return None
+
+
 #: The hexagon a bridge is drawn as, and the arrows into and out of it.
 BRIDGE_STYLE = ("#8250df", "#fbefff")
 
@@ -1904,6 +1929,25 @@ def weakest_kind(conclusions: list[dict]) -> str:
     """The least-supported evidence kind among these conclusions."""
     kinds = [designated_kind(c) or "none-yet" for c in conclusions]
     return min(kinds, key=lambda k: EVIDENCE_ORDER.index(k) if k in EVIDENCE_ORDER else 0)
+
+
+def click_lines(index: dict, prefix: str = "", key=None) -> list[str]:
+    """`click` directives making the boxes navigable.
+
+    Mermaid renders these as links on GitHub. Emitted once per distinct target so the collapsed
+    view, whose boxes stand for whole nodes, links to the first claim in the node rather than
+    repeating a link per claim.
+    """
+    out, seen = [], set()
+    for conclusion_key in sorted(index):
+        box = (key(conclusion_key) if key else conclusion_key)
+        if box in seen:
+            continue
+        url = declaration_url(conclusion_key)
+        if url:
+            seen.add(box)
+            out.append(f'  click {prefix}{mermaid_id(box)} href "{url}" _blank')
+    return out
 
 
 def render_node_overview(nodes: dict[str, dict], index: dict) -> list[str]:
@@ -1957,6 +2001,7 @@ def render_node_overview(nodes: dict[str, dict], index: dict) -> list[str]:
                        if conclusions_of(nodes[n]) else "none-yet") == kind]
         if members:
             lines.append(f"  class {','.join(members)} {mermaid_id(kind)};")
+    lines += click_lines(index, prefix="N", key=lambda k: k.rsplit(".", 1)[0])
     lines += ["```", ""]
     return lines
 
@@ -1999,6 +2044,8 @@ def render_graph(nodes: dict[str, dict]) -> str:
         "not a claim that the box rests on nothing; it is an admission that the question has not",
         "been asked. A solid border means someone has traced it to its sources, and the arrows",
         "into it are the answer.",
+        "",
+        "Every box and every claim named below links to the line of Lean that states it.",
         "",
         "A **hexagon** is a *bridge*, and the thick arrows around it are a different relation from",
         "the thin ones. A thin arrow into a box means the box **assumes** what the arrow comes",
@@ -2084,6 +2131,7 @@ def render_graph(nodes: dict[str, dict]) -> str:
                    if (designated_kind(index[k][1]) or "none-yet") == kind]
         if members:
             lines.append(f"  class {','.join(members)} {mermaid_id(kind)};")
+    lines += click_lines(index)
     lines += ["```", ""]
 
     # --- what it rests on --------------------------------------------------------------
@@ -2104,7 +2152,9 @@ def render_graph(nodes: dict[str, dict]) -> str:
         repeated = " *(above)*" if key in seen else ""
         pending = (" — *sources not traced*"
                    if import_status(conclusion) == "undetermined" else "")
-        out.append(f"{mark}- `{key}` — {label}{repeated}{pending}")
+        url = declaration_url(key)
+        shown = f"[`{key}`]({url})" if url else f"`{key}`"
+        out.append(f"{mark}- {shown} — {label}{repeated}{pending}")
         if key in seen:
             return
         seen.add(key)
@@ -2139,8 +2189,10 @@ def render_graph(nodes: dict[str, dict]) -> str:
             label, _, _ = EVIDENCE_STYLE.get(kind, (kind, "", ""))
             traced = ("**not yet traced**"
                       if import_status(index[key][1]) == "undetermined" else "traced")
+            url = declaration_url(key)
+            shown = f"[`{key}`]({url})" if url else f"`{key}`"
             lines.append(
-                f"| `{key}` | {label} | {len(importers.get(key, []))} | {traced} |")
+                f"| {shown} | {label} | {len(importers.get(key, []))} | {traced} |")
         lines.append("")
 
     # --- nodes with nothing stated yet --------------------------------------------------

--- a/tests/test_ieantn.py
+++ b/tests/test_ieantn.py
@@ -547,6 +547,50 @@ class TestBridgesInTheGraph(FixtureRepo):
         self.assertEqual(ieantn.mermaid_id("Lcm.v1.main::br-2"), "Lcm_v1_main__br_2")
 
 
+class TestDeclarationLinks(FixtureRepo):
+    """Every claim in the graph links to the line of Lean that states it.
+
+    Without this a reader has the node id and nothing else: they must guess the path from the id
+    and then search the file. The link is to source rather than to generated documentation because
+    source needs no hosting and no second build; `declaration_url` is the single place to change
+    when doc-gen is published.
+    """
+
+    def _lean(self, body: str) -> None:
+        path = self.root / "IEANTN" / "Nodes" / "A" / "v1" / "Conclusions.lean"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+
+    def test_it_finds_the_defining_line(self) -> None:
+        self.write_node("A.v1", LITERATURE)
+        self._lean("import X" + chr(10) + chr(10) + "def other : Prop := True"
+                   + chr(10) + "def main : Prop := True" + chr(10))
+        self.assertTrue(ieantn.declaration_url("A.v1.main").endswith("Conclusions.lean#L4"))
+
+    def test_a_noncomputable_definition_is_found_too(self) -> None:
+        self.write_node("A.v1", LITERATURE)
+        self._lean("noncomputable def main : Prop := True" + chr(10))
+        self.assertTrue(ieantn.declaration_url("A.v1.main").endswith("#L1"))
+
+    def test_a_name_that_merely_starts_the_same_is_not_matched(self) -> None:
+        """`main_lemma` must not answer for `main`, or the link lands on the wrong claim."""
+        self.write_node("A.v1", LITERATURE)
+        self._lean("def main_lemma : Prop := True" + chr(10) + "def main : Prop := True" + chr(10))
+        self.assertTrue(ieantn.declaration_url("A.v1.main").endswith("#L2"))
+
+    def test_a_missing_declaration_gives_no_link_rather_than_a_wrong_one(self) -> None:
+        self.write_node("A.v1", LITERATURE)
+        self._lean("def something_else : Prop := True" + chr(10))
+        self.assertIsNone(ieantn.declaration_url("A.v1.main"))
+
+    def test_the_page_makes_the_boxes_clickable(self) -> None:
+        self.write_node("A.v1", LITERATURE)
+        self._lean("def main : Prop := True" + chr(10))
+        rendered = ieantn.render_graph(ieantn.load_nodes())
+        self.assertIn("click A_v1_main href", rendered)
+        self.assertIn("[`A.v1.main`](", rendered)
+
+
 class TestGraphPage(FixtureRepo):
     """`GRAPH.md`: the network as a page someone can read without cloning anything.
 
@@ -578,9 +622,9 @@ class TestGraphPage(FixtureRepo):
         self._chain()
         rendered = ieantn.render_graph(ieantn.load_nodes())
         trees = rendered.split("## What each result rests on")[1].split("##")[0]
-        self.assertIn("- `A.v1.main`", trees)
-        self.assertNotIn("@- `Upstream.v1.main`", trees.replace("@", ""))
-        self.assertIn("  - `Upstream.v1.main`", trees)
+        self.assertIn("- [`A.v1.main`](", trees)
+        self.assertNotIn("@- [`Upstream.v1.main`](", trees.replace("@", ""))
+        self.assertIn("  - [`Upstream.v1.main`](", trees)
 
     def test_the_trust_table_ranks_by_dependants(self) -> None:
         """The honest answer to "how good is the evidence" is which unproved claims carry the most

--- a/tests/test_ieantn.py
+++ b/tests/test_ieantn.py
@@ -493,6 +493,60 @@ class TestNodeOverview(FixtureRepo):
         self.assertIn('subgraph sgUpstream_v1["Upstream.v1"]', rendered)
 
 
+class TestBridgesInTheGraph(FixtureRepo):
+    """A bridge is drawn as a node, not an arrow.
+
+    Two reasons, and the second is the one that forces it. First, an import arrow and a bridge are
+    different relations -- one says "assumes, unchecked", the other says "proved in Lean, and
+    recompiled on every push" -- and drawing them alike would make the picture claim more or less
+    verification than there is. Second, `from` may name several conclusions, so a bridge is an
+    implication with several hypotheses; an arrow cannot say which premises were needed together,
+    and a node with several arrows into it can.
+    """
+
+    def _bridged(self, premises: list[str]) -> dict:
+        self.write_node("Up.v1", LITERATURE)
+        self.write_node("Up2.v1", LITERATURE)
+        body = LITERATURE.replace(
+            "  designated:",
+            "    - id: br" + chr(10)
+            + "      kind: bridged" + chr(10)
+            + "      from: [" + ", ".join(premises) + "]" + chr(10)
+            + "      bridge: IEANTN/Bridges/Fam/Sewn.lean" + chr(10)
+            + "  designated:")
+        self.write_node("A.v1", body)
+        return ieantn.load_nodes()
+
+    def test_a_many_premise_bridge_is_one_node_with_two_arrows_in(self) -> None:
+        nodes = self._bridged(["Up.v1.main", "Up2.v1.main"])
+        found = ieantn.bridges_in(nodes)
+        self.assertEqual(len(found), 1)
+        self.assertEqual(sorted(found[0]["premises"]), ["Up.v1.main", "Up2.v1.main"])
+        rendered = ieantn.render_graph(nodes)
+        self.assertIn("Up_v1_main ==> BR", rendered)
+        self.assertIn("Up2_v1_main ==> BR", rendered)
+
+    def test_the_bridge_node_is_a_hexagon_named_for_its_file(self) -> None:
+        rendered = ieantn.render_graph(self._bridged(["Up.v1.main"]))
+        self.assertIn('{{"<b>Sewn</b>', rendered)
+
+    def test_a_bridge_that_is_not_designated_says_so(self) -> None:
+        """A spare ground is still real evidence and still worth drawing, but a reader should not
+        mistake it for the one the claim currently rests on."""
+        rendered = ieantn.render_graph(self._bridged(["Up.v1.main"]))
+        self.assertIn("<i>spare</i>", rendered)
+
+    def test_the_overview_shows_a_bridge_between_the_nodes(self) -> None:
+        nodes = self._bridged(["Up.v1.main"])
+        rendered = chr(10).join(
+            ieantn.render_node_overview(nodes, ieantn.index_conclusions(nodes)))
+        self.assertIn("NUp_v1 ==>|bridge| NA_v1", rendered)
+
+    def test_mermaid_ids_survive_dots_dashes_and_colons(self) -> None:
+        """Every one of these appears in a real key, and each ends a Mermaid id early."""
+        self.assertEqual(ieantn.mermaid_id("Lcm.v1.main::br-2"), "Lcm_v1_main__br_2")
+
+
 class TestGraphPage(FixtureRepo):
     """`GRAPH.md`: the network as a page someone can read without cloning anything.
 


### PR DESCRIPTION
Two things, taken in order.

## Bridges are drawn as nodes, not edges

An import arrow and a bridge are different relations. A thin arrow into a box means the box *assumes* what the arrow comes from, and nothing here checks the step. A bridge is the step, proved in Lean and recompiled on every push. Drawn alike, the picture would claim more or less verification than the network actually has.

And `from` may already name several conclusions — `bridge_sources` has handled that since it was written. That makes a bridge an implication with several hypotheses, and an arrow cannot say which premises were needed *together*. A node with several arrows into it can. So a bridge is a hexagon, with a thick arrow in from each premise and one out.

The overview collapses bridges to a thick node-to-node arrow, and says that it loses the "needed together".

Also hardens `mermaid_id`, which stripped dots and dashes but not colons — and justification ids now reach it. A bad id there fails when GitHub renders the page, not in CI.

## Backtracking

See the commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)