### PR TITLE
Record the Comparator receipt for ZeroFreeHeight.v1

### DIFF
--- a/GRAPH.md
+++ b/GRAPH.md
@@ -54,7 +54,7 @@ graph LR
   NPlatt2015_v1["<b>Platt2015.v1</b><br/>1 claim<br/><i>weakest: computation</i>"]
   NPlattTrudgian_v1["<b>PlattTrudgian.v1</b><br/>1 claim<br/><i>weakest: cited</i>"]
   NRosserSchoenfeld_v1["<b>RosserSchoenfeld.v1</b><br/><i>nothing stated yet</i>"]
-  NZeroFreeHeight_v1["<b>ZeroFreeHeight.v1</b><br/>1 claim<br/><i>weakest: unjustified</i>"]
+  NZeroFreeHeight_v1["<b>ZeroFreeHeight.v1</b><br/>1 claim<br/><i>weakest: verified</i>"]
   NBKLNW_v1 -->|2| NFKS2_v1
   NButhe_v1 --> NBKLNW_v1
   NButhe_v1 -->|3| NFKS2_v1
@@ -75,10 +75,10 @@ graph LR
   style NKadiri2005_v1 stroke-dasharray: 6 4;
   style NPlatt2015_v1 stroke-dasharray: 6 4;
   style NPlattTrudgian_v1 stroke-dasharray: 6 4;
-  class NMTY_v1,NRosserSchoenfeld_v1,NZeroFreeHeight_v1 none_yet;
+  class NMTY_v1,NRosserSchoenfeld_v1 none_yet;
   class NBKLNW_v1,NButhe_v1,NDusart2018_v1,NFKS_v1,NFKS2_v1,NKLN_v1,NKadiri2005_v1,NMT_v1,NPlattTrudgian_v1 literature;
   class NFKBJ_v1,NPlatt2015_v1 numerical;
-  class NLcm_v1,NLcm_v2 lean_comparator;
+  class NLcm_v1,NLcm_v2,NZeroFreeHeight_v1 lean_comparator;
   click NBKLNW_v1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md" _blank
   click NButhe_v1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe-v1.md" _blank
   click NDusart2018_v1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Dusart2018-v1.md" _blank
@@ -160,7 +160,7 @@ graph LR
     PlattTrudgian_v1_rh_up_to["<b>rh_up_to</b><br/><i>cited</i>"]
   end
   subgraph sgZeroFreeHeight_v1["ZeroFreeHeight.v1"]
-    ZeroFreeHeight_v1_classical_region_descends["<b>classical_region_descends</b><br/><i>unjustified</i>"]
+    ZeroFreeHeight_v1_classical_region_descends["<b>classical_region_descends</b><br/><i>verified</i>"]
   end
   Buthe_v1_theorem_2_theta_lower --> BKLNW_v1_corollary_5_1
   FKBJ_v1_rh_up_to --> Buthe_v1_theorem_2_li_gt_pi
@@ -207,9 +207,8 @@ graph LR
   classDef none_yet fill:#ffebe9,stroke:#cf222e,color:#1f2328;
   classDef bridge fill:#fbefff,stroke:#8250df,color:#1f2328,stroke-width:2px;
   class BRLcm_v1_lcmUpto_not_highlyAbundant__bridge_from_v2 bridge;
-  class Lcm_v1_lcmUpto_not_highlyAbundant,Lcm_v2_lcmUpto_not_highlyAbundant_of_primeGap lean_comparator;
+  class Lcm_v1_lcmUpto_not_highlyAbundant,Lcm_v2_lcmUpto_not_highlyAbundant_of_primeGap,ZeroFreeHeight_v1_classical_region_descends lean_comparator;
   class BKLNW_v1_corollary_5_1,BKLNW_v1_table8_psi_bound,BKLNW_v1_table8_psi_bound_above,BKLNW_v1_theta_error_le_one,Buthe_v1_theorem_2_li_gt_pi,Buthe_v1_theorem_2_li_minus_pi,Buthe_v1_theorem_2_li_minus_riemann_pi,Buthe_v1_theorem_2_psi,Buthe_v1_theorem_2_theta,Buthe_v1_theorem_2_theta_lower,Dusart2018_v1_proposition_5_4,FKS_v1_psi_bound_all_x,FKS_v1_psi_classical_bound,FKS2_v1_corollary_14,FKS2_v1_corollary_23,FKS2_v1_corollary_26,KLN_v1_subconvexity_bound,Kadiri2005_v1_zero_free_region,MT_v1_zero_free_region,MT_v1_zero_free_region_sharpened,PlattTrudgian_v1_rh_up_to literature;
-  class ZeroFreeHeight_v1_classical_region_descends none_yet;
   class FKBJ_v1_rh_up_to,Platt2015_v1_rh_up_to numerical;
   click BKLNW_v1_corollary_5_1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#corollary_5_1" _blank
   click BKLNW_v1_table8_psi_bound href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#table8_psi_bound" _blank
