### PR TITLE
Stub sweep: fourteen nodes whose prose outlived the stub it was written for

### DIFF
--- a/IEANTN/Nodes/BKLNW/v1/formalization.yaml
+++ b/IEANTN/Nodes/BKLNW/v1/formalization.yaml
@@ -1,7 +1,4 @@
 # Node metadata for `BKLNW.v1`.  See docs/NODES.md.
-#
-# A stub: the paper is in scope and cited, and no claim has been transcribed from it yet.
-# `conclusions` is deliberately empty -- see the module docstring in Conclusions.lean.
 version: "v0.4"
 
 node:
@@ -183,9 +180,10 @@ automation:
     models: ["Claude Opus 5 (Anthropic)"]
     framework: "Claude Code"
     role: >-
-      Created this stub and transcribed its bibliographic record from the PNT+
-      bibliography, under the direction of the maintainer. No mathematical claim is
-      made and no statement has been transcribed from the paper.
+      Transcribed four statements from the arXiv preprint 2002.11068v2 -- including the
+      definition of f at its equation (2.4), read off the rendered page because the
+      plain-text extraction was unusable -- and recorded what each rests on, under the
+      direction of the maintainer. No proof is claimed.
 
 review:
   status: self-assessed
@@ -193,7 +191,8 @@ review:
   notes: >-
     Statements read from the arXiv preprint 2002.11068v2 directly, including the definition of f in equation
     (2.4), which the plain-text extraction rendered unusably and which was read off the rendered page
-    instead. Not checked against the published Math. Comp. version.
+    instead. The published Math. Comp. version is held in the library but has not been checked against
+    these statements.
 
 limitations:
 - >-

--- a/IEANTN/Nodes/Brown1967/v1/formalization.yaml
+++ b/IEANTN/Nodes/Brown1967/v1/formalization.yaml
@@ -1,4 +1,4 @@
-# Node metadata for `KLN.v1`.  See docs/NODES.md.
+# Node metadata for `Brown1967.v1`.  See docs/NODES.md.
 #
 # A stub: the paper is in scope and cited, and no claim has been transcribed from it yet.
 # `conclusions` is deliberately empty -- see the module docstring in Conclusions.lean.

--- a/IEANTN/Nodes/Buthe2016/v1/formalization.yaml
+++ b/IEANTN/Nodes/Buthe2016/v1/formalization.yaml
@@ -1,4 +1,4 @@
-# Node metadata for `Buthe.v1`.  See docs/NODES.md.
+# Node metadata for `Buthe2016.v1`.  See docs/NODES.md.
 version: "v0.4"
 
 node:

--- a/IEANTN/Nodes/ChengGraham2004/v1/formalization.yaml
+++ b/IEANTN/Nodes/ChengGraham2004/v1/formalization.yaml
@@ -1,4 +1,4 @@
-# Node metadata for `KLN.v1`.  See docs/NODES.md.
+# Node metadata for `ChengGraham2004.v1`.  See docs/NODES.md.
 #
 # A stub: the paper is in scope and cited, and no claim has been transcribed from it yet.
 # `conclusions` is deliberately empty -- see the module docstring in Conclusions.lean.

--- a/IEANTN/Nodes/Dusart2018/v1/formalization.yaml
+++ b/IEANTN/Nodes/Dusart2018/v1/formalization.yaml
@@ -1,4 +1,4 @@
-# Node metadata for `Dusart2018`.
+# Node metadata for `Dusart2018.v1`.
 #
 # Shaped as a superset of Palomar's formalization.yaml so that a sufficiently-justified
 # conclusion can be spun off as a submission without restructuring. The `node`, `conclusions`

--- a/IEANTN/Nodes/FKS/v1/formalization.yaml
+++ b/IEANTN/Nodes/FKS/v1/formalization.yaml
@@ -1,7 +1,4 @@
 # Node metadata for `FKS.v1`.  See docs/NODES.md.
