### PR TITLE
verify: add --pr, so a fork's pull request can be verified in one command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ python scripts/ieantn.py progress <node> [--write]   # where a partial solution'
 python scripts/ieantn.py state          # STATE.md
 python scripts/ieantn.py graph          # GRAPH.md, two Mermaid diagrams
 python scripts/ieantn.py verify <node> --branch <branch>   # dispatch a verification and follow it
+python scripts/ieantn.py verify <node> --pr <n>            # same, for a pull request (fork-safe)
 python scripts/ieantn.py spinoff <conclusion> --out <dir> --compile   # Palomar submission
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,7 +201,21 @@ All holes closed and you believe Comparator will accept it.
 
    ```bash
    python scripts/ieantn.py verify Lcm.v1 --branch <your-branch>
+   python scripts/ieantn.py verify Lcm.v1 --pr 83          # a pull request, fork or not
    ```
+
+   **If you contributed from a fork, the maintainer wants the second form.** `verify.yml` both
+   reads and writes a branch on this repository — the receipt job checks it out and pushes the
+   receipt back to it — so a fork's pull request has no branch for it to use, and `--branch` fails
+   the existence guard without saying that a fork is the reason. `--pr` copies the head to a branch
+   here first, through this repository's own `refs/pull/<n>/head`, so nothing is written to your
+   fork and no access to it is needed. It refuses to move a branch that already exists at a
+   different commit rather than force-pushing over it.
+
+   The receipt then lands on the branch **here**, not on your pull request, so yours still shows
+   the pre-verification state; `--pr` prints the two ways to close that gap when the run succeeds.
+   Whichever is taken, GitHub tends to mark the original *Closed* rather than *Merged* even though
+   the commits landed — that badge understates what happened, and it is worth a comment saying so.
 
    Prefer this over `gh workflow run verify.yml` directly, for three reasons. A run waiting at the
    approval gate looks exactly like one that is building — a spinner and a job name — and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -518,6 +518,7 @@ python scripts/ieantn.py housekeeping     # the derived task queue
 # at the `verification` gate waiting for a human. It cannot approve; approval is the one
 # privileged act here and the gate exists because someone is supposed to have looked at the branch.
 python scripts/ieantn.py verify <node> --branch <branch>
+python scripts/ieantn.py verify <node> --pr <n>
 
 # scaffolding
 python scripts/ieantn.py new-node         # scaffold a node

--- a/docs/NODES.md
+++ b/docs/NODES.md
@@ -287,7 +287,9 @@ Landlock and `systemd-run`, so it does not run on Windows or macOS; WSL2 works f
 (Landlock ABI 3 and `systemd-run` are both present), but keep the clone inside the WSL filesystem —
 Lake builds over `/mnt/c` are pathologically slow.
 
-Dispatch it with `python scripts/ieantn.py verify <node> --branch <branch>` rather than
+Dispatch it with `python scripts/ieantn.py verify <node> --branch <branch>` — or `--pr <n>` for a
+pull request, which is the form to use for anything from a fork, since the receipt job writes to a
+branch on this repository and a fork's pull request has none. Prefer either over
 `gh workflow run verify.yml` directly: a run waiting at the approval gate is drawn exactly like one
 that is building, and that command is the only thing that says so. It cannot approve anything.
 [../CONTRIBUTING.md](../CONTRIBUTING.md) §3 has the full ordering and the three things that catch

--- a/scripts/ieantn.py
+++ b/scripts/ieantn.py
@@ -549,7 +549,92 @@ def local_head_sha() -> str | None:
     return (finished.stdout or "").strip() if finished.returncode == 0 else None
 
 
