### PR TITLE
Fix Mermaid click links, and make the receipt job regenerate all three derived files

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -159,8 +159,15 @@ jobs:
           fi
           git config user.name "ieantn-verifier[bot]"
           git config user.email "ieantn-verifier@users.noreply.github.com"
+          # Designating a `lean-comparator` justification changes the node's evidence kind, and
+          # three generated files depend on it, not one: STATE.md, GRAPH.md (box colour, and the
+          # conclusion leaves the "taken on trust" table) and docs/nodes/. `check` verifies all
+          # three, so regenerating only STATE.md would push a receipt whose own pull request fails
+          # CI -- with the one file nobody may edit by hand sitting in it.
           python3 scripts/ieantn.py state
-          git add receipts/ IEANTN/Nodes/ STATE.md
+          python3 scripts/ieantn.py graph
+          python3 scripts/ieantn.py pages
+          git add receipts/ IEANTN/Nodes/ STATE.md GRAPH.md docs/nodes/
           git diff --cached --quiet && { echo "nothing to record"; exit 0; }
           git commit -m "Record verification receipt for $NODE"
           git push origin HEAD:"refs/heads/$BRANCH"

--- a/GRAPH.md
+++ b/GRAPH.md
@@ -79,20 +79,20 @@ graph LR
   class NBKLNW_v1,NButhe_v1,NDusart2018_v1,NFKS_v1,NFKS2_v1,NKLN_v1,NKadiri2005_v1,NMT_v1,NPlattTrudgian_v1 literature;
   class NFKBJ_v1,NPlatt2015_v1 numerical;
   class NLcm_v1,NLcm_v2 lean_comparator;
-  click NBKLNW_v1 href "docs/nodes/BKLNW-v1.md" _blank
-  click NButhe_v1 href "docs/nodes/Buthe-v1.md" _blank
-  click NDusart2018_v1 href "docs/nodes/Dusart2018-v1.md" _blank
-  click NFKBJ_v1 href "docs/nodes/FKBJ-v1.md" _blank
-  click NFKS_v1 href "docs/nodes/FKS-v1.md" _blank
-  click NFKS2_v1 href "docs/nodes/FKS2-v1.md" _blank
-  click NKLN_v1 href "docs/nodes/KLN-v1.md" _blank
-  click NKadiri2005_v1 href "docs/nodes/Kadiri2005-v1.md" _blank
-  click NLcm_v1 href "docs/nodes/Lcm-v1.md" _blank
-  click NLcm_v2 href "docs/nodes/Lcm-v2.md" _blank
-  click NMT_v1 href "docs/nodes/MT-v1.md" _blank
-  click NPlatt2015_v1 href "docs/nodes/Platt2015-v1.md" _blank
-  click NPlattTrudgian_v1 href "docs/nodes/PlattTrudgian-v1.md" _blank
-  click NZeroFreeHeight_v1 href "docs/nodes/ZeroFreeHeight-v1.md" _blank
+  click NBKLNW_v1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md" _blank
+  click NButhe_v1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe-v1.md" _blank
+  click NDusart2018_v1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Dusart2018-v1.md" _blank
+  click NFKBJ_v1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/FKBJ-v1.md" _blank
+  click NFKS_v1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/FKS-v1.md" _blank
+  click NFKS2_v1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/FKS2-v1.md" _blank
+  click NKLN_v1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/KLN-v1.md" _blank
+  click NKadiri2005_v1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Kadiri2005-v1.md" _blank
+  click NLcm_v1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Lcm-v1.md" _blank
+  click NLcm_v2 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Lcm-v2.md" _blank
+  click NMT_v1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/MT-v1.md" _blank
+  click NPlatt2015_v1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Platt2015-v1.md" _blank
+  click NPlattTrudgian_v1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/PlattTrudgian-v1.md" _blank
+  click NZeroFreeHeight_v1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/ZeroFreeHeight-v1.md" _blank
   classDef lean_comparator fill:#dafbe1,stroke:#1a7f37,color:#1f2328;
   classDef numerical fill:#fff8c5,stroke:#9a6700,color:#1f2328;
   classDef literature fill:#ddf4ff,stroke:#0969da,color:#1f2328;
