### PR TITLE
ieantn.py verify: say when a run is waiting on a human

### DIFF
--- a/scripts/ieantn.py
+++ b/scripts/ieantn.py
@@ -39,6 +39,7 @@ import os
 import pathlib
 import re
 import subprocess
+import time
 import sys
 
 try:
@@ -476,6 +477,89 @@ def check_receipts(online: bool = True) -> bool:
             )
 
     return problems.report("receipt provenance")
+
+
+def repository_slug() -> str | None:
+    """`owner/name` for `origin`, or None if there is no usable remote."""
+    remote = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        cwd=ROOT, capture_output=True, text=True, encoding="utf-8",
+    ).stdout.strip()
+    return re.sub(r"^.*github\.com[:/]|\.git$", "", remote) if remote else None
+
+
+def _gh_json(args: list[str]) -> str:
+    finished = subprocess.run(["gh", *args], cwd=ROOT, capture_output=True, text=True,
+                              encoding="utf-8")
+    return finished.stdout.strip() if finished.returncode == 0 else ""
+
+
+def verify(node: str, branch: str, dispatch: bool) -> bool:
+    """Dispatch `verify.yml` and follow it, making the approval gate impossible to miss.
+
+    This exists because `gh run watch` draws a run that has not started identically to one that is
+    building: a spinner and a job name. A verification sits at the `verification` environment gate
+    until a maintainer approves it, and the difference is plainly visible in the API -- `status` is
+    `waiting` and no step has run -- but nothing surfaces it. Someone once waited thirty-two
+    minutes for a run that had executed nothing at all.
+
+    It cannot approve anything, and must not be able to. Approval is the one privileged act in this
+    repository, and the gate exists precisely because a human is supposed to have looked at the
+    branch. All this does is refuse to draw a progress spinner over a request for attention.
+    """
+    repository = repository_slug()
+    if not repository:
+        print("no `origin` remote; cannot find the run")
+        return False
+
+    if dispatch:
+        started = subprocess.run(
+            ["gh", "workflow", "run", "verify.yml", "-f", f"node={node}", "-f", f"branch={branch}"],
+            cwd=ROOT, capture_output=True, text=True, encoding="utf-8")
+        if started.returncode != 0:
+            print(f"dispatch failed: {started.stderr.strip()}")
+            return False
+        print(f"dispatched verify.yml for {node} on {branch}")
+        time.sleep(5)
+
+    run_id = _gh_json(["run", "list", "--workflow=verify.yml", "--limit", "1",
+                       "--json", "databaseId", "--jq", ".[0].databaseId"])
+    if not run_id:
+        print("no verification run found")
+        return False
+    url = f"https://github.com/{repository}/actions/runs/{run_id}"
+
+    announced = False
+    while True:
+        status = _gh_json(["api", f"repos/{repository}/actions/runs/{run_id}",
+                           "--jq", "[.status, .conclusion] | @tsv"]).split("\t")
+        state, conclusion = (status + ["", ""])[:2]
+
+        if state == "waiting":
+            if not announced:
+                print()
+                print("=" * 72)
+                print("  WAITING FOR YOUR APPROVAL -- nothing is running yet.")
+                print()
+                print(f"    {url}")
+                print("    Review deployments -> verification -> Approve and deploy")
+                print()
+                print("  Approving means vouching for this branch's core Lean, not its solution:")
+                print("  the receipt job runs `lake build` on it while holding a write token.")
+                print("=" * 72)
+                print()
+                announced = True
+        elif state == "completed":
+            print(f"run {run_id} completed: {conclusion}")
+            print(f"  {url}")
+            if conclusion == "success":
+                print("  the receipt is on the branch; open a pull request for it")
+            return conclusion == "success"
+        else:
+            jobs = _gh_json(["api", f"repos/{repository}/actions/runs/{run_id}/jobs",
+                             "--jq", r'.jobs[] | "\(.name): \(.status)"'])
+            print(f"[{state}] " + " | ".join(jobs.split("\n")) if jobs else f"[{state}]")
+        time.sleep(20)
 
 
 def check_closure() -> bool:
@@ -3211,6 +3295,11 @@ def main() -> int:
     picture.add_argument("--check", action="store_true", help="fail instead of rewriting")
     per_node = sub.add_parser("pages")
     per_node.add_argument("--check", action="store_true", help="fail instead of rewriting")
+    verification = sub.add_parser("verify")
+    verification.add_argument("node", help="e.g. Lcm.v1")
+    verification.add_argument("--branch", required=True, help="branch to record the receipt on")
+    verification.add_argument("--watch-only", action="store_true",
+                              help="follow the latest run instead of dispatching a new one")
     snapshot = sub.add_parser("state")
     snapshot.add_argument("--check", action="store_true", help="fail instead of rewriting")
     fresh = sub.add_parser("new-node")