-#
-# A stub: the paper is in scope and cited, and no claim has been transcribed from it yet.
-# `conclusions` is deliberately empty -- see the module docstring in Conclusions.lean.
 version: "v0.4"
 
 node:
@@ -126,17 +123,18 @@ automation:
     models: ["Claude Opus 5 (Anthropic)"]
     framework: "Claude Code"
     role: >-
-      Created this stub and transcribed its bibliographic record from the PNT+
-      bibliography, under the direction of the maintainer. No mathematical claim is
-      made and no statement has been transcribed from the paper.
+      Transcribed two statements from the paper and recorded what they rest on, under the
+      direction of the maintainer. The bibliographic record came from PrimeNumberTheoremAnd's
+      references.bib rather than the paper; see the review notes. No proof is claimed.
 
 review:
   status: self-assessed
   reviewers: ["Terence Tao"]
   notes: >-
     Bibliographic details taken from blueprint/src/references.bib in PrimeNumberTheoremAnd
-    rather than from the printed paper. Verify them against the paper before this node is
-    cited externally or used as the basis for a submission.
+    rather than from the printed paper. The published JMAA version is now held in the library;
+    verify them against it before this node is cited externally or used as the basis for a
+    submission. That check would also settle the numbering discrepancy noted below.
 
 limitations:
 - >-

--- a/IEANTN/Nodes/Hiary2016/v1/formalization.yaml
+++ b/IEANTN/Nodes/Hiary2016/v1/formalization.yaml
@@ -1,7 +1,4 @@
-# Node metadata for `KLN.v1`.  See docs/NODES.md.
-#
-# A stub: the paper is in scope and cited, and no claim has been transcribed from it yet.
-# `conclusions` is deliberately empty -- see the module docstring in Conclusions.lean.
+# Node metadata for `Hiary2016.v1`.  See docs/NODES.md.
 version: "v0.4"
 
 node:

--- a/IEANTN/Nodes/KLN/v1/formalization.yaml
+++ b/IEANTN/Nodes/KLN/v1/formalization.yaml
@@ -1,7 +1,4 @@
 # Node metadata for `KLN.v1`.  See docs/NODES.md.
-#
-# A stub: the paper is in scope and cited, and no claim has been transcribed from it yet.
-# `conclusions` is deliberately empty -- see the module docstring in Conclusions.lean.
 version: "v0.4"
 
 node:
@@ -105,17 +102,18 @@ automation:
     models: ["Claude Opus 5 (Anthropic)"]
     framework: "Claude Code"
     role: >-
-      Created this stub and transcribed its bibliographic record from the PNT+
-      bibliography, under the direction of the maintainer. No mathematical claim is
-      made and no statement has been transcribed from the paper.
+      Transcribed Lemma 3.2 from the arXiv preprint 2101.12263v1, applied FKS's correction to
+      the constant it quotes from Hiary, and stated Platt-Trudgian's simplified form of
+      Theorem 1.1, under the direction of the maintainer. No proof is claimed.
 
 review:
   status: self-assessed
   reviewers: ["Terence Tao"]
   notes: >-
     Lemma 3.2 read from the arXiv preprint 2101.12263v1 directly. The correction to its constant is FKS's,
-    read from the published J. Math. Anal. Appl. version. Neither the published KLN nor any recomputation
-    of its tables has been consulted.
+    read from the published J. Math. Anal. Appl. version. The published KLN -- J. Math. Anal. Appl. 465
+    (2018) 22-46, doi:10.1016/j.jmaa.2018.04.071 -- is now held in the library, but neither it nor any
+    recomputation of its tables has been consulted for these statements.
 
 limitations:
 - >-

--- a/IEANTN/Nodes/Kadiri2005/v1/formalization.yaml
+++ b/IEANTN/Nodes/Kadiri2005/v1/formalization.yaml
@@ -1,7 +1,4 @@
 # Node metadata for `Kadiri2005.v1`.  See docs/NODES.md.
