### PR TITLE
ZeroCount.v1: correct the claim that the two counting conventions are inequivalent

### DIFF
--- a/IEANTN/Nodes/ZeroCount/v1/Conclusions.lean
+++ b/IEANTN/Nodes/ZeroCount/v1/Conclusions.lean
@@ -30,16 +30,20 @@ That would have been the obvious composable choice — `HasRvMBound b₁ b₂ b�
 statement here, and the reason is a counting convention, not a constant.
 
 `HasRvMBound` is built on `zetaN`, which counts `Set.Ioo 0 T` — zeroes with `0 < Im ρ < T`. Rosser
-and Chirre–Helfgott count `0 < Im ρ ≤ T`. The two differ by `m(t)`, the multiplicity at height
-exactly `t`, and **neither bound implies the other**: writing `Q_open = Q_closed - m(t)` with
-`m(t) ≥ 0`, the upper bound transfers but the lower one does not, since `Q_open ≥ -B - m(t)` is
-weaker than `Q_open ≥ -B`. Recovering the open-interval form costs `m(t) ≤ N(t+1) - N(t-1)`, itself
-of size `log t`, so it would change the constant rather than being free.
+and Chirre–Helfgott count `0 < Im ρ ≤ T`. So the conclusions below use the source's convention,
+written out from `zetaZeroesSum` with `Set.Ioc`, and need no new definition for it.
 
-Generically `m(t) = 0` and the distinction is vacuous. It is not vacuous as a *statement*, which is
-what a node records, so the conclusions below use the source's convention, written out from
-`zetaZeroesSum` with `Set.Ioc`. No new definition is needed for that; see this node's limitations
-for what it means for composing with the rest of the network.
+The two conventions differ by `m(t)`, the multiplicity at height exactly `t`, and comparing them at a
+single height makes them look inequivalent — the upper bound transfers, the lower one loses `m(t)`.
+**That comparison is the wrong one.** The hypothesis holds at every nearby height, and the zeroes in
+a bounded region are finite, so there is an `s < t` with `N_Ioc(s) = N_Ioo(t)` exactly; substituting
+and letting `s ↑ t`, with the main term and the bound both continuous, gives the open-interval form
+with **no loss of constant**.
+
+So the two are equivalent, and stating the source's convention here costs a consumer only a lemma
+nobody has yet written. The clean shape for that is the `ZeroFreeHeight` pattern — keep both
+conventions and let a node or bridge record the passage between them — rather than forcing one
+convention on Vocabulary.
 
 ## A note on the sum
 

--- a/IEANTN/Nodes/ZeroCount/v1/formalization.yaml
+++ b/IEANTN/Nodes/ZeroCount/v1/formalization.yaml
@@ -103,12 +103,15 @@ review:
     IEANTN.HasRvMBound, which would otherwise have been the obvious composable choice -- that
     predicate is literally |Q(T)| <= b1 log T + b2 log log T + b3, which is this statement at
     (1/5, 0, 2). It is built on `zetaN`, which counts Set.Ioo 0 T, whereas Rosser and CH2 count
-    0 < Im rho <= T. The two differ by m(t), the multiplicity at height exactly t, and NEITHER BOUND
-    IMPLIES THE OTHER: with Q_open = Q_closed - m(t) and m(t) >= 0 the upper bound transfers but the
-    lower one does not, since Q_open >= -B - m(t) is weaker than Q_open >= -B. Recovering the
-    open-interval form costs m(t) <= N(t+1) - N(t-1), itself of size log t, so it changes the
-    constant. Generically m(t) = 0 and the distinction is vacuous, but a node records a statement
-    rather than a generic case, so the conclusions use the source's convention.
+    0 < Im rho <= T, so the conclusions use the source's convention.
+    A CORRECTION TO AN EARLIER VERSION OF THIS NOTE, which said the two bounds are inequivalent. They
+    are not. That comparison was made at a SINGLE height, where they differ by m(t) and the lower
+    bound appears to lose m(t). But the hypothesis holds at every nearby height, and the zeroes in a
+    bounded region are finite, so there is an s < t with N_Ioc(s) = N_Ioo(t) exactly; substituting
+    and letting s tend to t from below, with the main term and the bound both continuous, gives the
+    open-interval form with NO loss of constant. So rvm_error_bound does imply
+    HasRvMBound (1/5) 0 2 for T > 1; what is missing is a Lean proof of that passage, not a
+    mathematical obstruction.
     The junk-value warning on zetaZeroesSum was considered and does not bite: the zeroes in a bounded
     rectangle are finite in number, so the family has finite support and the sum is the honest count.
     That is a fact about zeta rather than a hypothesis, which is why no summability condition appears.
@@ -119,11 +122,12 @@ limitations:
   proof would need Rosser's argument or a modern replacement, neither of which is in Mathlib -- there
   is no Riemann-von Mangoldt formula there at all.
 - >-
-  DOES NOT COMPOSE WITH IEANTN.HasRvMBound, for the counting-convention reason recorded in the review
-  notes. A consumer holding this node and wanting HasRvMBound must bound the multiplicity at a single
-  height, which costs a term of size log t and hence a different constant. Whether Vocabulary should
-  grow a closed-interval count, or `zetaN` should be restated, is a question this node raises and does
-  not answer.
+  DOES NOT COMPOSE WITH IEANTN.HasRvMBound AS IT STANDS, but the gap is a missing lemma, not a loss of
+  constant. `rvm_error_bound` implies HasRvMBound (1/5) 0 2 for T > 1 by a limit from below -- see the
+  review notes, which correct an earlier claim here that the two are inequivalent. Nobody has written
+  that passage in Lean, so a consumer must do it. The clean shape for it is the ZeroFreeHeight
+  pattern: keep both conventions and let a node or bridge record the passage between them, rather than
+  forcing one convention on Vocabulary.
 - >-
   WEAKER THAN THE LITERATURE SUPPORTS. Rosser's own bound is 0.137 log t + 0.443 log log t + 1.588,
   and CH2 note that better bounds are available today. The weakening is theirs and is deliberate; a

--- a/docs/nodes/ZeroCount-v1.md
+++ b/docs/nodes/ZeroCount-v1.md
@@ -39,7 +39,7 @@ def rvm_error_bound : Prop :=
 |---|---|
 | Lean name | `ZeroCount.v1.rvm_error_bound` |
 | Challenge | `ZeroCount.v1.challenge_rvm_error_bound` |
-| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/ZeroCount/v1/Conclusions.lean#L80) |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/ZeroCount/v1/Conclusions.lean#L84) |
 | Evidence | cited (`literature`) |
 | Sources traced | none |
 | Assumes | nothing recorded |
@@ -68,7 +68,7 @@ def rvm_error_small : Prop :=
 |---|---|
 | Lean name | `ZeroCount.v1.rvm_error_small` |
 | Challenge | `ZeroCount.v1.challenge_rvm_error_small` |
-| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/ZeroCount/v1/Conclusions.lean#L90) |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/ZeroCount/v1/Conclusions.lean#L94) |
 | Evidence | cited (`literature`) |
 | Sources traced | none |
 | Assumes | nothing recorded |
@@ -83,7 +83,7 @@ def rvm_error_small : Prop :=
 Recorded by the node itself, not derived.
 
 - Asserted on the literature; no Lean proof exists here, and anything downstream inherits that. A proof would need Rosser's argument or a modern replacement, neither of which is in Mathlib -- there is no Riemann-von Mangoldt formula there at all.
-- DOES NOT COMPOSE WITH IEANTN.HasRvMBound, for the counting-convention reason recorded in the review notes. A consumer holding this node and wanting HasRvMBound must bound the multiplicity at a single height, which costs a term of size log t and hence a different constant. Whether Vocabulary should grow a closed-interval count, or `zetaN` should be restated, is a question this node raises and does not answer.
+- DOES NOT COMPOSE WITH IEANTN.HasRvMBound AS IT STANDS, but the gap is a missing lemma, not a loss of constant. `rvm_error_bound` implies HasRvMBound (1/5) 0 2 for T > 1 by a limit from below -- see the review notes, which correct an earlier claim here that the two are inequivalent. Nobody has written that passage in Lean, so a consumer must do it. The clean shape for it is the ZeroFreeHeight pattern: keep both conventions and let a node or bridge record the passage between them, rather than forcing one convention on Vocabulary.
 - WEAKER THAN THE LITERATURE SUPPORTS. Rosser's own bound is 0.137 log t + 0.443 log log t + 1.588, and CH2 note that better bounds are available today. The weakening is theirs and is deliberate; a node wanting the sharper form should state it directly rather than strengthening this one.
 - The `Q(t)` of Lemma B.1 is bounded only for t >= 1 and on 0 < t <= 280. CH2's Appendix B contains further estimates -- on sums over zeroes, and on the function they call `I+,C` -- which are what actually deliver C_T, and none of those are stated here.
 - No novelty is claimed. The result is Rosser's, in Chirre and Helfgott's restatement.


### PR DESCRIPTION
`ZeroCount.v1` claimed that `rvm_error_bound` (counting `Set.Ioc`) does not imply `HasRvMBound (1/5) 0 2` (counting `Set.Ioo`), because they differ by `m(t)`, the multiplicity at height exactly `t`, and the lower bound appears to lose it.

**That is wrong.** The error was comparing the two at a *single* height. The hypothesis holds at every nearby height:

```
zeroes in a bounded region are finite  ⟹  ∃ s < t with N_Ioc(s) = N_Ioo(t) exactly
hypothesis at s:   |N_Ioo(t) − main(s)| ≤ B(s)
s ↑ t, main and B continuous:   |N_Ioo(t) − main(t)| ≤ B(t)
```

No loss of constant. So the two forms are equivalent, and what's missing is a Lean proof of that passage — not a mathematical obstruction.

The conclusions are unchanged: the source's convention is still the right thing for a node to record. What changes is the docstring and the metadata, which now say the passage is available and nobody has written it, rather than that it is blocked.

Recorded as the shape to use when someone wants it — @teorth's suggestion — keep both conventions and let a node or bridge record the passage, as `ZeroFreeHeight.v1` does for the height of a zero-free region, rather than forcing one convention on Vocabulary.

Docstring and metadata only. **Fingerprints do not move**, so nothing downstream is disturbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)