### PR TITLE
FKS.v1: correct the rescaling arithmetic in psi_bound_all_x's note

### DIFF
--- a/IEANTN/Nodes/FKS/v1/Conclusions.lean
+++ b/IEANTN/Nodes/FKS/v1/Conclusions.lean
@@ -36,11 +36,24 @@ open IEANTN
 
 `Eψ(x) < 9.22022 (log x)^{3/2} exp(−0.8476836 √(log x))` for every `x > 2`.
 
-Stated in the paper's own normalisation rather than converted, because the conversion is not free:
-in the `admissibleBound` shape with `R = 5.5666305` this is `A = 9.22022 · R^{3/2} ≈ 121.0916` and
-`C = 0.8476836 · √R = 2.0000…`, and the rounding in that arithmetic is the difference between this
-constant and the `121.096` that `FKS2` quotes. Keeping the printed form means the transcription can
-be checked against the paper by eye. -/
+Stated in the paper's own normalisation rather than converted, because **the conversion does not
+close**. Rescaling to the `admissibleBound` shape with `R = 5.5666305` gives
+
+* `A = 9.22022 · R^{3/2} = 121.09602174…`, where `psi_classical_bound` below states `121.096`;
+* `C = 0.8476836 · √R = 1.99999992…`, where it states `2`.
+
+Both roundings go the strengthening way — a smaller `A` and a larger `C` are each a *stronger*
+claim — so `psi_classical_bound` is **not** derivable from this conclusion by rescaling, and a
+solution that tries will fail by `2.2·10⁻⁵` in `A` and `8·10⁻⁸` in `C`. The two are transcribed
+from different places in the paper and neither is claimed to follow from the other; see the note
+there. This is the shape of gap `IEANTN.margin` exists for, and a margin index on whichever
+conclusion is eventually proved is the likely resolution.
+
+A note here once put the rescaled `A` at `≈ 121.0916` and called the discrepancy rounding. The
+figure was wrong — it is `121.09602` — and so was the gloss: the difference is not a benign
+rounding but a gap in the direction that breaks the derivation.
+
+Keeping the printed form means the transcription can be checked against the paper by eye. -/
 def psi_bound_all_x : Prop :=
   ∀ x > (2 : ℝ), Eψ x < 9.22022 * (Real.log x) ^ ((3 : ℝ) / 2) *
     Real.exp (-0.8476836 * Real.sqrt (Real.log x))

--- a/docs/nodes/FKS-v1.md
+++ b/docs/nodes/FKS-v1.md
@@ -24,11 +24,24 @@
 
 `Eψ(x) < 9.22022 (log x)^{3/2} exp(−0.8476836 √(log x))` for every `x > 2`.
 
-Stated in the paper's own normalisation rather than converted, because the conversion is not free:
-in the `admissibleBound` shape with `R = 5.5666305` this is `A = 9.22022 · R^{3/2} ≈ 121.0916` and
-`C = 0.8476836 · √R = 2.0000…`, and the rounding in that arithmetic is the difference between this
-constant and the `121.096` that `FKS2` quotes. Keeping the printed form means the transcription can
-be checked against the paper by eye.
+Stated in the paper's own normalisation rather than converted, because **the conversion does not
+close**. Rescaling to the `admissibleBound` shape with `R = 5.5666305` gives
+
+* `A = 9.22022 · R^{3/2} = 121.09602174…`, where `psi_classical_bound` below states `121.096`;
+* `C = 0.8476836 · √R = 1.99999992…`, where it states `2`.
+
+Both roundings go the strengthening way — a smaller `A` and a larger `C` are each a *stronger*
+claim — so `psi_classical_bound` is **not** derivable from this conclusion by rescaling, and a
+solution that tries will fail by `2.2·10⁻⁵` in `A` and `8·10⁻⁸` in `C`. The two are transcribed
+from different places in the paper and neither is claimed to follow from the other; see the note
+there. This is the shape of gap `IEANTN.margin` exists for, and a margin index on whichever
+conclusion is eventually proved is the likely resolution.
+
+A note here once put the rescaled `A` at `≈ 121.0916` and called the discrepancy rounding. The
+figure was wrong — it is `121.09602` — and so was the gloss: the difference is not a benign
+rounding but a gap in the direction that breaks the derivation.
+
+Keeping the printed form means the transcription can be checked against the paper by eye.
 
 ```lean
 def psi_bound_all_x : Prop :=
@@ -40,7 +53,7 @@ def psi_bound_all_x : Prop :=
 |---|---|
 | Lean name | `FKS.v1.psi_bound_all_x` |
 | Challenge | `FKS.v1.challenge_psi_bound_all_x` |
-| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L44) |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L57) |
 | Evidence | cited (`literature`) |
 | Sources traced | identified |
 | Assumes | [`KLN.v1.subconvexity_bound`](KLN-v1.md#subconvexity_bound), [`MT.v1.zero_free_region_sharpened`](MT-v1.md#zero_free_region_sharpened), [`PlattTrudgian.v1.rh_up_to`](PlattTrudgian-v1.md#rh_up_to) |
@@ -77,7 +90,7 @@ def psi_classical_bound : Prop :=
 |---|---|
 | Lean name | `FKS.v1.psi_classical_bound` |
 | Challenge | `FKS.v1.challenge_psi_classical_bound` |
-| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L63) |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L76) |
 | Evidence | cited (`literature`) |
 | Sources traced | identified |
 | Assumes | [`KLN.v1.subconvexity_bound`](KLN-v1.md#subconvexity_bound), [`MT.v1.zero_free_region_sharpened`](MT-v1.md#zero_free_region_sharpened), [`PlattTrudgian.v1.rh_up_to`](PlattTrudgian-v1.md#rh_up_to) |


### PR DESCRIPTION
Found while analysing `FKS.v1` for its formalization issue.

The note on `psi_bound_all_x` said that converting Corollary 1.4 into the `admissibleBound` shape
gives `A = 9.22022 · R^{3/2} ≈ 121.0916`, and that the gap to `psi_classical_bound`'s `121.096`
was rounding. Both halves are wrong.

- The value is **`121.09602174…`**, not `121.0916`.
- `121.096` is *smaller* than that, and a smaller `A` is a **stronger** claim. Likewise
  `C = 0.8476836 · √R = 1.99999992…` where `psi_classical_bound` states `2`, and a larger `C`
  decays faster — stronger again.

So `psi_classical_bound` is **not** derivable from `psi_bound_all_x` by rescaling; an attempt
fails by `2.2·10⁻⁵` in `A` and `8·10⁻⁸` in `C`. Neither conclusion is claimed to follow from the
other — they are transcribed from different places in the paper — but the note implied the
conversion was available and merely lossy, which would send anyone formalizing this node down a
route that cannot close. `PrimeNumberTheoremAnd` has the same two statements and its
`FKS_corollary_1_3` is a bare `sorry` citing FKS2's Remark 2 rather than deriving it from 1.4,
which is consistent.

This is the shape of gap `IEANTN.margin` exists for, and the note now says so.

Fingerprints unchanged — a docstring is part of no declaration, and `fingerprint --check`
confirms. `check`, `lake build` and 192 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)