-#
-# A stub: the paper is in scope and cited, and no claim has been transcribed from it yet.
-# `conclusions` is deliberately empty -- see the module docstring in Conclusions.lean.
 version: "v0.4"
 
 node:
@@ -82,17 +79,21 @@ automation:
     models: ["Claude Opus 5 (Anthropic)"]
     framework: "Claude Code"
     role: >-
-      Created this stub and transcribed its bibliographic record from the PNT+
-      bibliography, under the direction of the maintainer. No mathematical claim is
-      made and no statement has been transcribed from the paper.
+      Transcribed Theoreme 1.1 first hand from the published Acta Arith. version and recorded
+      what it rests on, under the direction of the maintainer. No proof is claimed.
 
 review:
   status: self-assessed
   reviewers: ["Terence Tao"]
   notes: >-
-    Bibliographic details taken from blueprint/src/references.bib in PrimeNumberTheoremAnd
-    rather than from the printed paper. Verify them against the paper before this node is
-    cited externally or used as the basis for a submission.
+    Theoreme 1.1 was read first hand from the published Acta Arith. version, which the library holds,
+    and its constant, threshold and closed form all agree with what is stated here. The bibliographic
+    record -- originally taken from blueprint/src/references.bib in PrimeNumberTheoremAnd -- has since
+    been checked against the paper itself: the article's own first page reads ACTA ARITHMETICA 117.4
+    (2005), and it runs 37 pages ending at 339, which is the recorded 303-339. Note that `sources[].id`
+    still points at the arXiv preprint, which is the version that does NOT support this conclusion; the
+    source note records why. Replacing it with the published DOI would be the honest fix, and has not
+    been done here because the paper prints no DOI and guessing at one is how a citation goes wrong.
 
 limitations:
 - >-

--- a/IEANTN/Nodes/Platt2017/v1/formalization.yaml
+++ b/IEANTN/Nodes/Platt2017/v1/formalization.yaml
@@ -1,4 +1,4 @@
-# Node metadata for `FKBJ.v1`.  See docs/NODES.md.
+# Node metadata for `Platt2017.v1`.  See docs/NODES.md.
 version: "v0.4"
 
 node:

--- a/IEANTN/Nodes/PlattTrudgian2021/v1/formalization.yaml
+++ b/IEANTN/Nodes/PlattTrudgian2021/v1/formalization.yaml
@@ -1,4 +1,4 @@
-# Node metadata for `Buthe.v1`.  See docs/NODES.md.
+# Node metadata for `PlattTrudgian2021.v1`.  See docs/NODES.md.
 version: "v0.4"
 
 node:

--- a/IEANTN/Nodes/RosserSchoenfeld/v1/formalization.yaml
+++ b/IEANTN/Nodes/RosserSchoenfeld/v1/formalization.yaml
@@ -1,7 +1,4 @@
 # Node metadata for `RosserSchoenfeld.v1`.  See docs/NODES.md.
-#
-# A stub: the paper is in scope and cited, and no claim has been transcribed from it yet.
-# `conclusions` is deliberately empty -- see the module docstring in Conclusions.lean.
 version: "v0.4"
 
 node:
@@ -86,9 +83,9 @@ automation:
     models: ["Claude Opus 5 (Anthropic)"]
     framework: "Claude Code"
     role: >-
-      Created this stub and transcribed its bibliographic record from the PNT+
-      bibliography, under the direction of the maintainer. No mathematical claim is
-      made and no statement has been transcribed from the paper.
+      Transcribed Theorem 1 from the paper, stated the classical shape it bridges to, and
+      recorded what each rests on, under the direction of the maintainer. The bridge between
+      the two is proved in Lean and recompiled on every push.
 
 review:
   status: self-assessed