-def verify(node: str, branch: str, dispatch: bool, precheck: bool = True) -> bool:
+def branch_for_pr(pr: int) -> str | None:
+    """Resolve a pull request to a branch on `origin` that `verify.yml` can check out.
+
+    `verify.yml` takes a branch name and both reads and writes it on THIS repository: the receipt
+    job checks out `inputs.branch` and pushes the receipt back to `refs/heads/$BRANCH`. A pull
+    request from a fork has no such branch, so verifying one used to mean doing this by hand, and
+    the first time anybody tried it the dispatch failed the branch-existence guard with no hint
+    that a fork was the reason.
+
+    For a same-repository pull request there is nothing to do but read the name off it. For a fork,
+    the head is copied to a branch of the same name here. The commit is obtained through
+    `refs/pull/<n>/head`, which GitHub publishes on the BASE repository, so this needs no remote
+    for the contributor's fork and no push access to it -- which is just as well, since pushing to
+    someone else's repository is a different kind of act from pushing to your own.
+    """
+    fields = _gh_json(["pr", "view", str(pr), "--json",
+                       "headRefName,headRefOid,isCrossRepository,state,headRepositoryOwner",
+                       "--jq", "[.state, .headRefName, .headRefOid, "
+                               "(.isCrossRepository|tostring), .headRepositoryOwner.login] | @tsv"])
+    if not fields:
+        print(f"error: cannot read pull request #{pr}")
+        return None
+    state, ref, sha, cross, owner = (fields.split("\t") + [""] * 5)[:5]
+    if state != "OPEN":
+        print(f"error: pull request #{pr} is {state.lower()}, so there is nothing to verify")
+        return None
+
+    if cross != "true":
+        print(f"#{pr} is a branch on this repository: verifying `{ref}` directly")
+        return ref
+
+    existing = remote_branch_sha(ref)
+    if existing == sha:
+        print(f"#{pr} is from {owner}'s fork; `{ref}` here already matches its head")
+        return ref
+
+    # Fetch through the base repository's own pull ref rather than the fork.
+    fetched = subprocess.run(["git", "fetch", "origin", f"refs/pull/{pr}/head"],
+                             cwd=ROOT, capture_output=True, text=True, encoding="utf-8")
+    if fetched.returncode != 0:
+        print(f"error: could not fetch refs/pull/{pr}/head: {(fetched.stderr or '').strip()}")
+        return None
+
+    if existing is not None:
+        print(f"warning: `{ref}` already exists here at {existing[:8]} and #{pr} is at {sha[:8]};")
+        print("         refusing to move it. Delete it, or verify it as it stands with --branch.")
+        return None
+
+    print(f"#{pr} is from {owner}'s fork; copying its head to `{ref}` here so the receipt has")
+    print("  somewhere to land. Nothing is written to the fork.")
+    pushed = subprocess.run(["git", "push", "origin", f"{sha}:refs/heads/{ref}"],
+                            cwd=ROOT, capture_output=True, text=True, encoding="utf-8")
+    if pushed.returncode != 0:
+        print(f"error: could not create `{ref}` on origin: {(pushed.stderr or '').strip()}")
+        return None
+    return ref
+
+
+def report_pr_followup(pr: int, branch: str) -> None:
+    """Say where the receipt went, because it is not where someone would look for it.
+
+    The receipt lands on the branch here, NOT on the contributor's pull request, so #<pr> still
+    shows the pre-verification state and merging it would merge a node with no receipt. Both ways
+    out are worth printing: whichever is taken, GitHub tends to mark the original CLOSED rather
+    than MERGED, and a first-time contributor reading their own pull request cannot tell from that
+    badge that their work was accepted.
+    """
+    print()
+    print("=" * 72)
+    print(f"  THE RECEIPT IS ON `{branch}` HERE, NOT ON #{pr}.")
+    print(f"  Merging #{pr} as it stands would merge the node without its receipt.")
+    print()
+    print("  Either push the receipt into the fork, if the contributor allowed edits:")
+    print(f"    git fetch origin {branch}")
+    print(f"    git push <their-remote> FETCH_HEAD:{branch}")
+    print(f"  or open a pull request from `{branch}` and merge that instead:")
+    print(f"    gh pr create --head {branch} --title '<node>: verified'")
+    print()
+    print(f"  The second closes #{pr} automatically only if its head is an ancestor, and GitHub")
+    print("  marks it CLOSED rather than MERGED either way. Say so in a comment -- the badge")
+    print("  understates what happened, and the contributor has no other way to tell.")
+    print("=" * 72)
+
+
+def verify(node: str, branch: str, dispatch: bool, precheck: bool = True,
+           pr: int | None = None) -> bool:
     """Dispatch `verify.yml` and follow it, making the approval gate impossible to miss.
 
     This exists because `gh run watch` draws a run that has not started identically to one that is
@@ -650,7 +735,10 @@ def verify(node: str, branch: str, dispatch: bool, precheck: bool = True) -> boo
             print(f"run {run_id} completed: {conclusion}")
             print(f"  {url}")
             if conclusion == "success":
-                print("  the receipt is on the branch; open a pull request for it")
+                if pr is not None:
+                    report_pr_followup(pr, branch)
+                else:
+                    print("  the receipt is on the branch; open a pull request for it")
             return conclusion == "success"
         else:
             jobs = _gh_json(["api", f"repos/{repository}/actions/runs/{run_id}/jobs",
@@ -3776,7 +3864,11 @@ def main() -> int:
                          help="record the derived hole count in formalization.yaml")
     verification = sub.add_parser("verify")
     verification.add_argument("node", help="e.g. Lcm.v1")
-    verification.add_argument("--branch", required=True, help="branch to record the receipt on")
+    target = verification.add_mutually_exclusive_group(required=True)
+    target.add_argument("--branch", help="branch to record the receipt on")
+    target.add_argument("--pr", type=int, metavar="N",
+                        help="verify pull request N; a fork's head is copied to a branch here "
+                             "first, since the receipt job writes to this repository")
     verification.add_argument("--watch-only", action="store_true",
                               help="follow the latest run instead of dispatching a new one")
     verification.add_argument("--skip-precheck", action="store_true",
@@ -3843,8 +3935,13 @@ def main() -> int:
     if args.command == "progress":
         return 0 if progress(args.node, args.write) else 1
     if args.command == "verify":
-        return 0 if verify(args.node, args.branch, not args.watch_only,
-                           precheck=not args.skip_precheck) else 1
+        branch = args.branch
+        if args.pr is not None:
+            branch = branch_for_pr(args.pr)
+            if branch is None:
+                return 1
+        return 0 if verify(args.node, branch, not args.watch_only,
+                           precheck=not args.skip_precheck, pr=args.pr) else 1
     if args.command == "spinoff":
         return 0 if spinoff(args.conclusion, args.out, args.compile) else 1
     if args.command == "new-version":

--- a/tests/test_ieantn.py
+++ b/tests/test_ieantn.py
@@ -891,6 +891,78 @@ class TestVerifyApprovalNotice(FixtureRepo):
         self.assertIn("completed: success", out)
 
 
+class TestVerifyAPullRequest(FixtureRepo):
+    """`--pr` exists because the receipt job writes to a branch on THIS repository.
+
+    A fork's pull request has no such branch, so the first attempt at verifying one failed the
+    branch-existence guard with nothing to say that a fork was the reason.
+    """
+
+    def _resolve(self, fields: str, pushes: list[list[str]] | None = None,
+                 existing: str | None = None) -> tuple[str | None, str]:
+        recorded = pushes if pushes is not None else []
+
+        def fake_gh(args: list[str]) -> str:
+            return fields if args[0] == "pr" else ""
+
+        def fake_run(args: list[str], **_: object) -> object:
+            recorded.append(args)
+            return ieantn.subprocess.CompletedProcess(args, 0, "", "")
+
+        printed = io.StringIO()
+        with unittest.mock.patch.object(ieantn, "_gh_json", fake_gh), \
+             unittest.mock.patch.object(ieantn.subprocess, "run", fake_run), \
+             unittest.mock.patch.object(ieantn, "remote_branch_sha", lambda _: existing), \
+             contextlib.redirect_stdout(printed):
+            return ieantn.branch_for_pr(83), printed.getvalue()
+
+    def test_a_same_repository_pr_is_used_as_is_and_nothing_is_pushed(self) -> None:
+        pushes: list[list[str]] = []
+        branch, _ = self._resolve("OPEN\tmy-branch\tabc123\tfalse\tteorth", pushes)
+        self.assertEqual(branch, "my-branch")
+        self.assertEqual(pushes, [], "a branch already here needs no copying")
+
+    def test_a_fork_head_is_copied_to_a_branch_here(self) -> None:
+        pushes: list[list[str]] = []
+        branch, out = self._resolve("OPEN\ttheirs\tdeadbeef\ttrue\tcontributor", pushes)
+        self.assertEqual(branch, "theirs")
+        # Fetched through the BASE repository's pull ref, so no access to the fork is needed.
+        self.assertIn(["git", "fetch", "origin", "refs/pull/83/head"], pushes)
+        self.assertIn(["git", "push", "origin", "deadbeef:refs/heads/theirs"], pushes)
+        self.assertIn("Nothing is written to the fork", out)
+
+    def test_a_closed_pr_is_refused(self) -> None:
+        branch, out = self._resolve("MERGED\ttheirs\tdeadbeef\ttrue\tcontributor")
+        self.assertIsNone(branch)
+        self.assertIn("nothing to verify", out)
+
+    def test_an_existing_branch_at_a_different_commit_is_never_moved(self) -> None:
+        """Silently force-pushing over someone's branch is the one unrecoverable move here."""
+        pushes: list[list[str]] = []
+        branch, out = self._resolve("OPEN\ttheirs\tdeadbeef\ttrue\tcontributor", pushes,
+                                    existing="0ldc0de")
+        self.assertIsNone(branch)
+        self.assertNotIn(["git", "push", "origin", "deadbeef:refs/heads/theirs"], pushes)
+        self.assertIn("refusing to move it", out)
+
+    def test_an_existing_branch_already_at_the_head_is_reused(self) -> None:
+        pushes: list[list[str]] = []
+        branch, _ = self._resolve("OPEN\ttheirs\tdeadbeef\ttrue\tcontributor", pushes,
+                                  existing="deadbeef")
+        self.assertEqual(branch, "theirs")
+        self.assertEqual(pushes, [], "re-running a verification must not re-push")
+
+    def test_the_followup_says_the_receipt_is_not_on_the_pull_request(self) -> None:
+        """The receipt lands here, not on the contributor's PR, and merging theirs would miss it."""
+        printed = io.StringIO()
+        with contextlib.redirect_stdout(printed):
+            ieantn.report_pr_followup(83, "theirs")
+        out = printed.getvalue()
+        self.assertIn("NOT ON #83", out)
+        self.assertIn("without its receipt", out)
+        self.assertIn("CLOSED rather than MERGED", out)
+
+
 class TestTracedStatus(FixtureRepo):
     """`traced`: the inputs are known, and at least one of them is not an edge.
 


### PR DESCRIPTION
Comes out of verifying #83 — `PrimeInterval.v1`, the repository's first external node contribution.

`verify.yml` both reads *and writes* a branch on this repository: the receipt job checks out `inputs.branch` and pushes the receipt back to `refs/heads/$BRANCH`. A fork's pull request has no such branch, so `--branch primeinterval-v1` failed the existence guard with nothing to indicate a fork was the reason. Getting that one through took a manual branch push, a first-time-contributor CI approval gate, a blocked push to the fork, and a second PR (#84) opened to carry the receipt.

### What `--pr` does

```bash
python scripts/ieantn.py verify PrimeInterval.v1 --pr 83
```

Uses the branch directly when the PR is from this repository. For a fork, copies the head to a branch of the same name through **this repository's own `refs/pull/<n>/head`** — so no remote for the fork, and no push access to it. That distinction is the point: pushing to someone else's repository is a different kind of act from pushing to your own, and this never does it.

It **refuses to move a branch that already exists at a different commit** rather than force-pushing over it, and reuses one already at the head so a re-run pushes nothing.

### What it deliberately does not do

It cannot put the receipt on the contributor's pull request — that would mean writing to their fork. So it explains instead. On success:

```
  THE RECEIPT IS ON `theirs` HERE, NOT ON #83.
  Merging #83 as it stands would merge the node without its receipt.
```

…followed by both ways to close the gap, and the warning that GitHub marks the original **Closed** rather than **Merged** either way. That badge understates what happened, and a first-time contributor has no other way to read it — #83 hit exactly this.

### Tests

Six, and the two that matter were mutation-checked rather than merely observed to pass: removing the existing-branch guard fails one, and fetching from the fork instead of the base pull ref fails another.

Docs updated in `CONTRIBUTING.md` §3, `CLAUDE.md`, `docs/ARCHITECTURE.md` and `docs/NODES.md`.

Gate: `check` 8/8, 200 tests, pyright 0/0/0, `lake build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)