@@ -211,32 +211,32 @@ graph LR
   class BKLNW_v1_corollary_5_1,BKLNW_v1_table8_psi_bound,BKLNW_v1_table8_psi_bound_above,BKLNW_v1_theta_error_le_one,Buthe_v1_theorem_2_li_gt_pi,Buthe_v1_theorem_2_li_minus_pi,Buthe_v1_theorem_2_li_minus_riemann_pi,Buthe_v1_theorem_2_psi,Buthe_v1_theorem_2_theta,Buthe_v1_theorem_2_theta_lower,Dusart2018_v1_proposition_5_4,FKS_v1_psi_bound_all_x,FKS_v1_psi_classical_bound,FKS2_v1_corollary_14,FKS2_v1_corollary_23,FKS2_v1_corollary_26,KLN_v1_subconvexity_bound,Kadiri2005_v1_zero_free_region,MT_v1_zero_free_region,MT_v1_zero_free_region_sharpened,PlattTrudgian_v1_rh_up_to literature;
   class ZeroFreeHeight_v1_classical_region_descends none_yet;
   class FKBJ_v1_rh_up_to,Platt2015_v1_rh_up_to numerical;
-  click BKLNW_v1_corollary_5_1 href "docs/nodes/BKLNW-v1.md#corollary_5_1" _blank
-  click BKLNW_v1_table8_psi_bound href "docs/nodes/BKLNW-v1.md#table8_psi_bound" _blank
-  click BKLNW_v1_table8_psi_bound_above href "docs/nodes/BKLNW-v1.md#table8_psi_bound_above" _blank
-  click BKLNW_v1_theta_error_le_one href "docs/nodes/BKLNW-v1.md#theta_error_le_one" _blank
-  click Buthe_v1_theorem_2_li_gt_pi href "docs/nodes/Buthe-v1.md#theorem_2_li_gt_pi" _blank
-  click Buthe_v1_theorem_2_li_minus_pi href "docs/nodes/Buthe-v1.md#theorem_2_li_minus_pi" _blank
-  click Buthe_v1_theorem_2_li_minus_riemann_pi href "docs/nodes/Buthe-v1.md#theorem_2_li_minus_riemann_pi" _blank
-  click Buthe_v1_theorem_2_psi href "docs/nodes/Buthe-v1.md#theorem_2_psi" _blank
-  click Buthe_v1_theorem_2_theta href "docs/nodes/Buthe-v1.md#theorem_2_theta" _blank
-  click Buthe_v1_theorem_2_theta_lower href "docs/nodes/Buthe-v1.md#theorem_2_theta_lower" _blank
-  click Dusart2018_v1_proposition_5_4 href "docs/nodes/Dusart2018-v1.md#proposition_5_4" _blank
-  click FKBJ_v1_rh_up_to href "docs/nodes/FKBJ-v1.md#rh_up_to" _blank
-  click FKS_v1_psi_bound_all_x href "docs/nodes/FKS-v1.md#psi_bound_all_x" _blank
-  click FKS_v1_psi_classical_bound href "docs/nodes/FKS-v1.md#psi_classical_bound" _blank
-  click FKS2_v1_corollary_14 href "docs/nodes/FKS2-v1.md#corollary_14" _blank
-  click FKS2_v1_corollary_23 href "docs/nodes/FKS2-v1.md#corollary_23" _blank
-  click FKS2_v1_corollary_26 href "docs/nodes/FKS2-v1.md#corollary_26" _blank
-  click KLN_v1_subconvexity_bound href "docs/nodes/KLN-v1.md#subconvexity_bound" _blank
-  click Kadiri2005_v1_zero_free_region href "docs/nodes/Kadiri2005-v1.md#zero_free_region" _blank
-  click Lcm_v1_lcmUpto_not_highlyAbundant href "docs/nodes/Lcm-v1.md#lcmUpto_not_highlyAbundant" _blank
-  click Lcm_v2_lcmUpto_not_highlyAbundant_of_primeGap href "docs/nodes/Lcm-v2.md#lcmUpto_not_highlyAbundant_of_primeGap" _blank
-  click MT_v1_zero_free_region href "docs/nodes/MT-v1.md#zero_free_region" _blank
-  click MT_v1_zero_free_region_sharpened href "docs/nodes/MT-v1.md#zero_free_region_sharpened" _blank
-  click Platt2015_v1_rh_up_to href "docs/nodes/Platt2015-v1.md#rh_up_to" _blank
-  click PlattTrudgian_v1_rh_up_to href "docs/nodes/PlattTrudgian-v1.md#rh_up_to" _blank
-  click ZeroFreeHeight_v1_classical_region_descends href "docs/nodes/ZeroFreeHeight-v1.md#classical_region_descends" _blank
+  click BKLNW_v1_corollary_5_1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#corollary_5_1" _blank
+  click BKLNW_v1_table8_psi_bound href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#table8_psi_bound" _blank
+  click BKLNW_v1_table8_psi_bound_above href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#table8_psi_bound_above" _blank
+  click BKLNW_v1_theta_error_le_one href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#theta_error_le_one" _blank
+  click Buthe_v1_theorem_2_li_gt_pi href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe-v1.md#theorem_2_li_gt_pi" _blank
+  click Buthe_v1_theorem_2_li_minus_pi href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe-v1.md#theorem_2_li_minus_pi" _blank
+  click Buthe_v1_theorem_2_li_minus_riemann_pi href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe-v1.md#theorem_2_li_minus_riemann_pi" _blank
+  click Buthe_v1_theorem_2_psi href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe-v1.md#theorem_2_psi" _blank
+  click Buthe_v1_theorem_2_theta href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe-v1.md#theorem_2_theta" _blank
+  click Buthe_v1_theorem_2_theta_lower href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe-v1.md#theorem_2_theta_lower" _blank
+  click Dusart2018_v1_proposition_5_4 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Dusart2018-v1.md#proposition_5_4" _blank
+  click FKBJ_v1_rh_up_to href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/FKBJ-v1.md#rh_up_to" _blank
+  click FKS_v1_psi_bound_all_x href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/FKS-v1.md#psi_bound_all_x" _blank
+  click FKS_v1_psi_classical_bound href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/FKS-v1.md#psi_classical_bound" _blank
+  click FKS2_v1_corollary_14 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/FKS2-v1.md#corollary_14" _blank
+  click FKS2_v1_corollary_23 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/FKS2-v1.md#corollary_23" _blank
+  click FKS2_v1_corollary_26 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/FKS2-v1.md#corollary_26" _blank
+  click KLN_v1_subconvexity_bound href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/KLN-v1.md#subconvexity_bound" _blank
+  click Kadiri2005_v1_zero_free_region href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Kadiri2005-v1.md#zero_free_region" _blank
+  click Lcm_v1_lcmUpto_not_highlyAbundant href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Lcm-v1.md#lcmUpto_not_highlyAbundant" _blank
+  click Lcm_v2_lcmUpto_not_highlyAbundant_of_primeGap href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Lcm-v2.md#lcmUpto_not_highlyAbundant_of_primeGap" _blank
+  click MT_v1_zero_free_region href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/MT-v1.md#zero_free_region" _blank
+  click MT_v1_zero_free_region_sharpened href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/MT-v1.md#zero_free_region_sharpened" _blank
+  click Platt2015_v1_rh_up_to href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Platt2015-v1.md#rh_up_to" _blank
+  click PlattTrudgian_v1_rh_up_to href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/PlattTrudgian-v1.md#rh_up_to" _blank
+  click ZeroFreeHeight_v1_classical_region_descends href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/ZeroFreeHeight-v1.md#classical_region_descends" _blank
 ```
 
 ## What each result rests on

--- a/scripts/ieantn.py
+++ b/scripts/ieantn.py
@@ -2004,7 +2004,7 @@ def click_lines(index: dict, prefix: str = "", key=None) -> list[str]:
         if box in seen:
             continue
         node_id, _, cid = conclusion_key.rpartition(".")
-        url = node_page_url(node_id, "" if key else cid, from_root=True)
+        url = node_page_url(node_id, "" if key else cid, absolute=True)
         seen.add(box)
         out.append(f'  click {prefix}{mermaid_id(box)} href "{url}" _blank')
     return out
@@ -2286,13 +2286,25 @@ def node_page_path(node_id: str) -> pathlib.Path:
     return PAGES / f"{node_id.replace('.', '-')}.md"
 
 
-def node_page_url(node_id: str, anchor: str = "", from_root: bool = False) -> str:
+def node_page_url(node_id: str, anchor: str = "", from_root: bool = False,
+                  absolute: bool = False) -> str:
     """A link to a node's page.
 
-    `from_root` because GRAPH.md sits at the repository root and the node pages link to each other
-    from inside `docs/nodes/`; a path that is right for one is broken for the other.
+    Three forms, and all three are needed.
+
+    `from_root` because GRAPH.md sits at the repository root while the node pages link to each
+    other from inside `docs/nodes/`; a path right for one is broken for the other.
+
+    `absolute` because GitHub renders Mermaid in a sandboxed iframe served from
+    `viewscreen.githubusercontent.com`, so a relative `click` href resolves against *that* origin
+    and 404s — `https://viewscreen.githubusercontent.com/markdown/docs/nodes/Lcm-v1.md` is what a
+    reader actually got. Ordinary Markdown links on the same page are fine, because they are
+    rendered in the repository's own context; only the diagram is sandboxed. This is invisible
+    locally and invisible in CI: it can only be caught by clicking a box on GitHub.
     """
     fragment = f"#{anchor}" if anchor else ""
+    if absolute:
+        return f"{REPOSITORY_URL}/blob/main/docs/nodes/{node_id.replace('.', '-')}.md{fragment}"
     prefix = "docs/nodes/" if from_root else ""
     return f"{prefix}{node_id.replace('.', '-')}.md{fragment}"
 

--- a/tests/test_ieantn.py
+++ b/tests/test_ieantn.py
@@ -642,6 +642,16 @@ class TestNodePages(FixtureRepo):
         self._node("def main : Prop := True" + chr(10))
         self.assertIn("](docs/nodes/A-v1.md#main)", ieantn.render_graph(ieantn.load_nodes()))
 
+    def test_mermaid_clicks_are_absolute(self) -> None:
+        """GitHub renders Mermaid in a sandbox on viewscreen.githubusercontent.com, so a relative
+        click href resolves against that origin and 404s. Markdown links on the same page are
+        fine. Nothing local or in CI can catch this, so it is pinned here."""
+        self._node("def main : Prop := True" + chr(10))
+        rendered = ieantn.render_graph(ieantn.load_nodes())
+        for line in rendered.splitlines():
+            if line.strip().startswith("click "):
+                self.assertIn('href "https://github.com/', line)
+
     def test_a_page_for_a_node_that_no_longer_exists_is_removed(self) -> None:
         self._node("def main : Prop := True" + chr(10))
         ieantn.pages(False)


### PR DESCRIPTION
Two fixes, both invisible to every check we have.

## Mermaid click links 404

Every clickable box in `GRAPH.md` was broken. GitHub renders Mermaid in a sandboxed iframe served from `viewscreen.githubusercontent.com`, so a relative `click` href resolves against *that* origin — clicking `Lcm.v1` landed on `https://viewscreen.githubusercontent.com/markdown/docs/nodes/Lcm-v1.md`.

The Markdown links further down the same page were always fine: they render in the repository's own context, and only the diagram is sandboxed. This looked correct everywhere — the file matches what `graph` generates, paths resolve on a local clone, and CI compares generated output rather than following links. A test now pins every `click` line to an absolute URL.

## The receipt job regenerated one derived file out of three

**This blocks the next verification, so it should land first.**

Designating a `lean-comparator` justification changes the node's evidence kind, and `STATE.md`, `GRAPH.md` and `docs/nodes/` all depend on it. The Commit step regenerated only `STATE.md`, because it was written when that was the only one. The next receipt would have arrived in a pull request failing `check` on two stale files — with the one artefact nobody may edit by hand sitting in it.

`verify.yml` is the only job in the repository holding a write token, so the diff deserves the scrutiny that implies: it adds two generator calls and two paths to `git add`, grants nothing, reads no new input, and both generators are pure functions of metadata already in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)