--- a/IEANTN/Nodes/Trudgian2011/v1/formalization.yaml
+++ b/IEANTN/Nodes/Trudgian2011/v1/formalization.yaml
@@ -1,7 +1,4 @@
-# Node metadata for `KLN.v1`.  See docs/NODES.md.
-#
-# A stub: the paper is in scope and cited, and no claim has been transcribed from it yet.
-# `conclusions` is deliberately empty -- see the module docstring in Conclusions.lean.
+# Node metadata for `Trudgian2011.v1`.  See docs/NODES.md.
 version: "v0.4"
 
 node:

--- a/IEANTN/Nodes/Wedeniwski/v1/formalization.yaml
+++ b/IEANTN/Nodes/Wedeniwski/v1/formalization.yaml
@@ -1,4 +1,4 @@
-# Node metadata for `FKBJ.v1`.  See docs/NODES.md.
+# Node metadata for `Wedeniwski.v1`.  See docs/NODES.md.
 version: "v0.4"
 
 node:

--- a/docs/nodes/BKLNW-v1.md
+++ b/docs/nodes/BKLNW-v1.md
@@ -161,7 +161,7 @@ Recorded by the node itself, not derived.
 
 ## How this node was made
 
-- **agent** (Claude Opus 5 (Anthropic)) — Created this stub and transcribed its bibliographic record from the PNT+ bibliography, under the direction of the maintainer. No mathematical claim is made and no statement has been transcribed from the paper.
+- **agent** (Claude Opus 5 (Anthropic)) — Transcribed four statements from the arXiv preprint 2002.11068v2 -- including the definition of f at its equation (2.4), read off the rendered page because the plain-text extraction was unusable -- and recorded what each rests on, under the direction of the maintainer. No proof is claimed.
 
 ---
 

--- a/docs/nodes/FKS-v1.md
+++ b/docs/nodes/FKS-v1.md
@@ -98,7 +98,7 @@ Recorded by the node itself, not derived.
 
 ## How this node was made
 
-- **agent** (Claude Opus 5 (Anthropic)) — Created this stub and transcribed its bibliographic record from the PNT+ bibliography, under the direction of the maintainer. No mathematical claim is made and no statement has been transcribed from the paper.
+- **agent** (Claude Opus 5 (Anthropic)) — Transcribed two statements from the paper and recorded what they rest on, under the direction of the maintainer. The bibliographic record came from PrimeNumberTheoremAnd's references.bib rather than the paper; see the review notes. No proof is claimed.
 
 ---
 

--- a/docs/nodes/KLN-v1.md
+++ b/docs/nodes/KLN-v1.md
@@ -114,7 +114,7 @@ Recorded by the node itself, not derived.
 
 ## How this node was made
 
-- **agent** (Claude Opus 5 (Anthropic)) — Created this stub and transcribed its bibliographic record from the PNT+ bibliography, under the direction of the maintainer. No mathematical claim is made and no statement has been transcribed from the paper.
+- **agent** (Claude Opus 5 (Anthropic)) — Transcribed Lemma 3.2 from the arXiv preprint 2101.12263v1, applied FKS's correction to the constant it quotes from Hiary, and stated Platt-Trudgian's simplified form of Theorem 1.1, under the direction of the maintainer. No proof is claimed.
 
 ---
 

--- a/docs/nodes/Kadiri2005-v1.md
+++ b/docs/nodes/Kadiri2005-v1.md
@@ -58,7 +58,7 @@ Recorded by the node itself, not derived.
 
 ## How this node was made
 
-- **agent** (Claude Opus 5 (Anthropic)) — Created this stub and transcribed its bibliographic record from the PNT+ bibliography, under the direction of the maintainer. No mathematical claim is made and no statement has been transcribed from the paper.
+- **agent** (Claude Opus 5 (Anthropic)) — Transcribed Theoreme 1.1 first hand from the published Acta Arith. version and recorded what it rests on, under the direction of the maintainer. No proof is claimed.
 
 ---
 

