### PR TITLE
Point the intentions bot at this repository's own board, and link it from the docs

### DIFF
--- a/.github/workflows/intentions.yml
+++ b/.github/workflows/intentions.yml
@@ -3,16 +3,23 @@ name: Intentions
 # Lets a contributor claim an issue by commenting on it: the bot assigns them and moves the
 # issue's card on the project board from `Unclaimed` to `Claimed`.
 #
-# The board is `PNT+ Project`, owned by AlexKontorovich, shared with PrimeNumberTheoremAnd. This
-# repository's issues sit on it alongside PNT+'s, which is deliberate -- the two projects overlap
-# heavily in both mathematics and people, and one board is where a contributor can see what is
-# free across both.
+# The board is `IEANTN`, at https://github.com/users/teorth/projects/3.
+#
+# It has to be owned by this repository's owner, and that is not a preference. The action resolves
+# the board by looking first at projects linked to the repository and then at projects owned by
+# `github.repository_owner`; it takes no board-owner input. GitHub separately refuses to link a
+# project to a repository under a different owner -- "Only projects owned by the same owner as the
+# repository can be linked." So a board under another account is unreachable from here however the
+# token is provisioned. This repository's issues previously sat on AlexKontorovich's `PNT+ Project`
+# board for cross-project visibility; that is what those two rules together ruled out.
 #
 # Only `issue_comment` is listed, matching PrimeNumberTheoremAnd's caller. That gives the comment
-# commands but NOT the automatic board lifecycle: issues are added to the board by hand. Adding
-# the `issues` and `pull_request_target` triggers would auto-add every issue opened here to a board
-# that is not this repository's own, which should be a deliberate decision rather than a default;
-# `auto-add-labels` is the way to scope it if that is ever wanted.
+# commands but NOT the automatic board lifecycle: issues reach the board by hand, and their status
+# is set by hand until someone claims them. Adding the `issues` and `pull_request_target` triggers
+# would auto-add every issue opened here and drive `Status` from pull request events. Now that the
+# board belongs to this repository there is no longer a reason not to, beyond wanting to see the
+# comment commands work first; `auto-add-labels` scopes it to labelled issues if the full sweep is
+# too much.
 #
 # `default-ttl: none` disables claim expiry, so no `Claim Expires` field and no scheduled sweep are
 # needed. A claim then persists until it is disclaimed.
@@ -35,7 +42,7 @@ jobs:
       pull-requests: write
     uses: leanprover-community/intentions/.github/workflows/intentions.yml@v1
     with:
-      project-title: "PNT+ Project"
+      project-title: "IEANTN"
       default-ttl: "none"
     secrets:
       project-token: ${{ secrets.PAT_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,16 @@ reviewer notices — which is exactly what a routine, always-required acknowledg
 
 ## Where to start, by how much of the network you can see
 
+**If you are looking for something to do**, the [project
+board](https://github.com/users/teorth/projects/3) lists it. Anything marked `Unclaimed` is free to
+take: comment `claim` on the issue and a bot assigns it to you and moves the card to `Claimed`.
+`disclaim` releases it, and `propose PR #123` links your pull request. Claims do not expire, so
+release one you have put down rather than leaving it to block someone else.
+
+Claiming is a courtesy, not a lock — nothing in CI enforces it. Its purpose is to stop two people
+independently formalizing the same node, which in a repository where a single node can be a
+six-thousand-line solution is a costly collision.
+
 The three layers carry very different blast radii, and that is the natural order to work through
 them in.
 

--- a/README.md
+++ b/README.md
@@ -47,16 +47,17 @@ defeat the purpose of the split.
 ## Reading order
 
 0. [GRAPH.md](GRAPH.md) — **the network itself**: what it contains, what each result rests
-Each node also has a generated summary page under [docs/nodes/](docs/nodes/README.md): what it claims, in Lean and in prose, and everything recorded about why it should be believed.
    on, and what is taken on trust. Generated, and the place to start if you only want to
-   see the thing.
+   see the thing. Each node also has a generated summary page under
+   [docs/nodes/](docs/nodes/README.md): what it claims, in Lean and in prose, and everything
+   recorded about why it should be believed.
 1. [CONTRIBUTING.md](CONTRIBUTING.md) — the ten things people actually do, and how.
 2. [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — the design and why it is what it is.
 3. [docs/NODES.md](docs/NODES.md) — node file formats, in detail.
 4. [CLAUDE.md](CLAUDE.md) — the short version, for coding agents.
 5. [docs/ROADMAP.md](docs/ROADMAP.md) — what is deliberately not built yet, and why.
 6. [docs/SOURCES.md](docs/SOURCES.md) — the papers the nodes rest on, held and wanted.
-6. [SECURITY.md](SECURITY.md) — the trust model, and what a forged receipt would take.
+7. [SECURITY.md](SECURITY.md) — the trust model, and what a forged receipt would take.
 
 ## Status
 
@@ -71,6 +72,13 @@ workflow, and `ieantn.py status` grades it against the current environment.
 Outstanding: visualisation, the `/verify` comment trigger, and the composing half of the
 Palomar spin-off generator. [docs/ROADMAP.md](docs/ROADMAP.md) tracks what is deliberately not built
 and why; [SECURITY.md](SECURITY.md) states the trust model.
+
+## Claiming a task
+
+Open work is tracked on the [**IEANTN project board**](https://github.com/users/teorth/projects/3).
+Anything marked `Unclaimed` is free to take: comment `claim` on the issue and a bot assigns it to
+you and moves the card. `disclaim` releases it again, and `propose PR #123` links your pull request.
+Claims do not expire, so please release one you are no longer working on.
 
 This work grows out of the IEANTN subproject of
 [PNT+](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd), whose blueprint-based structure


### PR DESCRIPTION
The board is now **[IEANTN](https://github.com/users/teorth/projects/3)**, replacing AlexKontorovich's `PNT+ Project`.

## Why the shared board could not work

The first `claim` on #64 failed in 8 seconds with:

> Could not find a Projects v2 board titled "PNT+ Project" linked to `teorth/IEANTN` or owned by `teorth`.

Despite that message's opening, it is not a token problem. Two rules together close the route:

- **The action takes no board-owner input.** `resolveProjectId(octokit, owner, repo, title)` looks first at `repository(owner:"teorth", name:"IEANTN").projectsV2`, then at `repositoryOwner(login:"teorth").projectsV2`, with `owner` coming from `github.repository_owner`. Of the action's 16 declared inputs, none is the board owner.
- **GitHub refuses cross-owner links.** `linkProjectV2ToRepository` returns *"Only projects owned by the same owner as the repository can be linked."*

So no token, title or configuration could have reached a board under another account. `PAT_TOKEN` is fine — it never got as far as being exercised.

## What changed off-PR

- New Projects v2 board `IEANTN` under `teorth`.
- Its `Status` field reshaped from the default `Todo / In Progress / Done` to `Unclaimed / Claimed / In Progress / In Review / Completed`.
- A `Claim Note` text field added, for the freeform note a `claim` comment can carry.
- The seven IEANTN issues (#50, #52, #53, #54, #56, #63, #64) migrated with statuses preserved — #54 `Completed`, the rest `Unclaimed` — and removed from the PNT+ board.

No `Claim Expires` field and no scheduled sweep, because `default-ttl: none`.

## Also corrected in this PR

The comment explaining why only `issue_comment` is wired up argued that auto-add "would put every issue opened here onto a board this repository does not own". That reasoning expired with this change — the board *is* ours now, so the automatic lifecycle is available whenever it's wanted. The comment says that instead.

## Testing

`issue_comment` runs from the default branch, so after merging, `claim` on #64 should assign you and move the card to `Claimed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)