@@ -301,7 +300,7 @@ A line is one claim, indented under whatever assumes it.
   - [`Kadiri2005.v1.zero_free_region`](docs/nodes/Kadiri2005-v1.md#zero_free_region) — cited — *sources not traced*
   - [`Platt2015.v1.rh_up_to`](docs/nodes/Platt2015-v1.md#rh_up_to) — computation — *sources not traced*
 
-- [`ZeroFreeHeight.v1.classical_region_descends`](docs/nodes/ZeroFreeHeight-v1.md#classical_region_descends) — unjustified
+- [`ZeroFreeHeight.v1.classical_region_descends`](docs/nodes/ZeroFreeHeight-v1.md#classical_region_descends) — verified
 
 ## What the network takes on trust
 
@@ -334,7 +333,6 @@ rather than maintained.
 | [`FKS2.v1.corollary_23`](docs/nodes/FKS2-v1.md#corollary_23) | cited | 0 | traced |
 | [`FKS2.v1.corollary_26`](docs/nodes/FKS2-v1.md#corollary_26) | cited | 0 | traced |
 | [`MT.v1.zero_free_region`](docs/nodes/MT-v1.md#zero_free_region) | cited | 0 | traced |
-| [`ZeroFreeHeight.v1.classical_region_descends`](docs/nodes/ZeroFreeHeight-v1.md#classical_region_descends) | unjustified | 0 | traced |
 
 ## Nodes that state nothing yet
 

--- a/IEANTN/Nodes/ZeroFreeHeight/v1/formalization.yaml
+++ b/IEANTN/Nodes/ZeroFreeHeight/v1/formalization.yaml
@@ -6,7 +6,7 @@ node:
   family: ZeroFreeHeight
   version: v1
   kind: folklore
-  status: awaiting-verification # change this once the node is filled in
+  status: active                # change this once the node is filled in
 
 project:
   name: Lowering the height of a classical zero-free region
@@ -51,7 +51,10 @@ conclusions:
       Mathlib's riemannZeta_ne_zero_of_one_le_re and therefore not a network edge. A Lean solution exists
       in Solutions/ZeroFreeHeight.v1 and is awaiting Comparator; until a receipt is written this node
       is unjustified, and the justification must not be edited by hand.
-  designated: folklore-lean
+  - id: comparator
+    kind: lean-comparator
+    note: 'Comparator accepted the solution. Run: https://github.com/teorth/IEANTN/actions/runs/33003934956'
+  designated: comparator
   issue: 30
 sources:
 - title: Lowering the height threshold of a classical zero-free region

--- a/IEANTN/Nodes/ZeroFreeHeight/v1/formalization.yaml
+++ b/IEANTN/Nodes/ZeroFreeHeight/v1/formalization.yaml
@@ -6,7 +6,7 @@ node:
   family: ZeroFreeHeight
   version: v1
   kind: folklore
-  status: active                # change this once the node is filled in
+  status: active
 
 project:
   name: Lowering the height of a classical zero-free region

--- a/STATE.md
+++ b/STATE.md
@@ -11,9 +11,8 @@ Derived from node metadata alone. Receipt freshness needs Lean, and lives in
 
 | Designated justification | Conclusions |
 |---|---:|
-| `lean-comparator` | 2 |
+| `lean-comparator` | 3 |
 | `literature` | 21 |
-| `none-yet` | 1 |
 | `numerical` | 2 |
 
 ## Nodes
@@ -47,7 +46,7 @@ Derived from node metadata alone. Receipt freshness needs Lean, and lives in
 | `Platt2015.v1` | stub | `rh_up_to` | numerical | 0 | - |
 | `PlattTrudgian.v1` | active | `rh_up_to` | literature | 0 | - |
 | `RosserSchoenfeld.v1` | stub | *(none yet)* | - | - | - |
-| `ZeroFreeHeight.v1` | awaiting-verification | `classical_region_descends` | none-yet | 0 | #30 |
+| `ZeroFreeHeight.v1` | active | `classical_region_descends` | lean-comparator | 0 | #30 |
 
 ## Leverage
 

--- a/docs/nodes/README.md
+++ b/docs/nodes/README.md
@@ -21,5 +21,5 @@ One page per node: what it claims, in Lean and in prose, and everything recorded
 | [`Platt2015.v1`](Platt2015-v1.md) | computation | 1 | computation |
 | [`PlattTrudgian.v1`](PlattTrudgian-v1.md) | computation | 1 | cited |
 | [`RosserSchoenfeld.v1`](RosserSchoenfeld-v1.md) | paper | 0 | — |
-| [`ZeroFreeHeight.v1`](ZeroFreeHeight-v1.md) | folklore | 1 | unjustified |
+| [`ZeroFreeHeight.v1`](ZeroFreeHeight-v1.md) | folklore | 1 | verified |
 

--- a/docs/nodes/ZeroFreeHeight-v1.md
+++ b/docs/nodes/ZeroFreeHeight-v1.md
@@ -7,7 +7,7 @@
 | | |
 |---|---|
 | Kind | folklore |
-| Status | awaiting-verification |
+| Status | active |
 | Maintainers | Terence Tao |
 | Licence | Apache-2.0 |
 | Review | self-assessed |
@@ -53,14 +53,18 @@ def classical_region_descends : Prop :=
 | Lean name | `ZeroFreeHeight.v1.classical_region_descends` |
 | Challenge | `ZeroFreeHeight.v1.challenge_classical_region_descends` |
 | Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/ZeroFreeHeight/v1/Conclusions.lean#L69) |
-| Evidence | unjustified (`none-yet`) |
+| Evidence | verified (`lean-comparator`) |
 | Sources traced | none |
 | Assumes | nothing recorded |
 | Assumed by | nothing yet |
 
-**Justification `folklore-lean`** — **designated** — none-yet
+**Justification `folklore-lean`** — none-yet
 
 > Imports none, and that is a real `none` rather than an untraced `undetermined`: the statement is a conditional whose two analytic inputs are its own hypotheses -- a verification of the Riemann hypothesis and a zero-free region -- so a consumer supplies them rather than this node importing them. The only external fact used is the classical non-vanishing of zeta on Re s >= 1, which is Mathlib's riemannZeta_ne_zero_of_one_le_re and therefore not a network edge. A Lean solution exists in Solutions/ZeroFreeHeight.v1 and is awaiting Comparator; until a receipt is written this node is unjustified, and the justification must not be edited by hand.
+
+**Justification `comparator`** — **designated** — lean-comparator
+
+> Comparator accepted the solution. Run: https://github.com/teorth/IEANTN/actions/runs/33003934956
 
 ## Limitations
 

--- a/receipts/ZeroFreeHeight.v1.classical_region_descends.json
+++ b/receipts/ZeroFreeHeight.v1.classical_region_descends.json
@@ -1,0 +1,28 @@
+{
+  "challenge": "ZeroFreeHeight.v1.challenge_classical_region_descends",
+  "conclusion": "ZeroFreeHeight.v1.classical_region_descends",
+  "environment": {
+    "lean_toolchain": "leanprover/lean4:v4.34.0-rc2",
+    "mathlib_rev": "5b1c3618759375e0ef0033d39000b1338e99f133"
+  },
+  "repository": {
+    "commit": "00ee45dc6e430e1e31b2592bc42fd75a28a5e6cd"
+  },
+  "run": {
+    "recorded_at": "2026-08-26T20:01:01Z",
+    "workflow_run": "https://github.com/teorth/IEANTN/actions/runs/33003934956"
+  },
+  "schema": 2,
+  "solution": {
+    "project": "Solutions/ZeroFreeHeight.v1"
+  },
+  "statement": {
+    "ZeroFreeHeight.v1.classical_region_descends": "796809d584f97568c9b74fbd219ee65b3a6a70a0b52a2660f08e8302be76a367"
+  },
+  "tools": {
+    "comparator": "10dd2b33dc43751af3257f4d684535375306f162",
+    "landrun": "811cfff51ceaf3d9843708aa6d22e9b84ccac8b4",
+    "lean4export": "cacf989bd75f608700820f6afc595f32e7a99a4d",
+    "nanoda": "68d5ca9db226849b41a6fff59d796ff19d0a8840"
+  }
+}


### PR DESCRIPTION
Closes #30.

Comparator accepted `ZeroFreeHeight.v1.classical_region_descends`, written by the verification workflow at [run 33003934956](https://github.com/teorth/IEANTN/actions/runs/33003934956). The node moves from `awaiting-verification` to `active`, and its designated justification from `none-yet` to `lean-comparator`.

**This is the third verified node, and the first that isn't `Lcm`** — and the first folklore one, which is the case the kind was added for: a step used without comment throughout the literature, now checkable.

## What the receipt records

Schema 2: the statement fingerprints, the environment, `repository.commit` `00ee45d`, and pinned revisions for all three tools (Comparator, landrun, lean4export). Staleness is derived from those rather than stored.

## The workflow itself was under test here

Both prior receipts were written when `STATE.md` was the only derived file. This is the first run against the three-file world, and the first for a node whose evidence kind actually changes on the graph and its node page — so it exercised #31's fix directly. The receipt commit touched `GRAPH.md`, `docs/nodes/README.md` and `docs/nodes/ZeroFreeHeight-v1.md` alongside `STATE.md`, and `check` passes. Without that fix this pull request would have arrived failing on two stale files.

The one blemish found: `new-node` writes `status: template  # change this once the node is filled in`, and `record-receipt` rewrites the value without touching the comment, so a verified node carried an instruction to change something already changed. Removed here; the comment belongs to the template value rather than the key, which is worth fixing in the tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)