--- a/docs/nodes/RosserSchoenfeld-v1.md
+++ b/docs/nodes/RosserSchoenfeld-v1.md
@@ -97,7 +97,7 @@ Recorded by the node itself, not derived.
 
 ## How this node was made
 
-- **agent** (Claude Opus 5 (Anthropic)) — Created this stub and transcribed its bibliographic record from the PNT+ bibliography, under the direction of the maintainer. No mathematical claim is made and no statement has been transcribed from the paper.
+- **agent** (Claude Opus 5 (Anthropic)) — Transcribed Theorem 1 from the paper, stated the classical shape it bridges to, and recorded what each rests on, under the direction of the maintainer. The bridge between the two is proved in Lean and recompiled on every push.
 
 ---
 

--- a/scripts/ieantn.py
+++ b/scripts/ieantn.py
@@ -1042,6 +1042,27 @@ def check_graph() -> bool:
 
         if meta.get("id") != node_id:
             problems.add(where, f"node.id `{meta.get('id')}` != path-derived id `{node_id}`")
+
+        # Two self-contradictions, both observed. Every FKS2-family node carried prose written
+        # when it was a stub and never revisited -- one still said "no statement has been
+        # transcribed from the paper" over four Comparator-verified conclusions, and one named
+        # the wrong node in its own header. These files are the Palomar submission surface, so
+        # stale prose here is a false statement to a registry rather than an untidy comment.
+        # Neither check is a heuristic: each fires only when the file contradicts itself.
+        text = (node["_dir"] / "formalization.yaml").read_text(encoding="utf-8")
+        first = text.split("\n", 1)[0]
+        if first.startswith("#") and node_id not in first:
+            named = re.findall(r"`([A-Za-z0-9]+\.v[0-9]+)`", first)
+            if named and node_id not in named:
+                problems.add(where, f"the header comment says `{named[0]}`, not `{node_id}`")
+        if conclusions_of(node) and "deliberately empty" in text:
+            problems.add(
+                where,
+                f"still says `conclusions` is deliberately empty, with "
+                f"{len(conclusions_of(node))} stated. Prose written for a stub has outlived it; "
+                "read the whole file rather than only deleting the phrase.",
+            )
+
         status = meta.get("status")
         if status is not None and status not in NODE_STATUSES:
             problems.add(where, f"node.status `{status}` is not one of {sorted(NODE_STATUSES)}")

--- a/tests/test_ieantn.py
+++ b/tests/test_ieantn.py
@@ -234,6 +234,45 @@ class TestFixture(FixtureRepo):
 
 
 class TestGraphChecks(FixtureRepo):
