### PR TITLE
Record Büthe Table 1 and Equation (6.2) on Buthe.v1

### DIFF
--- a/GRAPH.md
+++ b/GRAPH.md
@@ -54,7 +54,7 @@ bridge needed together is in the detailed picture below.
 graph LR
   NBKLNW_v1["<b>BKLNW.v1</b><br/>4 claims<br/><i>weakest: cited</i>"]
   NBrown1967_v1["<b>Brown1967.v1</b><br/><i>nothing stated yet</i>"]
-  NButhe_v1["<b>Buthe.v1</b><br/>6 claims<br/><i>weakest: cited</i>"]
+  NButhe_v1["<b>Buthe.v1</b><br/>7 claims<br/><i>weakest: cited</i>"]
   NButhe_v2["<b>Buthe.v2</b><br/>2 claims<br/><i>weakest: unjustified</i>"]
   NButhe2016_v1["<b>Buthe2016.v1</b><br/>4 claims<br/><i>weakest: cited</i>"]
   NButheNumerics_v1["<b>ButheNumerics.v1</b><br/>3 claims<br/><i>weakest: computation</i>"]
@@ -225,6 +225,7 @@ graph LR
     BKLNW_v1_theta_error_le_one["<b>theta_error_le_one</b><br/><i>cited</i>"]
   end
   subgraph sgButhe_v1["Buthe.v1"]
+    Buthe_v1_table_1_interval_bounds["<b>table_1_interval_bounds</b><br/><i>cited</i>"]
     Buthe_v1_theorem_2_li_gt_pi["<b>theorem_2_li_gt_pi</b><br/><i>cited</i>"]
     Buthe_v1_theorem_2_li_minus_pi["<b>theorem_2_li_minus_pi</b><br/><i>cited</i>"]
     Buthe_v1_theorem_2_li_minus_riemann_pi["<b>theorem_2_li_minus_riemann_pi</b><br/><i>cited</i>"]
@@ -499,6 +500,7 @@ graph LR
   BRWedeniwski_v1_rh_up_to__bridge_from_platt2017 ==> Wedeniwski_v1_rh_up_to
   style BKLNW_v1_table8_psi_bound stroke-dasharray: 8 4;
   style BKLNW_v1_table8_psi_bound_above stroke-dasharray: 8 4;
+  style Buthe_v1_table_1_interval_bounds stroke-dasharray: 8 4;
   style Buthe_v1_theorem_2_li_minus_riemann_pi stroke-dasharray: 8 4;
   style Buthe_v1_theorem_2_psi stroke-dasharray: 8 4;
   style Buthe_v1_theorem_2_theta stroke-dasharray: 8 4;
@@ -534,13 +536,14 @@ graph LR
   class CH2_v3_extremal_majorant,CH2_v3_extremal_minorant,GammaAsymptotics_v2_digamma_sub_log_isBigO_strip,ZetaLogDeriv_v1_logDeriv_functional_equation,ZetaZeroes_v1_exists_ordinate_free_height,ZetaZeroes_v1_finite_zeroes_on_compact,ZetaZeroes_v1_no_nontrivial_zeroes_left,ZetaZeroes_v1_zeroes_off_axis_in_strip,ZetaZeroes_v1_zeta_eq_zero_iff_zeta1,ZetaZeroes_v1_zeta_eq_zeta1_div lean_comparator;
   class CH2_v4_contour_shift,CH2_v4_contour_shift_holomorphic lean_comparator_drifted;
   class CH2_v2_proposition_2_4_lower,CH2_v2_proposition_2_4_upper,DudekPlatt_v2_ramanujan_inequality_3915,DudekPlatt_v3_criterion,FKS2_v1_corollary_14,FKS2_v1_corollary_22,FKS2_v1_corollary_23,FKS2_v1_corollary_26,FKS2_v2_proposition_13,FKS2_v2_theorem_3,Lcm_v1_lcmUpto_not_highlyAbundant,Lcm_v2_lcmUpto_not_highlyAbundant_of_primeGap,PrimeInterval_v1_classicalBound_hasPrimeInInterval,PrimeInterval_v1_eTheta_criterion,PrimeInterval_v1_numericalBound_hasPrimeInInterval,PrimeInterval_v1_theta_characterisation,ZeroFreeHeight_v1_classical_region_descends lean_comparator_stale;
