### PR TITLE
CH2.v1: the sup bound CH2.v3 was said to need, it does not need

### DIFF
--- a/Solutions/CH2.v1/progress.yaml
+++ b/Solutions/CH2.v1/progress.yaml
@@ -162,11 +162,38 @@ stages:
       argument needs -- negative at one point plus decreasing gives negative thereafter -- so the
       conclusion stands and only the justification sentence is wrong. Do not formalize that sentence
       as written.
-      Second warning: CH2.v3 states its approximant EXISTENTIALLY, pinning only phi 0 and the L1
-      error; the residue weights need pointwise control of phi, so a sup bound will have to be added
-      to that node. Adding a third conclusion there should not disturb its two receipts, whose
-      fingerprints do not move, but re-verification will need comparator.json extended to cover all
-      three.
+      CH2.v3 NEEDS NO SUP BOUND. An earlier revision of this file warned that it would: that the
+      residue weights need pointwise control of the approximant, that CH2.v3 states it only
+      existentially -- pinning phi 0 and the L1 error and nothing else -- and that a third
+      conclusion would therefore have to be added to a node that is already green. That was wrong,
+      and it is recorded here rather than deleted because it was wrong in a direction that costs
+      work: it would have sent someone to re-open a verified node for no reason.
+      The residue weights are not the approximant. They are omega^+_{T,sigma} and theta_{T,sigma},
+      defined in Theorem 1.1 as
+        omega^+_{T,sigma}(s) = -theta_{T,sigma}(s) cot(pi theta_{T,sigma}(s)) + c_{T,sigma},
+        theta_{T,sigma}(s)   = 1 - (s - sigma)/(i T),
+        c_{T,sigma}          = theta_{T,sigma}(1 + iT) cot(pi theta_{T,sigma}(1 + iT)),
+      which are elementary closed forms in s, T and sigma. Section 7 estimates them by comparison
+      with F(z) = 1/pi - (1-z) cot(pi (1-z)) in its Lemma cor:thonny, again elementary. Nothing in
+      that argument evaluates the approximant anywhere.
+      COUNTED IN THE SOURCE, not inferred: across sections 7, 8, 9 and 10 the token varphi occurs
+      ZERO times, and Phi_lambda once, in a remark observing that the weight is the same object --
+      not in a step. All 137 live occurrences of varphi are in sections 2, 4 and 6, the
+      introduction, and an appendix.
+      Where pointwise control IS needed is section 6, the proof of Theorem 1.1, which uses Phi_lambda
+      and varphi throughout. That does not resurrect the problem, for two reasons. Section 6 is the
+      stage above that may not be needed at all. And Phi_lambda is itself explicit --
+        (Phi_lambda^o +- Phi_lambda^*)(z) = 1/(1 - e^u) +- (sgn(lambda)/(2 pi i))
+                                            (u/(e^u - 1) + |lambda|/(e^{-|lambda|} - 1)),
+        u = u(z) = 2 pi i sgn(lambda) z - |lambda|,
+      so a formalization of section 6 would define it directly rather than reach for CH2.v3, whose
+      existential statement was never the right source for a pointwise fact anyway.
+      A WARNING ABOUT READING THIS SOURCE, which is probably how the mistake happened. 46 per cent
+      of VonMangoldt.tex is inside \begin{comment} blocks, including long stretches of Phi_lambda
+      material with lemma statements and proofs in them. A grep over the raw file finds text that is
+      not in the paper -- Phi_lambda alone drops from 57 hits to 31 once comments are stripped.
+      Strip \begin{comment}...\end{comment} and percent-comments before concluding anything from a
+      count.
 
   - stage: "corollary 1.3: the numerics"
     state: not started


### PR DESCRIPTION
`progress.yaml` warned that §7's residue weights need pointwise control of the extremal approximant, that `CH2.v3` states it only existentially (pinning `φ 0` and the L¹ error and nothing else), and that a third conclusion would therefore have to be added to a node that is **already green and verified**. Checked against the arXiv source, that is wrong.

### The residue weights are not the approximant

Theorem 1.1 defines them in closed form:

```
ω⁺_{T,σ}(s) = −θ_{T,σ}(s)·cot(π θ_{T,σ}(s)) + c_{T,σ}
θ_{T,σ}(s)  = 1 − (s − σ)/(iT)
c_{T,σ}     = θ_{T,σ}(1+iT)·cot(π θ_{T,σ}(1+iT))
```

§7's Lemma `cor:thonny` estimates these against `F(z) = 1/π − (1−z)cot(π(1−z))` — again elementary. Nothing in that argument evaluates the approximant anywhere.

Counted in the source rather than inferred, over the **live** text:

| symbol | §7 | §8 | §9 | §10 |
|---|---|---|---|---|
| `\varphi` | 0 | 0 | 0 | 0 |
| `Φ_λ` | 1 (a remark, not a step) | 0 | 0 | 0 |

All 137 live occurrences of `\varphi` are in §2, §4, §6, the introduction and an appendix.

### Where pointwise control really is needed

§6, the proof of Theorem 1.1. That doesn't resurrect the problem: §6 is the stage `progress.yaml` already marks as possibly unnecessary, and `Φ_λ` is itself explicit, so a formalization would define it directly. An existential statement was never the right source for a pointwise fact.

### How the mistake was probably made

**46% of `VonMangoldt.tex` is inside `\begin{comment}` blocks** — including long stretches of `Φ_λ` material with lemma statements and proofs in them. A grep over the raw file reads text that is not in the paper: `Φ_λ` drops from 57 hits to 31 once comments are stripped. Worth knowing for anyone else reading this source.

The wrong warning is recorded rather than deleted, since it was wrong in the expensive direction — it would have sent someone to re-open a verified node and extend its `comparator.json` for no reason.

No Lean changes; `progress.yaml` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)