@@ -3270,6 +3359,8 @@ def main() -> int:
         return 0 if graph(args.check) else 1
     if args.command == "pages":
         return 0 if pages(args.check) else 1
+    if args.command == "verify":
+        return 0 if verify(args.node, args.branch, not args.watch_only) else 1
     if args.command == "spinoff":
         return 0 if spinoff(args.conclusion, args.out, args.compile) else 1
     if args.command == "new-version":

--- a/tests/test_ieantn.py
+++ b/tests/test_ieantn.py
@@ -25,6 +25,7 @@ import pathlib
 import tempfile
 import textwrap
 import unittest
+import unittest.mock
 
 _SPEC = importlib.util.spec_from_file_location(
     "ieantn", pathlib.Path(__file__).resolve().parent.parent / "scripts" / "ieantn.py"
@@ -675,6 +676,55 @@ class TestNodePages(FixtureRepo):
         ieantn.pages(False)
         page = (self.root / "docs" / "nodes" / "Empty-v1.md").read_text(encoding="utf-8")
         self.assertIn("states nothing yet", page)
+
+
+class TestVerifyApprovalNotice(FixtureRepo):
+    """A verification parked at the approval gate must say so.
+
+    `gh run watch` draws a run that has not started identically to one that is building, and the
+    difference is plainly visible in the API. Someone once waited thirty-two minutes for a run that
+    had executed nothing at all.
+    """
+
+    def _run(self, states: list[str]) -> str:
+        """Drive `verify` through a scripted sequence of run states."""
+        remaining = list(states)
+
+        def fake(args: list[str]) -> str:
+            if args[0] == "run":
+                return "424242"
+            if args[-1].endswith("@tsv"):
+                state = remaining.pop(0)
+                return state + ("\tsuccess" if state == "completed" else "\t")
+            return ""
+
+        printed = io.StringIO()
+        with unittest.mock.patch.object(ieantn, "_gh_json", fake), \
+             unittest.mock.patch.object(ieantn.time, "sleep", lambda _: None), \
+             unittest.mock.patch.object(ieantn, "repository_slug", lambda: "teorth/IEANTN"), \
+             contextlib.redirect_stdout(printed):
+            ieantn.verify("A.v1", "some-branch", dispatch=False)
+        return printed.getvalue()
+
+    def test_a_waiting_run_asks_for_approval_and_gives_the_url(self) -> None:
+        out = self._run(["waiting", "completed"])
+        self.assertIn("WAITING FOR YOUR APPROVAL", out)
+        self.assertIn("https://github.com/teorth/IEANTN/actions/runs/424242", out)
+
+    def test_it_says_what_approving_means(self) -> None:
+        """The gate exists because a human is supposed to have looked at the branch."""
+        self.assertIn("vouching for this branch's core Lean", self._run(["waiting", "completed"]))
+
+    def test_the_notice_is_printed_once_not_every_poll(self) -> None:
+        out = self._run(["waiting", "waiting", "waiting", "completed"])
+        self.assertEqual(out.count("WAITING FOR YOUR APPROVAL"), 1)
+
+    def test_a_run_that_never_waits_says_nothing_about_approval(self) -> None:
+        self.assertNotIn("WAITING", self._run(["in_progress", "completed"]))
+
+    def test_the_conclusion_is_reported(self) -> None:
+        out = self._run(["completed"])
+        self.assertIn("completed: success", out)
 
 
 class TestGraphPage(FixtureRepo):


### PR DESCRIPTION
`gh run watch` draws a run that has not started identically to one that is building: a spinner and a job name. A verification sits at the `verification` environment gate until a maintainer approves it, and the difference is plain in the API — `status` is `waiting`, no step has run, `updatedAt` is seconds after `createdAt`. Nothing surfaced it, and the last verification sat unattended for 32 minutes having executed nothing.

```
python scripts/ieantn.py verify ZeroFreeHeight.v1 --branch verify/zerofreeheight-v1
```

dispatches and follows the run, printing an unmissable block with the approval URL and what approving commits you to. `--watch-only` follows the latest run without dispatching.

**It cannot approve, and must not be able to.** Approval is the one privileged act in this repository and the gate exists precisely because a human is supposed to have looked at the branch. All this does is refuse to draw a progress spinner over a request for attention.

Tests were mutation-checked rather than merely run: announcing on every poll instead of once fails one of them, and dropping the waiting branch fails three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)