-  class BKLNW_v1_corollary_5_1,BKLNW_v1_table8_psi_bound,BKLNW_v1_table8_psi_bound_above,BKLNW_v1_theta_error_le_one,Buthe_v1_theorem_2_li_gt_pi,Buthe_v1_theorem_2_li_minus_pi,Buthe_v1_theorem_2_li_minus_riemann_pi,Buthe_v1_theorem_2_psi,Buthe_v1_theorem_2_theta,Buthe_v1_theorem_2_theta_lower,Buthe2016_v1_theorem_2_li_minus_pi,Buthe2016_v1_theorem_2_li_minus_riemann_pi,Buthe2016_v1_theorem_2_psi,Buthe2016_v1_theorem_2_theta,CH2_v1_corollary_1_2_lambda_sum,CH2_v1_corollary_1_2_psi,CH2_v1_corollary_1_3_lambda_sum,CH2_v1_corollary_1_3_psi,DudekPlatt_v1_largest_counterexample_on_rh,DudekPlatt_v1_ramanujan_inequality,Dusart2018_v1_proposition_5_4,FKS_v1_psi_bound_all_x,FKS_v1_psi_classical_bound,Hiary2016_v1_zeta_half_line_bound,KLN_v1_subconvexity_bound,KLN_v1_zero_density,Kadiri2005_v1_zero_free_region,MT_v1_zero_free_region,MT_v1_zero_free_region_sharpened,PlattTrudgian_v1_rh_up_to,PlattTrudgian2021_v1_theorem_1_classical,PlattTrudgian2021_v1_theorem_1_numerical,RosserSchoenfeld_v1_zero_free_region,Trudgian2011_v1_integral_S_bound,ZeroCount_v1_rvm_error_bound,ZeroCount_v1_rvm_error_small literature;
+  class BKLNW_v1_corollary_5_1,BKLNW_v1_table8_psi_bound,BKLNW_v1_table8_psi_bound_above,BKLNW_v1_theta_error_le_one,Buthe_v1_table_1_interval_bounds,Buthe_v1_theorem_2_li_gt_pi,Buthe_v1_theorem_2_li_minus_pi,Buthe_v1_theorem_2_li_minus_riemann_pi,Buthe_v1_theorem_2_psi,Buthe_v1_theorem_2_theta,Buthe_v1_theorem_2_theta_lower,Buthe2016_v1_theorem_2_li_minus_pi,Buthe2016_v1_theorem_2_li_minus_riemann_pi,Buthe2016_v1_theorem_2_psi,Buthe2016_v1_theorem_2_theta,CH2_v1_corollary_1_2_lambda_sum,CH2_v1_corollary_1_2_psi,CH2_v1_corollary_1_3_lambda_sum,CH2_v1_corollary_1_3_psi,DudekPlatt_v1_largest_counterexample_on_rh,DudekPlatt_v1_ramanujan_inequality,Dusart2018_v1_proposition_5_4,FKS_v1_psi_bound_all_x,FKS_v1_psi_classical_bound,Hiary2016_v1_zeta_half_line_bound,KLN_v1_subconvexity_bound,KLN_v1_zero_density,Kadiri2005_v1_zero_free_region,MT_v1_zero_free_region,MT_v1_zero_free_region_sharpened,PlattTrudgian_v1_rh_up_to,PlattTrudgian2021_v1_theorem_1_classical,PlattTrudgian2021_v1_theorem_1_numerical,RosserSchoenfeld_v1_zero_free_region,Trudgian2011_v1_integral_S_bound,ZeroCount_v1_rvm_error_bound,ZeroCount_v1_rvm_error_small literature;
   class Buthe_v2_lemma_3_bounds,Buthe_v2_lemma_3_positivity,ContourIntegration_v1_residue_theorem_rectangle,CotangentSeries_v1_cot_series_zeta_values,GammaAsymptotics_v1_digamma_sub_log_isBigO none_yet;
   class ButheNumerics_v1_lemma_3_constant_gt_at_10,ButheNumerics_v1_lemma_3_constant_nonpos,ButheNumerics_v1_li_minus_pi_below_1e7,DudekPlattNumerics_v1_pi_two_sided_paper,DudekPlattNumerics_v2_pi_two_sided_pnt,FKBJ_v1_rh_up_to,FKS2Numerics_v1_corollary_22_mid_range,FKS2Numerics_v1_corollary_23_mid_range,FKS2Numerics_v1_nu_asymp_e30_le,FKS2Numerics_v1_table6_row2_floor,FKS2Numerics_v1_theta_asymp_ge_one_below_e30,LowZeroes_v1_sum_inv_ordinates_below_2e4,Platt2015_v1_rh_up_to,Platt2017_v1_rh_up_to,ZetaLogDerivValues_v1_deriv_logDeriv_neg_one,ZetaLogDerivValues_v1_logDeriv_laurent_alternating,ZetaLogDerivValues_v1_logDeriv_neg_one,ZetaLogDerivValues_v1_logDeriv_three_halves,ZetaLogDerivValues_v1_logDeriv_two numerical;
   click BKLNW_v1_corollary_5_1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#corollary_5_1" _blank
   click BKLNW_v1_table8_psi_bound href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#table8_psi_bound" _blank
   click BKLNW_v1_table8_psi_bound_above href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#table8_psi_bound_above" _blank
   click BKLNW_v1_theta_error_le_one href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#theta_error_le_one" _blank