+    def _prepend_header(self, node_id: str, header: str) -> None:
+        path = (self.root / "IEANTN" / "Nodes" / node_id.replace(".", "/")
+                / "formalization.yaml")
+        path.write_text(header + path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    def test_a_header_naming_another_node_fails(self) -> None:
+        """Observed across nine nodes: a metadata file copied from a sibling and edited
+        everywhere except its own first line, so it introduced itself as the node it came from."""
+        self.write_node("A.v1", LITERATURE)
+        self._prepend_header("A.v1", "# Node metadata for `B.v2`.  See docs/NODES.md.\n")
+        self.assertFalse(ieantn.check_graph())
+
+    def test_a_header_naming_this_node_passes(self) -> None:
+        self.write_node("A.v1", LITERATURE)
+        self._prepend_header("A.v1", "# Node metadata for `A.v1`.  See docs/NODES.md.\n")
+        self.assertTrue(ieantn.check_graph())
+
+    def test_claiming_no_conclusions_while_stating_some_fails(self) -> None:
+        """The other half of the same drift: prose written when the node was a stub, left in
+        place as conclusions were added under it. These files are the Palomar submission surface,
+        so this is a false statement to a registry rather than an untidy comment."""
+        self.write_node("A.v1", LITERATURE)
+        self._prepend_header(
+            "A.v1", "# `conclusions` is deliberately empty -- see Conclusions.lean.\n")
+        self.assertFalse(ieantn.check_graph())
+
+    def test_a_genuine_stub_may_say_its_conclusions_are_empty(self) -> None:
+        """The check must fire on the contradiction, not on the phrase: a node that really has
+        stated nothing is entitled to say so, and several do."""
+        directory = self.root / "IEANTN" / "Nodes" / "Paper" / "v1"
+        directory.mkdir(parents=True)
+        (directory / "formalization.yaml").write_text(
+            "# `conclusions` is deliberately empty -- see Conclusions.lean.\n"
+            + node_yaml("Paper.v1", "", status="stub"),
+            encoding="utf-8")
+        (directory / "Conclusions.lean").write_text(
+            "import IEANTN.Vocabulary\n", encoding="utf-8")
+        self.assertTrue(ieantn.check_graph())
+
     def test_wellformed_graph_passes(self) -> None:
         self.write_node("Upstream.v1", LITERATURE)
         self.write_node("Downstream.v1", IMPORTING)


### PR DESCRIPTION
Follows the FKS2 three in #48. The guard that found these is now in `check-graph`, with tests.

### Two exact self-contradictions

Neither is a heuristic — each fires only when a file contradicts itself.

**A header naming a different node than `node.id`.** Nine files did: `Brown1967`, `Buthe2016`,
`ChengGraham2004`, `Hiary2016`, `Platt2017`, `PlattTrudgian2021`, `Trudgian2011` and
`Wedeniwski` introduced themselves as KLN, Büthe or FKBJ, and `Dusart2018` named its family
rather than its id. Each was copied from a sibling and edited everywhere except its first line.

**"`conclusions` is deliberately empty" on a node with conclusions.** Seven had it: `BKLNW` (4
stated), `FKS` (2), `Hiary2016` (1), `Kadiri2005` (1), `KLN` (2), `RosserSchoenfeld` (2),
`Trudgian2011` (1).

### The worse one

`BKLNW`, `FKS`, `KLN`, `Kadiri2005` and `RosserSchoenfeld` all said, in
`automation.methods[].role`:

> No mathematical claim is made and no statement has been transcribed from the paper.

directly contradicted by the `review.notes` three lines below — which in BKLNW's case says the
statements were read from arXiv 2002.11068v2, *including* the definition of `f` at equation
(2.4), off the rendered page because the plain-text extraction was unusable.

Each role is rewritten from that node's own notes and limitations. **Those were accurate
throughout**; the boilerplate role was the only false thing, which is why this is a targeted fix
rather than a rewrite.

### What deliberately did not change

`Brown1967`, `ChengGraham2004` and `MTY` keep the stub language — they have no conclusions, so it
is true. There's a test asserting the check fires on the contradiction and not on the phrase.

### Notes this session's library work overtook

The published `BKLNW`, `FKS` and `KLN` are now held but have not been checked against these
statements — worth saying precisely because it is now possible.

`Kadiri2005`'s note said the bibliographic record came from PrimeNumberTheoremAnd's
`references.bib` and wanted checking. It has now been checked against the paper: the article's
first page reads `ACTA ARITHMETICA 117.4 (2005)` and it runs 37 pages ending at 339, which is the
recorded 303–339. That note also now records that **`sources[].id` points at the arXiv preprint —
the version that does *not* support the conclusion** (it gives 5.70176 where the published version
gives 5.69693). Replacing it with the published DOI is the honest fix and is deliberately not done
here: the paper prints no DOI, and guessing at one is how a citation goes wrong.

### Gate

No statement, dependency or receipt changes — `ieantn.py diff` reports no network impact.
`check`, `lake build`, `pyright` and **192** unit tests all green. The four new guard tests were
checked against a build with the guard removed: the two positive-detection tests fail there, the
two "must not fire" tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)