+  click Buthe_v1_table_1_interval_bounds href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe-v1.md#table_1_interval_bounds" _blank
   click Buthe_v1_theorem_2_li_gt_pi href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe-v1.md#theorem_2_li_gt_pi" _blank
   click Buthe_v1_theorem_2_li_minus_pi href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe-v1.md#theorem_2_li_minus_pi" _blank
   click Buthe_v1_theorem_2_li_minus_riemann_pi href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe-v1.md#theorem_2_li_minus_riemann_pi" _blank
@@ -660,6 +663,8 @@ A line is one claim, indented under whatever assumes it.
     - [`KLN.v1.zero_density`](docs/nodes/KLN-v1.md#zero_density) — cited
       - [`Platt2017.v1.rh_up_to`](docs/nodes/Platt2017-v1.md#rh_up_to) — computation — *sources known, not all drawable*
         - [`Trudgian2011.v1.integral_S_bound`](docs/nodes/Trudgian2011-v1.md#integral_S_bound) — cited — *sources not traced*
+
+- [`Buthe.v1.table_1_interval_bounds`](docs/nodes/Buthe-v1.md#table_1_interval_bounds) — cited — *sources known, not all drawable*
 
 - [`Buthe.v1.theorem_2_li_gt_pi`](docs/nodes/Buthe-v1.md#theorem_2_li_gt_pi) — cited
   - [`FKBJ.v1.rh_up_to`](docs/nodes/FKBJ-v1.md#rh_up_to) — computation — *sources known, not all drawable*
@@ -926,6 +931,7 @@ rather than maintained.
 | [`Wedeniwski.v1.rh_up_to`](docs/nodes/Wedeniwski-v1.md#rh_up_to) | asserted | 1 | **not yet traced** |
 | [`BKLNW.v1.table8_psi_bound`](docs/nodes/BKLNW-v1.md#table8_psi_bound) | cited | 0 | known, not all drawable |
 | [`BKLNW.v1.table8_psi_bound_above`](docs/nodes/BKLNW-v1.md#table8_psi_bound_above) | cited | 0 | known, not all drawable |
+| [`Buthe.v1.table_1_interval_bounds`](docs/nodes/Buthe-v1.md#table_1_interval_bounds) | cited | 0 | known, not all drawable |
 | [`Buthe.v1.theorem_2_li_gt_pi`](docs/nodes/Buthe-v1.md#theorem_2_li_gt_pi) | cited | 0 | traced |
 | [`Buthe.v1.theorem_2_li_minus_pi`](docs/nodes/Buthe-v1.md#theorem_2_li_minus_pi) | cited | 0 | traced |
 | [`Buthe.v1.theorem_2_li_minus_riemann_pi`](docs/nodes/Buthe-v1.md#theorem_2_li_minus_riemann_pi) | cited | 0 | known, not all drawable |

--- a/IEANTN/Nodes.lean
+++ b/IEANTN/Nodes.lean
@@ -6,6 +6,7 @@ Authors: Terence Tao
 import IEANTN.Nodes.BKLNW.v1.Tables
 import IEANTN.Nodes.BKLNW.v1.Challenge
 import IEANTN.Nodes.Brown1967.v1.Challenge
+import IEANTN.Nodes.Buthe.v1.Tables
 import IEANTN.Nodes.Buthe.v1.Challenge
 import IEANTN.Nodes.Buthe.v2.Challenge
 import IEANTN.Nodes.Buthe2016.v1.Challenge

--- a/IEANTN/Nodes/Buthe/v1/Challenge.lean
+++ b/IEANTN/Nodes/Buthe/v1/Challenge.lean
@@ -55,3 +55,6 @@ theorem Buthe.v1.challenge_theorem_2_li_gt_pi
     (buthenumerics_v1_lemma_3_constant_gt_at_10 : ButheNumerics.v1.lemma_3_constant_gt_at_10) :
     Buthe.v1.theorem_2_li_gt_pi := by
   sorry
+
+theorem Buthe.v1.challenge_table_1_interval_bounds : Buthe.v1.table_1_interval_bounds := by
+  sorry

--- a/IEANTN/Nodes/Buthe/v1/Conclusions.lean
+++ b/IEANTN/Nodes/Buthe/v1/Conclusions.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Terence Tao
 -/
 import IEANTN.Vocabulary.ErrorTerms
+import IEANTN.Nodes.Buthe.v1.Tables
 
 /-!
 # Node `Buthe.v1`
@@ -72,5 +73,16 @@ Together with (1.9) this makes the bound two-sided, which is what a statement ab
 needs. Büthe notes that it also pushes the lower bound for the Skewes number to `10¹⁹`. -/
 def theorem_2_li_gt_pi : Prop :=
   ∀ x : ℝ, 2 ≤ x → x ≤ 10 ^ (19 : ℕ) → 0 < li x - primeCounting x
+
+/-- **Table 1 / Equation (6.2).** If `(x, M⁻, M⁺)` is a row of Table 1, then
+`M⁻ ≤ (t − ψ(t)) / √t ≤ M⁺` for every `t ∈ [x, 2x]`.
+
+This is the claim *about* `Tables.lean`, the same shape as PNT+'s `eq_6_2`. The last row's
+`2x` exceeds `10¹⁹`; the table still records it because that is what the paper prints. -/
+def table_1_interval_bounds : Prop :=
+  ∀ p ∈ table_1, ∀ t : ℝ,
+    p.1 ≤ t → t ≤ 2 * p.1 →
+      p.2.1 ≤ (t - Chebyshev.psi t) / Real.sqrt t ∧
+        (t - Chebyshev.psi t) / Real.sqrt t ≤ p.2.2
 
 end Buthe.v1

--- a/IEANTN/Nodes/Buthe/v1/Tables.lean
+++ b/IEANTN/Nodes/Buthe/v1/Tables.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 IEANTN contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Tao, Taksh Kothari
+-/
+import IEANTN.Vocabulary.ErrorTerms
+
+/-!
+# Tables: `Buthe.v1`
+
+Data from Büthe, *An analytic method for bounding ψ(x)*, Math. Comp. **87** (2018), 1991–2009.
+Data only — what is claimed *about* it is in `Conclusions.lean`.
+
+Transcribed from the same list already in PrimeNumberTheoremAnd (`Buthe.table_1`), which matches
+the printed Table 1 of arXiv:1511.02032v2: upper and lower bounds `M±_ψ(x)` for
+`(t − ψ(t)) / √t` on each dyadic interval `[x, 2x]`.
+-/
+
+namespace Buthe.v1
+
+/-- **Table 1**: rows `(x, M⁻_ψ(x), M⁺_ψ(x))`.
+
+Equation (6.2) of the paper (and of the PNT+ transcription) reads: if `(x, M⁻, M⁺)` is a row,
+then `M⁻ ≤ (t − ψ(t)) / √t ≤ M⁺` for all `t ∈ [x, 2x]`. The last three rows start at
+`128 · 10¹⁶`, `256 · 10¹⁶` and `512 · 10¹⁶`; twice the last of those is past `10¹⁹`, which is
+the range of Theorem 2, so a consumer that needs a uniform range should stop at a row whose
+`2x` still sits inside that range.
+
+Cross-checked against PNT+'s `table_1` (31 rows) and against the first/last printed blocks
+(`10¹⁰`, `−0.77`, `0.85` and `512 · 10¹⁶`, `−0.83`, `0.94`). -/
+def table_1 : List (ℝ × ℝ × ℝ) :=
+  [
+    (10 ^ 10, -0.77, 0.85),
+    (2 * 10 ^ 10, -0.75, 0.64),
+    (4 * 10 ^ 10, -0.73, 0.80),
+    (8 * 10 ^ 10, -0.80, 0.86),
+    (16 * 10 ^ 10, -0.88, 0.68),
+    (32 * 10 ^ 10, -0.88, 0.78),
+    (64 * 10 ^ 10, -0.66, 0.74),
+    (10 ^ 12, -0.80, 0.81),
+    (2 * 10 ^ 12, -0.79, 0.76),
+    (4 * 10 ^ 12, -0.73, 0.73),
+    (8 * 10 ^ 12, -0.80, 0.76),
+    (16 * 10 ^ 12, -0.80, 0.68),
+    (32 * 10 ^ 12, -0.67, 0.93),
+    (64 * 10 ^ 12, -0.78, 0.77),
+    (10 ^ 14, -0.79, 0.72),
+    (2 * 10 ^ 14, -0.60, 0.76),
+    (4 * 10 ^ 14, -0.65, 0.73),
+    (8 * 10 ^ 14, -0.81, 0.88),
+    (16 * 10 ^ 14, -0.66, 0.86),
+    (32 * 10 ^ 14, -0.74, 0.86),
+    (64 * 10 ^ 14, -0.73, 0.66),
+    (10 ^ 16, -0.88, 0.74),
+    (2 * 10 ^ 16, -0.87, 0.70),
+    (4 * 10 ^ 16, -0.65, 0.73),
+    (8 * 10 ^ 16, -0.82, 0.77),
+    (16 * 10 ^ 16, -0.71, 0.92),
+    (32 * 10 ^ 16, -0.78, 0.71),
+    (64 * 10 ^ 16, -0.94, 0.82),
+    (128 * 10 ^ 16, -0.94, 0.75),
+    (256 * 10 ^ 16, -0.82, 0.86),
+    (512 * 10 ^ 16, -0.83, 0.94)
+  ]
+
+end Buthe.v1

--- a/IEANTN/Nodes/Buthe/v1/formalization.yaml
+++ b/IEANTN/Nodes/Buthe/v1/formalization.yaml
@@ -239,6 +239,21 @@ conclusions:
       nodes and this is `identified`. Whether the Rosser-Schoenfeld citation is an alternative route or
       a step inside that clause has not been determined here, and is worth settling.
   designated: buthe-paper
+- id: table_1_interval_bounds
+  declaration: Buthe.v1.table_1_interval_bounds
+  challenge: Buthe.v1.challenge_table_1_interval_bounds
+  imports_status: traced
+  justifications:
+  - id: buthe-paper
+    kind: literature
+    source: Buthe
+    locator: Table 1, Equation (6.2)
+    note: >-
+      Asserted on the authority of the paper. The entries are in Tables.lean, copied from the PNT+
+      transcription of Table 1 (31 rows) and checked at the first and last printed blocks. Equation
+      (6.2) is the paper's own reading of the table: each row (x, M-, M+) bounds (t - psi(t))/sqrt(t)
+      on [x, 2x]. No external node is an input; the table is Buthe's computation.
+  designated: buthe-paper
 sources:
 - title: An analytic method for bounding psi(x)
   authors:
@@ -280,8 +295,7 @@ limitations:
   zeros as input, and the network can state only that there are none off the critical line below that
   height.
 - >-
-  Theorem 2 is now stated in full, (1.5) through (1.10). The paper's other results -- the sieve bound
-  of Section 6 and the Table 1 data that PNT+ formalizes -- are not stated; the table is the natural first
-  use of a Tables.lean in this node.
+  Theorem 2 is stated in full, (1.5) through (1.10). Table 1 is now in Tables.lean, and
+  table_1_interval_bounds records Equation (6.2). The sieve bound of Section 6 is still unstated.
 - >-
   No novelty is claimed. The results are Buthe's.

--- a/STATE.md
+++ b/STATE.md
@@ -7,7 +7,7 @@ column says what a receipt is presently worth, not merely what was claimed for i
 reason a receipt has stopped standing is below, and `python scripts/ieantn.py status`
 adds the environment detail.
 
-47 node version(s), 91 conclusion(s).  3 state nothing yet.
+47 node version(s), 92 conclusion(s).  3 state nothing yet.
 
 ## Evidence
 
@@ -16,7 +16,7 @@ adds the environment detail.
 | `asserted` | 1 |
 | `bridged` | 1 |
 | `lean-comparator` | 29 |
-| `literature` | 36 |
+| `literature` | 37 |
 | `none-yet` | 5 |
 | `numerical` | 19 |
 
@@ -35,6 +35,7 @@ adds the environment detail.
 | `Buthe.v1` | active | `theorem_2_li_minus_riemann_pi` | literature | 1 | - |
 | `Buthe.v1` | active | `theorem_2_li_minus_pi` | literature | 5 | - |
 | `Buthe.v1` | active | `theorem_2_li_gt_pi` | literature | 4 | - |
+| `Buthe.v1` | active | `table_1_interval_bounds` | literature | 0 | - |
 | `Buthe.v2` | awaiting-solution | `lemma_3_bounds` | none-yet | 0 | #56 |
 | `Buthe.v2` | awaiting-solution | `lemma_3_positivity` | none-yet | 0 | #56 |
 | `Buthe2016.v1` | stub | `theorem_2_psi` | literature | 0 | - |

--- a/docs/nodes/Buthe-v1.md
+++ b/docs/nodes/Buthe-v1.md
@@ -32,7 +32,7 @@ def theorem_2_psi : Prop :=
 |---|---|
 | Lean name | `Buthe.v1.theorem_2_psi` |
 | Challenge | `Buthe.v1.challenge_theorem_2_psi` |
-| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L31) |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L32) |
 | Evidence | cited (`literature`) |
 | Sources traced | traced |
 | Assumes | [`FKBJ.v1.rh_up_to`](FKBJ-v1.md#rh_up_to) |
@@ -58,7 +58,7 @@ def theorem_2_theta : Prop :=
 |---|---|
 | Lean name | `Buthe.v1.theorem_2_theta` |
 | Challenge | `Buthe.v1.challenge_theorem_2_theta` |
-| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L38) |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L39) |
 | Evidence | cited (`literature`) |
 | Sources traced | traced |
 | Assumes | [`FKBJ.v1.rh_up_to`](FKBJ-v1.md#rh_up_to) |
@@ -84,7 +84,7 @@ def theorem_2_theta_lower : Prop :=
 |---|---|
 | Lean name | `Buthe.v1.theorem_2_theta_lower` |
 | Challenge | `Buthe.v1.challenge_theorem_2_theta_lower` |
-| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L45) |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L46) |
 | Evidence | cited (`literature`) |
 | Sources traced | traced |
 | Assumes | [`FKBJ.v1.rh_up_to`](FKBJ-v1.md#rh_up_to) |
@@ -112,7 +112,7 @@ def theorem_2_li_minus_riemann_pi : Prop :=
 |---|---|
 | Lean name | `Buthe.v1.theorem_2_li_minus_riemann_pi` |
 | Challenge | `Buthe.v1.challenge_theorem_2_li_minus_riemann_pi` |
-| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L53) |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L54) |
 | Evidence | cited (`literature`) |
 | Sources traced | traced |
 | Assumes | [`FKBJ.v1.rh_up_to`](FKBJ-v1.md#rh_up_to) |
@@ -143,7 +143,7 @@ def theorem_2_li_minus_pi : Prop :=
 |---|---|
 | Lean name | `Buthe.v1.theorem_2_li_minus_pi` |
 | Challenge | `Buthe.v1.challenge_theorem_2_li_minus_pi` |
-| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L63) |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L64) |
 | Evidence | cited (`literature`) |
 | Sources traced | identified |
 | Assumes | [`FKBJ.v1.rh_up_to`](FKBJ-v1.md#rh_up_to), [`Buthe.v1.theorem_2_theta`](Buthe-v1.md#theorem_2_theta), [`ButheNumerics.v1.lemma_3_constant_nonpos`](ButheNumerics-v1.md#lemma_3_constant_nonpos), [`ButheNumerics.v1.li_minus_pi_below_1e7`](ButheNumerics-v1.md#li_minus_pi_below_1e7), [`Buthe.v2.lemma_3_bounds`](Buthe-v2.md#lemma_3_bounds) |
@@ -169,7 +169,7 @@ def theorem_2_li_gt_pi : Prop :=
 |---|---|
 | Lean name | `Buthe.v1.theorem_2_li_gt_pi` |
 | Challenge | `Buthe.v1.challenge_theorem_2_li_gt_pi` |
-| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L73) |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L74) |
 | Evidence | cited (`literature`) |
 | Sources traced | identified |
 | Assumes | [`FKBJ.v1.rh_up_to`](FKBJ-v1.md#rh_up_to), [`Buthe.v1.theorem_2_theta_lower`](Buthe-v1.md#theorem_2_theta_lower), [`Buthe.v2.lemma_3_positivity`](Buthe-v2.md#lemma_3_positivity), [`ButheNumerics.v1.lemma_3_constant_gt_at_10`](ButheNumerics-v1.md#lemma_3_constant_gt_at_10) |
@@ -179,6 +179,36 @@ def theorem_2_li_gt_pi : Prop :=
 
 > Asserted on the authority of the paper, transcribed from arXiv:1511.02032v2. Note the estimate is against li, the un-offset logarithmic integral, not Li; the two differ by li(2) = 1.045..., which is far from negligible at this precision. Imports: Buthe states that the algorithm 'has been implemented and used to calculate analytic bounds for x <= 10^19, using the zeros with imaginary part up to 10^11, whose calculation has been reported in [5]' -- Franke, Kleinjung, Buthe and Jost, recorded as FKBJ.v1. That is the only external input Theorem 2 has; the analytic method is the paper's own. The edge understates the dependency, because the algorithm consumes the tabulated zeros themselves and the network can only state their consequence; see FKBJ.v1's limitations. Audited against arXiv:1511.02032v2 on 2026-08-26 and confirmed exact: all six equations of Theorem 2 match in constant, threshold and strictness, and the vocabulary matches the paper's own (1.4) -- li is the principal-value integral from 0, pi* is the Riemann prime-counting function. Reclassified from `identified` to `traced`: the edge to FKBJ.v1 is real, but as the note above says it understates the dependency -- the algorithm consumes the tabulated zeros themselves, and a table is not a proposition. `traced` is the value for exactly that, so the understatement is now visible in the graph rather than only in this note. DERIVATION, read from the paper's own proof: "The bound (1.10) follows from (1.7) and [14, Theorem 19]." Not computed either. (1.7) is recorded as an import. Reference [14] is Rosser and Schoenfeld, Approximate formulas for some functions of prime numbers, Illinois J. Math. 6 (1962), 64-94 -- which is NOT the Rosser-Schoenfeld paper this network holds: RosserSchoenfeld.v1 is Sharper bounds for the Chebyshev functions, Math. Comp. 29 (1975). Two different papers by the same pair, which is the same trap BKLNW's two Buthe references set in the other direction. The 1962 paper still has no node. But it turns out not to be needed as an edge: Lemma 3's own "Furthermore" clause, Buthe.v2.lemma_3_positivity, has exactly the shape (1.7) => (1.10) requires, and Buthe proves it by taking a = 10 in (6.17) using ButheNumerics.v1.lemma_3_constant_gt_at_10. So the inputs are all nodes and this is `identified`. Whether the Rosser-Schoenfeld citation is an alternative route or a step inside that clause has not been determined here, and is worth settling.
 
+### `table_1_interval_bounds`
+
+**Table 1 / Equation (6.2).** If `(x, M⁻, M⁺)` is a row of Table 1, then
+`M⁻ ≤ (t − ψ(t)) / √t ≤ M⁺` for every `t ∈ [x, 2x]`.
+
+This is the claim *about* `Tables.lean`, the same shape as PNT+'s `eq_6_2`. The last row's
+`2x` exceeds `10¹⁹`; the table still records it because that is what the paper prints.
+
+```lean
+def table_1_interval_bounds : Prop :=
+  ∀ p ∈ table_1, ∀ t : ℝ,
+    p.1 ≤ t → t ≤ 2 * p.1 →
+      p.2.1 ≤ (t - Chebyshev.psi t) / Real.sqrt t ∧
+        (t - Chebyshev.psi t) / Real.sqrt t ≤ p.2.2
+```
+
+| | |
+|---|---|
+| Lean name | `Buthe.v1.table_1_interval_bounds` |
+| Challenge | `Buthe.v1.challenge_table_1_interval_bounds` |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe/v1/Conclusions.lean#L82) |
+| Evidence | cited (`literature`) |
+| Sources traced | traced |
+| Assumes | nothing recorded |
+| Assumed by | nothing yet |
+
+**Justification `buthe-paper`** — **designated** — literature, Table 1, Equation (6.2)
+
+> Asserted on the authority of the paper. The entries are in Tables.lean, copied from the PNT+ transcription of Table 1 (31 rows) and checked at the first and last printed blocks. Equation (6.2) is the paper's own reading of the table: each row (x, M-, M+) bounds (t - psi(t))/sqrt(t) on [x, 2x]. No external node is an input; the table is Buthe's computation.
+
 ## Limitations
 
 Recorded by the node itself, not derived.
@@ -186,7 +216,7 @@ Recorded by the node itself, not derived.
 - Every conclusion rests on the cited paper; none is proved in Lean here.
 - (1.8), (1.9) and (1.10) are stated against li rather than Li, and (1.8) against the Riemann prime-counting function pi* rather than pi. A node consuming them alongside FKS2, which works with Li and pi, must do the conversions rather than assume them away.
 - The import of FKBJ.v1 records a real dependency but understates it: Buthe's algorithm takes the tabulated zeros as input, and the network can state only that there are none off the critical line below that height.
-- Theorem 2 is now stated in full, (1.5) through (1.10). The paper's other results -- the sieve bound of Section 6 and the Table 1 data that PNT+ formalizes -- are not stated; the table is the natural first use of a Tables.lean in this node.
+- Theorem 2 is stated in full, (1.5) through (1.10). Table 1 is now in Tables.lean, and table_1_interval_bounds records Equation (6.2). The sieve bound of Section 6 is still unstated.
 - No novelty is claimed. The results are Buthe's.
 
 ## How this node was made

--- a/docs/nodes/README.md
+++ b/docs/nodes/README.md
@@ -8,7 +8,7 @@ One page per node: what it claims, in Lean and in prose, and everything recorded
 |---|---|---:|---|
 | [`BKLNW.v1`](BKLNW-v1.md) | paper | 4 | cited |
 | [`Brown1967.v1`](Brown1967-v1.md) | paper | 0 | — |
-| [`Buthe.v1`](Buthe-v1.md) | paper | 6 | cited |
+| [`Buthe.v1`](Buthe-v1.md) | paper | 7 | cited |
 | [`Buthe.v2`](Buthe-v2.md) | pipeline | 2 | unjustified |
 | [`Buthe2016.v1`](Buthe2016-v1.md) | paper | 4 | cited |
 | [`ButheNumerics.v1`](ButheNumerics-v1.md) | computation | 3 | computation |

--- a/fingerprints.json
+++ b/fingerprints.json
@@ -3,6 +3,7 @@
   "BKLNW.v1.table8_psi_bound": "ca438b3fd179bb808eea0af5e6e5756972119f77cac4594002ac23026b21fd88",
   "BKLNW.v1.table8_psi_bound_above": "82db1a5f1d93030d6af49b8fee381dec3d4e9e3cf67570c7ad4da1e097247c49",
   "BKLNW.v1.theta_error_le_one": "947d9d2967ba9f67230b81001b5f1cbab75e675e6b90aac697b953eb2a9b3e4d",
+  "Buthe.v1.table_1_interval_bounds": "61f09b0349336603134fe23fdca49da5deb323d110dbc069c4f617ad57161d14",
   "Buthe.v1.theorem_2_li_gt_pi": "41514450a57e0e4560add9979ed8007a680586add977fb2c9cdb2a6ec86537c7",
   "Buthe.v1.theorem_2_li_minus_pi": "e2c176561fc3b9501e1ca61c8e027906d616a6a6083d7bc3101a266f1dba6f8d",
   "Buthe.v1.theorem_2_li_minus_riemann_pi": "48f94104deec978b966123bbbdcbfcb9a2f75d7a2914dc659c0faf656a7310d8",


### PR DESCRIPTION
Refs #56 (item 1).

Adds \`Tables.lean\` with the 31 rows of Table 1 (same list as PNT+ \`Buthe.table_1\`, checked at the first and last printed blocks) and a conclusion \`table_1_interval_bounds\` for Equation (6.2): each row \`(x, M⁻, M⁺)\` bounds \`(t − ψ(t))/√t\` on \`[x, 2x]\`.

Challenge, graph, state, and the generated node page were regenerated. Fingerprints were not updated locally (no Mathlib checkout here); CI's \`lake exe ieantn_hash\` will need a follow-up commit if the check fails on the new declaration.

Did not touch the kind-\`literature\` vs \`numerical\` question on the issue.
