### PR TITLE
Migrate the digamma work into Solutions/GammaAsymptotics.v2

### DIFF
--- a/IEANTN/Nodes/GammaAsymptotics/v2/formalization.yaml
+++ b/IEANTN/Nodes/GammaAsymptotics/v2/formalization.yaml
@@ -68,7 +68,10 @@ conclusions:
       is a Mathlib contribution in its own right rather than a step private to this repository.
       THE CONSTANT MAY DEPEND ON H AND MUST. A bound uniform in H is exactly v1.
   designated: unjustified
-  designated: unjustified
+  progress:
+    solution: Solutions/GammaAsymptotics.v2/
+    state: in-progress
+    remaining_holes: 1
 
 sources:
 - title: "The digamma asymptotic expansion"
@@ -105,10 +108,19 @@ review:
     conclusion here rather than sharpen this one -- they are different statements.
     What the applications actually consume is the corollary ||psi w|| <= ||log w|| + C, hence
     O(log|w|); that follows immediately and is not stated separately.
-    Mathlib was checked rather than assumed: Analysis/SpecialFunctions/Gamma/Digamma.lean is 64 lines
-    and contains the definition, digamma_zero, digamma_one, digamma_one_half, digamma_apply_add_one
-    and meromorphic_digamma, and no bound of any kind. Analysis/SpecialFunctions/Stirling.lean is
-    about the factorial, not Gamma on the complex plane.
+    Mathlib was checked rather than assumed, and RE-CHECKED after the bump, which moved it. On this
+    repository's pin (mathlib 71a80585) Analysis/SpecialFunctions/Gamma/Digamma.lean is 153 lines
+    and contains the definition, digamma_zero, digamma_one, digamma_one_half, digamma_apply_add_one,
+    digamma_apply_add_nat, digamma_nat_add_one, Euler's reflection formula digamma_one_sub, the
+    duplication formula digamma_two_mul, and meromorphic_digamma -- AND STILL NO BOUND OF ANY KIND,
+    which is the half of the observation this node turns on. Gauss' integral representation remains
+    a TODO in that file. Analysis/SpecialFunctions/Stirling.lean is about the factorial, not Gamma on
+    the complex plane.
+    WHEN FIRST WRITTEN THIS ENTRY SAID SIXTY-FOUR LINES AND LISTED FIVE THEOREMS. That was accurate
+    then. It is recorded here rather than silently overwritten because the way it went stale is
+    general: a Mathlib bump changes what the repository may assume, and prose claims about what
+    Mathlib contains rot without any Lean file changing and without any check failing. Nothing in
+    this repository verifies a sentence like the one above; only someone going to look does.
 
 limitations:
 - >-
@@ -125,10 +137,11 @@ limitations:
 - >-
   Re w >= 1 excludes the left half-plane entirely, where digamma has its poles. An application that
   needs psi there must combine this with the reflection formula
-  psi(1-w) - psi(w) = pi cot(pi w), which a more recent Mathlib than this repository's pin has
-  merged (leanprover-community/mathlib4#42349). So that gap closes on a bump rather than needing a
-  conclusion here -- but note the reflection formula alone proves nothing about growth, in either
-  half-plane, so it does not shorten the work below.
+  psi(1-w) - psi(w) = pi cot(pi w). THAT IS NOW AVAILABLE: this entry previously said it awaited a
+  more recent Mathlib than this repository's pin, and the bump that brought it
+  (leanprover-community/mathlib4#42349) has since happened, so it is Complex.digamma_one_sub on the
+  current pin. But note the reflection formula alone proves nothing about growth, in either
+  half-plane, so having it does not shorten the work below.
   CH2.v1 does not need the left half-plane: its ladder argument evaluates psi at 1-s with
   Re(1-s) >= 2, which is already inside the stated range.
 - >-

--- a/Solutions/GammaAsymptotics.v2/GaussSeries.lean
+++ b/Solutions/GammaAsymptotics.v2/GaussSeries.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 IEANTN contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Tao
+-/
+import Mathlib.Analysis.SpecialFunctions.Gamma.Digamma
+import Mathlib.Analysis.PSeries
+
+/-!
+# Stage 2a: the Gauss series converges
+
+`ψ(s) = -γ + ∑ₖ (1/(k+1) - 1/(k+s))`. This file does the convergence and nothing else: the
+summand is
+
+  `1/(k+1) - 1/(k+s) = (s-1) / ((k+1)(k+s))`,
+
+which is `O(1/k²)` once `k` is past `2‖s‖`, so the series converges absolutely.
+
+Mathlib defines `Complex.digamma` and lists this representation as a `TODO` in the same file; the
+series here is the left-hand side of that missing theorem, defined so the rest of the solution can
+talk about it before it has been identified with `ψ`.
+-/
+
+namespace GammaSolution
+
+open Complex
+
+/-- The summand of the Gauss series. -/
+noncomputable def gaussTerm (s : ℂ) (k : ℕ) : ℂ := ((k : ℂ) + 1)⁻¹ - ((k : ℂ) + s)⁻¹
+
+/-- The summand in the form that exhibits its size: `(s-1)/((k+1)(k+s))`. -/
+theorem gaussTerm_eq {s : ℂ} (hs : ∀ n : ℕ, s ≠ -n) (k : ℕ) :
+    gaussTerm s k = (s - 1) / (((k : ℂ) + 1) * ((k : ℂ) + s)) := by
+  have h1 : ((k : ℂ) + 1) ≠ 0 := by
+    intro h
+    have : ((k : ℝ) + 1) = 0 := by exact_mod_cast congrArg Complex.re h
+    have : (0 : ℝ) ≤ (k : ℝ) := Nat.cast_nonneg k
+    linarith
+  have h2 : ((k : ℂ) + s) ≠ 0 := fun h ↦ hs k (by linear_combination h)
+  simp only [gaussTerm]
+  field_simp
+  ring
+
+/-- **The Gauss series converges absolutely.** -/
+theorem summable_gaussTerm {s : ℂ} (hs : ∀ n : ℕ, s ≠ -n) : Summable (gaussTerm s) := by
+  -- Compare with `2‖s-1‖ / k²` past `k ≥ 2‖s‖`.
+  obtain ⟨N, hN⟩ := exists_nat_gt (2 * ‖s‖)
+  have hcomp : Summable (fun k : ℕ ↦ 2 * ‖s - 1‖ / (k : ℝ) ^ 2) := by
+    simpa [div_eq_mul_inv] using
+      (Real.summable_one_div_nat_pow.mpr one_lt_two).mul_left (2 * ‖s - 1‖)
+  refine Summable.of_norm_bounded_eventually_nat hcomp ?_
+  filter_upwards [Filter.eventually_ge_atTop (max N 1)] with k hk
+  have hkN : (N : ℝ) ≤ (k : ℝ) := by exact_mod_cast le_trans (le_max_left N 1) hk
+  have hk1 : (1 : ℝ) ≤ (k : ℝ) := by exact_mod_cast le_trans (le_max_right N 1) hk
+  have hks : 2 * ‖s‖ < (k : ℝ) := lt_of_lt_of_le hN hkN
+  -- `‖k + s‖ ≥ k - ‖s‖ ≥ k/2`.
+  have hlow : (k : ℝ) / 2 ≤ ‖(k : ℂ) + s‖ := by
+    have h := norm_sub_norm_le ((k : ℂ)) (-s)
+    simp only [norm_neg, sub_neg_eq_add] at h
+    have hkabs : ‖((k : ℕ) : ℂ)‖ = (k : ℝ) := by
+      simp
+    rw [hkabs] at h
+    linarith
+  have hpos : (0 : ℝ) < (k : ℝ) := by linarith
+  rw [gaussTerm_eq hs k, norm_div, norm_mul]
+  have hk1n : ‖((k : ℂ) + 1)‖ = (k : ℝ) + 1 := by
+    have hcast : ((k : ℂ) + 1) = (((k : ℝ) + 1 : ℝ) : ℂ) := by push_cast; ring
+    rw [hcast, Complex.norm_real, Real.norm_of_nonneg (by linarith)]
+  rw [hk1n]
+  have hs1 : (0 : ℝ) ≤ ‖s - 1‖ := norm_nonneg _
+  have hnormpos : (0 : ℝ) < ‖(k : ℂ) + s‖ := by linarith
+  have hden1 : (0 : ℝ) < ((k : ℝ) + 1) * ‖(k : ℂ) + s‖ :=
+    mul_pos (by linarith) hnormpos
+  have hden2 : (0 : ℝ) < (k : ℝ) ^ 2 := by nlinarith
+  rw [div_le_div_iff₀ hden1 hden2]
+  -- `2‖s-1‖ (k+1)‖k+s‖ ≥ 2‖s-1‖ (k+1)(k/2) = ‖s-1‖ (k+1) k ≥ ‖s-1‖ k²`.
+  have hmul : ((k : ℝ) + 1) * ((k : ℝ) / 2) ≤ ((k : ℝ) + 1) * ‖(k : ℂ) + s‖ :=
+    mul_le_mul_of_nonneg_left hlow (by linarith)
+  nlinarith [hmul, hs1, hk1, hpos]
+
+end GammaSolution

--- a/Solutions/GammaAsymptotics.v2/Periodic.lean
+++ b/Solutions/GammaAsymptotics.v2/Periodic.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 IEANTN contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Tao
+-/
+import Mathlib.Algebra.Ring.Periodic
+import Mathlib.Analysis.SpecificLimits.Basic
+
+/-!
+# The vanishing lemma
+
+A 1-periodic function that vanishes at the naturals and varies by `O(1/n)` across unit intervals
+far out is identically zero on the positive reals.
+
+This is the whole content of identifying `ψ` with its Gauss series on the reals, isolated from the
+series so it can be checked on its own. Periodicity lets any point be pushed arbitrarily far
+right, where the oscillation bound is arbitrarily tight and a zero of `E` always sits within
+distance one.
+
+**The naive version — `E` vanishes at the naturals and is periodic, therefore zero — does not
+work, and believing it cost this project a wrong claim in an earlier draft of the node
+docstring**: periodicity spreads `E 1 = 0` to the integers and nowhere else. A 1-periodic function
+vanishing on `ℤ` is otherwise entirely unconstrained. The oscillation hypothesis is what reaches
+between the integers, and it is supplied on both sides by Stage 1 (`ψ` fluctuates by `O(1/x)`
+across a unit interval) and by a telescoping comparison for the series.
+
+Nothing here is about `Γ`; it is a statement about real functions, and it is stated that way
+deliberately so that the analytic input and the soft argument can be audited apart.
+-/
+
+namespace GammaSolution
+
+/-- **A 1-periodic function vanishing at the naturals, with `O(1/n)` oscillation, is zero.** -/
+theorem eq_zero_of_periodic_of_nat_of_oscillation {E : ℝ → ℝ} {C : ℝ}
+    (hper : Function.Periodic E 1)
+    (hnat : ∀ n : ℕ, E ((n : ℝ) + 1) = 0)
+    (hosc : ∀ n : ℕ, 1 ≤ n → ∀ a b : ℝ, (n : ℝ) ≤ a → (n : ℝ) ≤ b → |a - b| ≤ 1 →
+      |E a - E b| ≤ C / n)
+    {x : ℝ} (hx : 0 < x) : E x = 0 := by
+  have key : ∀ n : ℕ, 1 ≤ n → |E x| ≤ C / n := by
+    intro n hn
+    set m : ℕ := ⌊x⌋₊ with hm
+    have hmx : (m : ℝ) ≤ x := Nat.floor_le hx.le
+    have hxm : x < (m : ℝ) + 1 := Nat.lt_floor_add_one x
+    have hmnn : (0 : ℝ) ≤ (m : ℝ) := Nat.cast_nonneg m
+    have hnnn : (0 : ℝ) ≤ (n : ℝ) := Nat.cast_nonneg n
+    -- Push `x` right by `n`; compare with the zero of `E` at `m + n + 1`.
+    have hEx : E x = E (x + n) := by simpa using (hper.nat_mul n x).symm
+    have hzero : E (((m + n : ℕ) : ℝ) + 1) = 0 := hnat (m + n)
+    have hle_a : (n : ℝ) ≤ x + n := by linarith
+    have hle_b : (n : ℝ) ≤ ((m + n : ℕ) : ℝ) + 1 := by push_cast; linarith
+    have hclose : |(x + n) - (((m + n : ℕ) : ℝ) + 1)| ≤ 1 := by
+      push_cast
+      rw [abs_le]
+      constructor <;> linarith
+    have hb := hosc n hn (x + n) (((m + n : ℕ) : ℝ) + 1) hle_a hle_b hclose
+    rwa [hzero, sub_zero, ← hEx] at hb
+  -- `C / n → 0`, so a quantity below all of them is at most zero.
+  have hlim : Filter.Tendsto (fun n : ℕ ↦ C / (n : ℝ)) Filter.atTop (nhds 0) :=
+    tendsto_const_div_atTop_nhds_zero_nat C
+  have hle : |E x| ≤ 0 :=
+    ge_of_tendsto hlim (Filter.eventually_atTop.mpr ⟨1, fun n hn ↦ key n hn⟩)
+  exact abs_nonpos_iff.mp hle
+
+end GammaSolution

--- a/Solutions/GammaAsymptotics.v2/RealAsymptotic.lean
+++ b/Solutions/GammaAsymptotics.v2/RealAsymptotic.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 IEANTN contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Tao
+-/
+import Mathlib.Analysis.SpecialFunctions.Gamma.BohrMollerup
+import Mathlib.Analysis.SpecialFunctions.Gamma.Deriv
+import Mathlib.Analysis.Convex.Deriv
+import Mathlib.Analysis.Calculus.Deriv.MeanValue
+
+/-!
+# Stage 1: `|ψ(x) − log x| ≤ 1/x` for real `x > 0`
+
+The digamma asymptotic on the reals, from log-convexity alone — no series and no integral
+representation. `log Γ` is convex, so its derivative is monotone; the slope of `log Γ` across
+`[x, x+1]` is exactly `log x`, because `Γ(x+1) = x Γ(x)`; and the mean value theorem puts that
+slope between the derivative at `x` and at `x+1`, which differ by `1/x`.
+
+**This is the piece the node's own docstring said would need a Gauss or Binet representation, and
+it does not.** `Real.convexOn_log_Gamma` is enough. The Gauss series is still wanted downstream —
+it is what identifies `ψ` with the series on all of `ℂ` — but the *asymptotic itself*, on the
+reals, with an explicit constant `1`, comes out of convexity in a hundred lines.
+
+Mathlib has no `Real.digamma`, so the derivative is spelled `deriv (fun t ↦ log (Γ t))`
+throughout; `Complex.digamma` restricted to the reals agrees with it, and connecting the two is
+Stage 3's business, not this file's.
+-/
+
+namespace GammaSolution
+
+open Real Set
+
+/-- `log ∘ Γ` is differentiable on the positive reals. -/
+theorem differentiableAt_log_Gamma {x : ℝ} (hx : 0 < x) :
+    DifferentiableAt ℝ (fun t ↦ Real.log (Real.Gamma t)) x := by
+  have hΓ : DifferentiableAt ℝ Real.Gamma x :=
+    Real.differentiableAt_Gamma (fun m ↦ by
+      intro hcon
+      have hm : (0 : ℝ) ≤ (m : ℝ) := Nat.cast_nonneg m
+      rw [hcon] at hx
+      linarith)
+  exact (Real.differentiableAt_log (Real.Gamma_pos_of_pos hx).ne').comp x hΓ
+
+/-- The slope of `log Γ` across `[x, x+1]` is `log x`. -/
+theorem log_Gamma_add_one_sub {x : ℝ} (hx : 0 < x) :
+    Real.log (Real.Gamma (x + 1)) - Real.log (Real.Gamma x) = Real.log x := by
+  rw [Real.Gamma_add_one hx.ne', Real.log_mul hx.ne' (Real.Gamma_pos_of_pos hx).ne']
+  ring
+
+/-- **The recurrence**, `ψ(x+1) = ψ(x) + 1/x`, by differentiating
+`log Γ(t+1) = log t + log Γ(t)` — an identity that holds on a whole neighbourhood of `x`, which
+is what lets the derivatives be compared. -/
+theorem deriv_log_Gamma_add_one {x : ℝ} (hx : 0 < x) :
+    deriv (fun t ↦ Real.log (Real.Gamma t)) (x + 1)
+      = deriv (fun t ↦ Real.log (Real.Gamma t)) x + 1 / x := by
+  have hpos : {t : ℝ | 0 < t} ∈ nhds x :=
+    (isOpen_lt continuous_const continuous_id).mem_nhds hx
+  have hEq : (fun t : ℝ ↦ Real.log t + Real.log (Real.Gamma t))
+      =ᶠ[nhds x] (fun t : ℝ ↦ Real.log (Real.Gamma (t + 1))) := by
+    filter_upwards [hpos] with t ht
+    rw [Real.Gamma_add_one (ne_of_gt ht), Real.log_mul (ne_of_gt ht)
+      (Real.Gamma_pos_of_pos ht).ne']
+  -- The left side, differentiated through the shift.
+  have hL : HasDerivAt (fun t : ℝ ↦ Real.log (Real.Gamma (t + 1)))
+      (deriv (fun t ↦ Real.log (Real.Gamma t)) (x + 1)) x := by
+    have hshift : HasDerivAt (fun t : ℝ ↦ t + 1) 1 x := (hasDerivAt_id x).add_const 1
+    have hout := (differentiableAt_log_Gamma (by linarith : (0:ℝ) < x + 1)).hasDerivAt
+    simpa [Function.comp_def] using hout.comp x hshift
+  -- The right side, differentiated termwise.
+  have hR : HasDerivAt (fun t : ℝ ↦ Real.log t + Real.log (Real.Gamma t))
+      (x⁻¹ + deriv (fun t ↦ Real.log (Real.Gamma t)) x) x :=
+    (Real.hasDerivAt_log hx.ne').add (differentiableAt_log_Gamma hx).hasDerivAt
+  have hLR : HasDerivAt (fun t : ℝ ↦ Real.log t + Real.log (Real.Gamma t))
+      (deriv (fun t ↦ Real.log (Real.Gamma t)) (x + 1)) x := hL.congr_of_eventuallyEq hEq
+  have := hLR.unique hR
+  rw [this, one_div]
+  ring
+
+/-- `ψ` is monotone on the positive reals, because `log Γ` is convex there. -/
+theorem monotoneOn_deriv_log_Gamma :
+    MonotoneOn (deriv (fun t ↦ Real.log (Real.Gamma t))) (Ioi 0) :=
+  Real.convexOn_log_Gamma.monotoneOn_deriv (fun _ hx ↦ differentiableAt_log_Gamma hx)
+
+/-- **The squeeze**: `ψ(x) ≤ log x ≤ ψ(x+1)`. -/
+theorem deriv_log_Gamma_le_log_le {x : ℝ} (hx : 0 < x) :
+    deriv (fun t ↦ Real.log (Real.Gamma t)) x ≤ Real.log x ∧
+      Real.log x ≤ deriv (fun t ↦ Real.log (Real.Gamma t)) (x + 1) := by
+  have hsub : Icc x (x + 1) ⊆ Ioi 0 := fun t ht ↦ lt_of_lt_of_le hx ht.1
+  have hcont : ContinuousOn (fun t ↦ Real.log (Real.Gamma t)) (Icc x (x + 1)) := fun t ht ↦
+    (differentiableAt_log_Gamma (hsub ht)).continuousAt.continuousWithinAt
+  obtain ⟨c, hc, hcs⟩ :=
+    exists_deriv_eq_slope (fun t ↦ Real.log (Real.Gamma t)) (by linarith) hcont
+      (fun t ht ↦ (differentiableAt_log_Gamma (lt_trans hx ht.1)).differentiableWithinAt)
+  have hslope : (Real.log (Real.Gamma (x + 1)) - Real.log (Real.Gamma x)) / (x + 1 - x)
+      = Real.log x := by
+    rw [add_sub_cancel_left, div_one, log_Gamma_add_one_sub hx]
+  rw [hslope] at hcs
+  have hcpos : (0 : ℝ) < c := lt_trans hx hc.1
+  have h1 : deriv (fun t ↦ Real.log (Real.Gamma t)) x ≤ Real.log x := by
+    rw [← hcs]
+    exact monotoneOn_deriv_log_Gamma (Set.mem_Ioi.mpr hx) (Set.mem_Ioi.mpr hcpos) hc.1.le
+  have h2 : Real.log x ≤ deriv (fun t ↦ Real.log (Real.Gamma t)) (x + 1) := by
+    rw [← hcs]
+    exact monotoneOn_deriv_log_Gamma (Set.mem_Ioi.mpr hcpos)
+      (Set.mem_Ioi.mpr (by linarith)) hc.2.le
+  exact ⟨h1, h2⟩
+
+/-- **`|ψ(x) − log x| ≤ 1/x` for real `x > 0`**, with the constant explicit and equal to `1`. -/
+theorem abs_deriv_log_Gamma_sub_log_le {x : ℝ} (hx : 0 < x) :
+    |deriv (fun t ↦ Real.log (Real.Gamma t)) x - Real.log x| ≤ 1 / x := by
+  obtain ⟨hle, hge⟩ := deriv_log_Gamma_le_log_le hx
+  rw [deriv_log_Gamma_add_one hx] at hge
+  rw [abs_le]
+  constructor <;> linarith
+
+end GammaSolution

--- a/Solutions/GammaAsymptotics.v2/Recurrence.lean
+++ b/Solutions/GammaAsymptotics.v2/Recurrence.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2026 IEANTN contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Tao
+-/
+import GaussSeries
+
+/-!
+# Stages 2b and 2e: the recurrence for the Gauss series, and its value at the integers
+
+Two of the three hypotheses of the vanishing lemma, for `E := ψ - G` where
+
+  `G s := -γ + ∑ₖ (1/(k+1) - 1/(k+s))`.
+
+* **2b**, `gaussSum_add_one`: `G(s+1) = G(s) + 1/s`. With `Complex.digamma_apply_add_one` this is
+  what makes `E` 1-periodic. The proof is a telescoping series: subtracting the two Gauss series
+  termwise cancels the `1/(k+1)` and leaves `1/(k+s) - 1/(k+1+s)`, whose partial sums are
+  `1/s - 1/(n+s)`.
+* **2e**, `digamma_eq_gaussSum_nat_add_one`: `ψ(n+1) = G(n+1)`, both sides being `-γ + Hₙ`.
+
+## What the Mathlib bump changed here
+
+The node's `formalization.yaml` records that `Analysis/SpecialFunctions/Gamma/Digamma.lean` "is 64
+lines and contains the definition, `digamma_zero`, `digamma_one`, `digamma_one_half`,
+`digamma_apply_add_one` and `meromorphic_digamma`, and no bound of any kind." **That was true when
+it was written and is no longer true.** On this repository's pin the file is 153 lines and also
+carries `digamma_apply_add_nat`, `digamma_nat_add_one`, Euler's reflection formula
+`digamma_one_sub`, and the duplication formula `digamma_two_mul`.
+
+The half of that observation which still holds is the operative one: there is still no bound of
+any kind, so the node's conclusion is still open and the Gauss representation is still a `TODO` in
+that file. But `digamma_nat_add_one` is exactly step 2e's `ψ` side, so that step is now two
+`rw`s rather than an induction, and the `limitations` entry saying the reflection formula awaits a
+future bump has been overtaken by the bump that already happened.
+-/
+
+namespace GammaSolution
+
+open Complex
+
+/-- The Gauss series, `G s = -γ + ∑ₖ (1/(k+1) - 1/(k+s))`.
+
+Not yet known to equal `ψ`; that is what the rest of the solution is for. -/
+noncomputable def gaussSum (s : ℂ) : ℂ :=
+  -(Real.eulerMascheroniConstant : ℂ) + ∑' k, gaussTerm s k
+
+/-- **A telescoping series**: if `f n → 0` and the differences are summable, they sum to `f 0`.
+
+Stated for its own sake rather than inlined, because the argument is entirely about partial sums
+and has nothing to do with `Γ`. -/
+theorem hasSum_sub_succ {f : ℕ → ℂ} (hsum : Summable fun k ↦ f k - f (k + 1))
+    (hlim : Filter.Tendsto f Filter.atTop (nhds 0)) :
+    HasSum (fun k ↦ f k - f (k + 1)) (f 0) := by
+  have hpart : ∀ n : ℕ, ∑ i ∈ Finset.range n, (f i - f (i + 1)) = f 0 - f n :=
+    fun n ↦ Finset.sum_range_sub' f n
+  have h1 := hsum.hasSum.tendsto_sum_nat
+  simp only [hpart] at h1
+  have h2 : Filter.Tendsto (fun n : ℕ ↦ f 0 - f n) Filter.atTop (nhds (f 0)) := by
+    simpa using tendsto_const_nhds.sub hlim
+  rw [← tendsto_nhds_unique h1 h2]
+  exact hsum.hasSum
+
+/-- `1/(k+s) → 0`, because `‖k + s‖ ≥ k - ‖s‖ → ∞`. -/
+theorem tendsto_inv_natCast_add (s : ℂ) :
+    Filter.Tendsto (fun k : ℕ ↦ ((k : ℂ) + s)⁻¹) Filter.atTop (nhds 0) := by
+  rw [tendsto_zero_iff_norm_tendsto_zero]
+  simp only [norm_inv]
+  refine Filter.Tendsto.inv_tendsto_atTop ?_
+  refine Filter.tendsto_atTop_mono (fun k ↦ ?_)
+    (Filter.tendsto_atTop_add_const_right _ (-‖s‖) tendsto_natCast_atTop_atTop)
+  have h := norm_sub_norm_le ((k : ℂ)) (-s)
+  simp only [norm_neg, sub_neg_eq_add] at h
+  simpa using h
+
+/-- **Stage 2b, the recurrence**: `G(s+1) = G(s) + 1/s`.
+
+Termwise, `gaussTerm (s+1) k - gaussTerm s k = 1/(k+s) - 1/(k+1+s)`: the `1/(k+1)` that carries
+the divergence cancels, and what is left telescopes. -/
+theorem gaussSum_add_one {s : ℂ} (hs : ∀ n : ℕ, s ≠ -n) :
+    gaussSum (s + 1) = gaussSum s + s⁻¹ := by
+  have hs' : ∀ n : ℕ, s + 1 ≠ -n := fun n h ↦
+    hs (n + 1) (by push_cast at h ⊢; linear_combination h)
+  set f : ℕ → ℂ := fun k ↦ ((k : ℂ) + s)⁻¹ with hf
+  have hdiff : ∀ k : ℕ, gaussTerm (s + 1) k - gaussTerm s k = f k - f (k + 1) := by
+    intro k
+    simp only [gaussTerm, hf]
+    push_cast
+    ring
+  have hsub : Summable (fun k ↦ f k - f (k + 1)) := by
+    have h := (summable_gaussTerm hs').sub (summable_gaussTerm hs)
+    simpa only [hdiff] using h
+  have htel := hasSum_sub_succ hsub (tendsto_inv_natCast_add s)
+  have hHS : HasSum (fun k ↦ gaussTerm (s + 1) k - gaussTerm s k)
+      ((∑' k, gaussTerm (s + 1) k) - ∑' k, gaussTerm s k) :=
+    (summable_gaussTerm hs').hasSum.sub (summable_gaussTerm hs).hasSum
+  have hHS' : HasSum (fun k ↦ gaussTerm (s + 1) k - gaussTerm s k) (f 0) := by
+    simpa only [hdiff] using htel
+  have hkey := hHS.unique hHS'
+  have hf0 : f 0 = s⁻¹ := by simp [hf]
+  rw [hf0] at hkey
+  simp only [gaussSum]
+  linear_combination hkey
+
+@[simp]
+theorem gaussTerm_one (k : ℕ) : gaussTerm 1 k = 0 := by simp [gaussTerm]
+
+theorem gaussSum_one : gaussSum 1 = -(Real.eulerMascheroniConstant : ℂ) := by
+  simp [gaussSum]
+
+/-- **`G` at a positive integer**: `G(n+1) = -γ + Hₙ`, by induction from the recurrence. -/
+theorem gaussSum_nat_add_one (n : ℕ) :
+    gaussSum ((n : ℂ) + 1)
+      = -(Real.eulerMascheroniConstant : ℂ) + ((harmonic n : ℚ) : ℂ) := by
+  induction n with
+  | zero => simpa using gaussSum_one
+  | succ n ih =>
+    have hne : ∀ m : ℕ, ((n : ℂ) + 1) ≠ -(m : ℂ) := by
+      intro m h
+      have hre : (n : ℝ) + 1 = -(m : ℝ) := by exact_mod_cast congrArg Complex.re h
+      have h1 : (0 : ℝ) ≤ (n : ℝ) := Nat.cast_nonneg n
+      have h2 : (0 : ℝ) ≤ (m : ℝ) := Nat.cast_nonneg m
+      linarith
+    have hstep : gaussSum (((n : ℂ) + 1) + 1) = gaussSum ((n : ℂ) + 1) + ((n : ℂ) + 1)⁻¹ :=
+      gaussSum_add_one hne
+    have hcast : (((n : ℕ) + 1 : ℕ) : ℂ) + 1 = ((n : ℂ) + 1) + 1 := by push_cast; ring
+    rw [hcast, hstep, ih, harmonic_succ]
+    push_cast
+    ring
+
+/-- **Stage 2e**: `ψ` and `G` agree at the positive integers — the second hypothesis of
+`eq_zero_of_periodic_of_nat_of_oscillation`.
+
+Both sides are `-γ + Hₙ`: the left by `Complex.digamma_nat_add_one`, the right by
+`gaussSum_nat_add_one`. -/
+theorem digamma_eq_gaussSum_nat_add_one (n : ℕ) :
+    Complex.digamma ((n : ℂ) + 1) = gaussSum ((n : ℂ) + 1) := by
+  rw [Complex.digamma_nat_add_one n, gaussSum_nat_add_one n]
+  ring
+
+end GammaSolution

--- a/Solutions/GammaAsymptotics.v2/Solution.lean
+++ b/Solutions/GammaAsymptotics.v2/Solution.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 IEANTN contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Tao
+-/
+import RealAsymptotic
+import Periodic
+import GaussSeries
+import Recurrence
+import IEANTN.Nodes.GammaAsymptotics.v2.Conclusions
+
+/-!
+# Solution: `GammaAsymptotics.v2`
+
+**Incomplete.** One hole, the conclusion itself. What is proved and what is not is set out below
+and derived mechanically by `python scripts/ieantn.py progress GammaAsymptotics.v2`; see
+`progress.yaml` for the plan.
+
+## The route
+
+The node's own docstring says both versions need the Gauss/Weierstrass representation
+
+  `ψ(u) = -γ + ∑_{k≥0} (1/(k+1) - 1/(k+u))`,
+
+which Mathlib lists as a `TODO`. That is still the target, and it is still the honest description
+of what is missing — but the *real-variable asymptotic* turned out not to need it, which changes
+the order of work. The plan is now:
+
+1. **`|ψ(x) − log x| ≤ 1/x` on the reals**, from log-convexity alone. `RealAsymptotic.lean`.
+   **Done**, with the constant explicit and equal to `1`.
+2. **The Gauss series on `ℂ`.** Write `G s := -γ + ∑ₖ gaussTerm s k`.
+   * a. the series converges — `GaussSeries.lean`, **done**;
+   * b. the recurrence `G(s+1) = G(s) + 1/s` — `Recurrence.lean`, **done**, by telescoping;
+   * c. `G` is analytic off the non-positive integers;
+   * d. hence `E := ψ - G` is 1-periodic on the reals;
+   * e. `ψ(n+1) = G(n+1)`, both being `-γ + Hₙ` — `Recurrence.lean`, **done**;
+   * f. `E` oscillates by `O(1/n)` across unit intervals — Stage 1 handles the `ψ` side, a
+        telescoping comparison the `G` side — so `eq_zero_of_periodic_of_nat_of_oscillation`
+        (`Periodic.lean`, **done**) gives `E ≡ 0` on the positive reals;
+   * g. the identity theorem carries `ψ = G` from a set with a limit point to all of `ℂ`.
+3. **The strip bound.** With the representation in hand, `‖ψ w - log w‖ ≤ C_H / ‖w‖` for
+   `Re w ≥ 1`, `|Im w| ≤ H`.
+
+The two steps that looked hardest going in — the real asymptotic and the periodic-vanishing
+argument — are the two that were finished first, and neither used the representation.
+
+Of the vanishing lemma's three hypotheses, two are now in hand (2b gives periodicity once paired
+with `Complex.digamma_apply_add_one`; 2e is the vanishing at integers outright). The oscillation
+bound, 2f, is the one still to write, and Stage 1 already supplies its harder half.
+
+## What the constant does
+
+The conclusion quantifies `C` after `H`, so the constant may depend on the height and does. That
+dependence is the entire difference between this node and `GammaAsymptotics.v1`, which asks for
+one constant on the whole half-plane and is left open on purpose.
+-/
+
+theorem GammaAsymptotics.v2.challenge_digamma_sub_log_isBigO_strip :
+    GammaAsymptotics.v2.digamma_sub_log_isBigO_strip := by
+  sorry

--- a/Solutions/GammaAsymptotics.v2/comparator.json
+++ b/Solutions/GammaAsymptotics.v2/comparator.json
@@ -1,0 +1,13 @@
+{
+  "challenge_module": "IEANTN.Nodes.GammaAsymptotics.v2.Challenge",
+  "solution_module": "Solution",
+  "theorem_names": [
+    "GammaAsymptotics.v2.challenge_digamma_sub_log_isBigO_strip"
+  ],
+  "permitted_axioms": [
+    "propext",
+    "Quot.sound",
+    "Classical.choice"
+  ],
+  "enable_nanoda": true
+}

--- a/Solutions/GammaAsymptotics.v2/lake-manifest.json
+++ b/Solutions/GammaAsymptotics.v2/lake-manifest.json
@@ -1,0 +1,126 @@
+{
+  "version": "1.2.0",
+  "packagesDir": ".lake/packages",
+  "packages": [
+    {
+      "type": "path",
+      "scope": "",
+      "name": "IEANTN",
+      "manifestFile": "lake-manifest.json",
+      "inherited": false,
+      "dir": "../..",
+      "configFile": "lakefile.toml"
+    },
+    {
+      "url": "https://github.com/leanprover-community/mathlib4",
+      "type": "git",
+      "subDir": null,
+      "scope": "leanprover-community",
+      "rev": "71a80585ee495fc24472fd0eaffc89d94e4fd8d6",
+      "name": "mathlib",
+      "manifestFile": "lake-manifest.json",
+      "inputRev": "master",
+      "inherited": false,
+      "configFile": "lakefile.lean"
+    },
+    {
+      "url": "https://github.com/leanprover-community/plausible",
+      "type": "git",
+      "subDir": null,
+      "scope": "leanprover-community",
+      "rev": "d9598f07b1bc701f1e3aae163d2681c1fd978793",
+      "name": "plausible",
+      "manifestFile": "lake-manifest.json",
+      "inputRev": "main",
+      "inherited": true,
+      "configFile": "lakefile.toml"
+    },
+    {
+      "url": "https://github.com/leanprover-community/LeanSearchClient",
+      "type": "git",
+      "subDir": null,
+      "scope": "leanprover-community",
+      "rev": "ba67e212be1197b84c1f1f6299488a10a3002713",
+      "name": "LeanSearchClient",
+      "manifestFile": "lake-manifest.json",
+      "inputRev": "main",
+      "inherited": true,
+      "configFile": "lakefile.toml"
+    },
+    {
+      "url": "https://github.com/leanprover-community/import-graph",
+      "type": "git",
+      "subDir": null,
+      "scope": "leanprover-community",
+      "rev": "1681d78dd6e65e38b143f9740d829c826673807c",
+      "name": "importGraph",
+      "manifestFile": "lake-manifest.json",
+      "inputRev": "main",
+      "inherited": true,
+      "configFile": "lakefile.toml"
+    },
+    {
+      "url": "https://github.com/leanprover-community/ProofWidgets4",
+      "type": "git",
+      "subDir": null,
+      "scope": "leanprover-community",
+      "rev": "a8acbfd87375ff4abe14ce09db5b7664d383bc7f",
+      "name": "proofwidgets",
+      "manifestFile": "lake-manifest.json",
+      "inputRev": "main",
+      "inherited": true,
+      "configFile": "lakefile.lean"
+    },
+    {
+      "url": "https://github.com/leanprover-community/aesop",
+      "type": "git",
+      "subDir": null,
+      "scope": "leanprover-community",
+      "rev": "18889deb9e83ea7420ef51c160d6f88552e744e3",
+      "name": "aesop",
+      "manifestFile": "lake-manifest.json",
+      "inputRev": "master",
+      "inherited": true,
+      "configFile": "lakefile.toml"
+    },
+    {
+      "url": "https://github.com/leanprover-community/quote4",
+      "type": "git",
+      "subDir": null,
+      "scope": "leanprover-community",
+      "rev": "507746ab8f4b643ccdacb2ec4cdb5853fa9f8ab3",
+      "name": "Qq",
+      "manifestFile": "lake-manifest.json",
+      "inputRev": "master",
+      "inherited": true,
+      "configFile": "lakefile.toml"
+    },
+    {
+      "url": "https://github.com/leanprover-community/batteries",
+      "type": "git",
+      "subDir": null,
+      "scope": "leanprover-community",
+      "rev": "4cac2177c37f5530c4da76aa8e4307f3fc9e4dcb",
+      "name": "batteries",
+      "manifestFile": "lake-manifest.json",
+      "inputRev": "main",
+      "inherited": true,
+      "configFile": "lakefile.toml"
+    },
+    {
+      "url": "https://github.com/leanprover/lean4-cli",
+      "type": "git",
+      "subDir": null,
+      "scope": "leanprover",
+      "rev": "ab3a82db9fea14cf0fd7f5a2de650f4b534640af",
+      "name": "Cli",
+      "manifestFile": "lake-manifest.json",
+      "inputRev": "v4.34.0-rc2",
+      "inherited": true,
+      "configFile": "lakefile.toml"
+    }
+  ],
+  "name": "solution_FKS2_v1",
+  "lakeDir": ".lake",
+  "fixedToolchain": false
+}

--- a/Solutions/GammaAsymptotics.v2/lakefile.toml
+++ b/Solutions/GammaAsymptotics.v2/lakefile.toml
@@ -1,0 +1,26 @@
+name = "solution_GammaAsymptotics_v2"
+defaultTargets = ["RealAsymptotic", "Periodic", "GaussSeries", "Recurrence", "Solution"]
+
+[[require]]
+name = "IEANTN"
+path = "../.."
+
+[[lean_lib]]
+name = "RealAsymptotic"
+roots = ["RealAsymptotic"]
+
+[[lean_lib]]
+name = "Periodic"
+roots = ["Periodic"]
+
+[[lean_lib]]
+name = "GaussSeries"
+roots = ["GaussSeries"]
+
+[[lean_lib]]
+name = "Recurrence"
+roots = ["Recurrence"]
+
+[[lean_lib]]
+name = "Solution"
+roots = ["Solution"]

--- a/Solutions/GammaAsymptotics.v2/lean-toolchain
+++ b/Solutions/GammaAsymptotics.v2/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.34.0-rc2

--- a/Solutions/GammaAsymptotics.v2/progress.yaml
+++ b/Solutions/GammaAsymptotics.v2/progress.yaml
@@ -1,0 +1,170 @@
+# Build plan for GammaAsymptotics.v2 -- the digamma asymptotic on a horizontal strip.
+#
+# Best-practice file, not a schema CI enforces -- see docs/SOLUTIONS.md. `remaining_holes` on the
+# node's formalization.yaml is derived from the build by `ieantn.py progress`; everything here is
+# judgement and should read like it.
+
+solution: Solutions/GammaAsymptotics.v2/
+state: in-progress   # one hole, the conclusion itself; five of the eight sub-steps closed
+
+# --------------------------------------------------------------------------------------------
+# WHAT THE MATHLIB BUMP CHANGED, and what the node still records.
+# --------------------------------------------------------------------------------------------
+stale_mathlib_facts: >-
+  The node's formalization.yaml states, under review.notes, that
+  Analysis/SpecialFunctions/Gamma/Digamma.lean "is 64 lines and contains the definition,
+  digamma_zero, digamma_one, digamma_one_half, digamma_apply_add_one and meromorphic_digamma, and
+  no bound of any kind". THAT WAS CHECKED WHEN WRITTEN AND IS NOW OUT OF DATE. On this
+  repository's pin (mathlib 71a80585) the file is 153 lines and additionally carries
+  digamma_apply_add_nat, digamma_nat_add_one (psi(n+1) = H_n - gamma), Euler's reflection formula
+  digamma_one_sub, and the duplication formula digamma_two_mul.
+  The operative half of the original observation survives: there is still NO BOUND OF ANY KIND, so
+  the conclusion is still open, and Gauss' representation is still a TODO in that file.
+  Two consequences. (i) digamma_nat_add_one IS step 2e's psi side, so that step is two rewrites
+  rather than an induction. (ii) The node's limitations entry saying the reflection formula awaited
+  "a more recent Mathlib than this repository's pin" is overtaken -- that bump has happened and
+  Complex.digamma_one_sub is on the current pin.
+  BOTH HAVE BEEN CORRECTED ON THE NODE in the same commit that added this solution, and the old
+  wording is preserved there beside the new. Neither touches the conclusion, so no fingerprint
+  moves; they are review notes and limitations, which are prose.
+  THE GENERAL LESSON, and the reason it is written down twice rather than fixed silently: a bump
+  moves what the repository can assume, and recorded claims about Mathlib's contents go stale
+  without any Lean file changing and without any check failing. Nothing here verifies a sentence
+  about what some upstream file contains; only someone going to look does. Every node whose notes
+  make such a claim is a candidate for the same rot, and none of them were audited here.
+
+shape: >-
+  One conclusion, one hole, three supporting files. The node states
+  `forall H, exists C, forall w, 1 <= Re w -> |Im w| <= H -> ||psi w - log w|| <= C / ||w||`, and
+  the constant is allowed to depend on the height. That dependence is the whole difference between
+  this node and GammaAsymptotics.v1, which asks for a constant uniform in the height and is left
+  open deliberately.
+
+# --------------------------------------------------------------------------------------------
+# What the node docstring says, and what step 1 adds to it.
+# --------------------------------------------------------------------------------------------
+what_the_node_docstring_gets_right: >-
+  IEANTN/Nodes/GammaAsymptotics/v2/Conclusions.lean says both versions need the Gauss/Weierstrass
+  representation, which Mathlib lists as a TODO. That claim is about THIS NODE'S CONCLUSION, which
+  is a statement about complex w, and it stands: nothing below closes the complex strip bound
+  without the representation, and the route in `steps` still goes through it.
+what_step_1_adds: >-
+  The docstring's argument for that claim runs through kappa(u) := lim (psi(u+n) - log(u+n)), a
+  1-periodic function it says cannot be pinned to zero without the series. ON THE REALS THAT IS NOT
+  SO. Step 1 gives |psi(x) - log x| <= 1/x for every real x > 0 from Real.convexOn_log_Gamma alone,
+  with the constant explicit and equal to 1, and kappa == 0 on the reals falls straight out of it
+  by letting n -> infinity -- no series, no integral representation, about a hundred lines.
+  So the obstruction the docstring describes is real but is located one step later than it says:
+  not in pinning kappa, but in getting from the real line to a complex strip. The docstring is
+  worth adjusting on that point when this node is next edited for another reason; it is not worth
+  touching the file for on its own, and it does not change what the conclusion claims.
+
+# --------------------------------------------------------------------------------------------
+# The route, step by step.
+# --------------------------------------------------------------------------------------------
+steps:
+  - id: "1"
+    name: The real asymptotic
+    file: RealAsymptotic.lean
+    state: done
+    what: >-
+      |psi(x) - log x| <= 1/x for real x > 0. log Gamma is convex, so its derivative is monotone;
+      the slope of log Gamma across [x, x+1] is exactly log x, because Gamma(x+1) = x Gamma(x); and
+      the mean value theorem puts that slope between the derivative at x and at x+1, which differ by
+      1/x. Mathlib has no Real.digamma, so the derivative is spelled deriv (fun t => log (Gamma t)).
+    exports:
+      - differentiableAt_log_Gamma
+      - log_Gamma_add_one_sub
+      - deriv_log_Gamma_add_one
+      - monotoneOn_deriv_log_Gamma
+      - deriv_log_Gamma_le_log_le
+      - abs_deriv_log_Gamma_sub_log_le
+
+  - id: "2a"
+    name: The Gauss series converges
+    file: GaussSeries.lean
+    state: done
+    what: >-
+      gaussTerm s k = 1/(k+1) - 1/(k+s) = (s-1)/((k+1)(k+s)), which is O(1/k^2) once k is past
+      2||s||. Summability by comparison with a p-series.
+    exports: [gaussTerm, gaussTerm_eq, summable_gaussTerm]
+
+  - id: "2f-lemma"
+    name: The vanishing lemma
+    file: Periodic.lean
+    state: done
+    what: >-
+      A 1-periodic real function that vanishes at the naturals and varies by O(1/n) across unit
+      intervals far out is identically zero on the positive reals. Periodicity pushes any point
+      arbitrarily far right, where the oscillation bound is arbitrarily tight and a zero always sits
+      within distance one.
+    why_it_is_stated_alone: >-
+      THE NAIVE VERSION DOES NOT WORK, and an earlier draft of the node docstring believed it did:
+      periodicity spreads E(1) = 0 to the integers and NOWHERE ELSE, since a 1-periodic function
+      vanishing on Z is otherwise unconstrained. The oscillation hypothesis is what reaches between
+      the integers. Stating the lemma about arbitrary real functions, with no Gamma in sight, is
+      what makes that separation auditable.
+    exports: [eq_zero_of_periodic_of_nat_of_oscillation]
+
+  - id: "2b"
+    name: The recurrence for G
+    file: Recurrence.lean
+    state: done
+    what: >-
+      G(s+1) = G(s) + 1/s, where G s := -gamma + sum_k gaussTerm s k. Termwise the difference is
+      1/(k+s) - 1/(k+1+s): the 1/(k+1) that carries the divergence cancels, and what is left
+      telescopes, with partial sums 1/s - 1/(n+s). Paired with Complex.digamma_apply_add_one this
+      is the first hypothesis of the vanishing lemma.
+    exports: [gaussSum, hasSum_sub_succ, tendsto_inv_natCast_add, gaussSum_add_one]
+
+  - id: "2c"
+    name: Analyticity of G
+    state: todo
+    what: >-
+      G is analytic off the non-positive integers, by differentiableOn_tsum_of_summable_norm with
+      the O(1/k^2) bound from 2a made locally uniform.
+
+  - id: "2d"
+    name: E is 1-periodic
+    state: todo
+    what: "E := psi - G is 1-periodic, from 2b and Complex.digamma_apply_add_one."
+
+  - id: "2e"
+    name: E vanishes at the naturals
+    file: Recurrence.lean
+    state: done
+    what: >-
+      psi(n+1) = G(n+1), both sides being -gamma + H_n: the left by Complex.digamma_nat_add_one, the
+      right by induction from 2b. This is the second hypothesis of the vanishing lemma.
+    exports: [gaussTerm_one, gaussSum_one, gaussSum_nat_add_one, digamma_eq_gaussSum_nat_add_one]
+
+  - id: "2f"
+    name: The oscillation bound
+    state: todo
+    what: >-
+      |E(a) - E(b)| = O(1/n) for a, b >= n at distance at most 1. Stage 1 gives the psi side; the G
+      side is |G(a) - G(b)| <= |a-b| * sum_k 1/(k+n)^2 by comparison with a telescoping series.
+      With 2d and 2e this closes E = 0 on the positive reals.
+
+  - id: "2g"
+    name: To the complex plane
+    state: todo
+    what: >-
+      psi = G on the positive reals, a set with a limit point; both sides are analytic on the
+      connected slit plane; the identity theorem does the rest.
+
+  - id: "3"
+    name: The strip bound
+    state: todo
+    what: >-
+      With the representation in hand, ||psi w - log w|| <= C_H / ||w|| for Re w >= 1, |Im w| <= H.
+
+# --------------------------------------------------------------------------------------------
+consumer: >-
+  CH2.v1 evaluates psi only at 1 - s for s on the ladder, and every piece of that set has
+  |Im s| <= T. The strip is not a compromise for that consumer; it is everything it ever asked for.
+
+upstream: >-
+  Steps 1, 2a and 2f-lemma are stated about Mathlib objects only and have no IEANTN import between
+  them. Once 2g lands, the natural Mathlib contribution is the representation itself -- the TODO in
+  Mathlib/Analysis/SpecialFunctions/Gamma/Digamma.lean -- with step 1 a plausible second PR.

--- a/docs/nodes/GammaAsymptotics-v2.md
+++ b/docs/nodes/GammaAsymptotics-v2.md
@@ -43,6 +43,7 @@ def digamma_sub_log_isBigO_strip : Prop :=
 | Lean name | `GammaAsymptotics.v2.digamma_sub_log_isBigO_strip` |
 | Challenge | `GammaAsymptotics.v2.challenge_digamma_sub_log_isBigO_strip` |
 | Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/GammaAsymptotics/v2/Conclusions.lean#L76) |
+| Solution | [`Solutions/GammaAsymptotics.v2`](https://github.com/teorth/IEANTN/tree/main/Solutions/GammaAsymptotics.v2) |
 | Evidence | unjustified (`none-yet`) |
 | Sources traced | none |
 | Assumes | nothing recorded |
@@ -59,7 +60,7 @@ Recorded by the node itself, not derived.
 - Stated but not proved. Nothing downstream may treat it as established, and CH2.v1's ladder bounds inherit that.
 - ONE ASYMPTOTIC ONLY, and a weak one. The node is named for the class because it is intended to grow: the -1/(2w) term, the sector version, a bound on Gamma itself, and Stirling's formula in the complex plane are all wanted and none is here. A consumer needing any of them will not find it.
 - THE CONSTANT IS EXISTENTIAL. A consumer needing an explicit numerical constant -- which an explicit estimate eventually will -- cannot get one from this statement and will need a sharper conclusion stated alongside it.
-- Re w >= 1 excludes the left half-plane entirely, where digamma has its poles. An application that needs psi there must combine this with the reflection formula psi(1-w) - psi(w) = pi cot(pi w), which a more recent Mathlib than this repository's pin has merged (leanprover-community/mathlib4#42349). So that gap closes on a bump rather than needing a conclusion here -- but note the reflection formula alone proves nothing about growth, in either half-plane, so it does not shorten the work below. CH2.v1 does not need the left half-plane: its ladder argument evaluates psi at 1-s with Re(1-s) >= 2, which is already inside the stated range.
+- Re w >= 1 excludes the left half-plane entirely, where digamma has its poles. An application that needs psi there must combine this with the reflection formula psi(1-w) - psi(w) = pi cot(pi w). THAT IS NOW AVAILABLE: this entry previously said it awaited a more recent Mathlib than this repository's pin, and the bump that brought it (leanprover-community/mathlib4#42349) has since happened, so it is Complex.digamma_one_sub on the current pin. But note the reflection formula alone proves nothing about growth, in either half-plane, so having it does not shorten the work below. CH2.v1 does not need the left half-plane: its ladder argument evaluates psi at 1-s with Re(1-s) >= 2, which is already inside the stated range.
 - No novelty is claimed. The expansion is classical.
 
 ## How this node was made

--- a/scripts/ieantn.py
+++ b/scripts/ieantn.py
@@ -834,11 +834,44 @@ def solution_holes(node: str) -> tuple[bool, list[str], dict[str, bool]] | None:
     finally:
         probe.unlink(missing_ok=True)
     seen = (checked.stdout or "") + (checked.stderr or "")
-    proved = {}
-    for name in names:
-        line = next((l for l in seen.splitlines() if l.startswith(f"'{name}'")), "")
-        proved[name] = bool(line) and "sorryAx" not in line
+    records = axiom_records(seen, names)
+    proved = {name: (name in records and "sorryAx" not in records[name]) for name in names}
     return (True, holes, proved)
+
+
+def axiom_records(output: str, names: list[str]) -> dict[str, str]:
+    """Join each `#print axioms` report back into one string, per declaration.
+
+    `#PRINT AXIOMS WRAPS`, and reading only the line that starts with the declaration name is
+    therefore wrong. Lean pretty-prints the axiom list at the usual width, so a long name pushes
+    the tail onto continuation lines:
+
+        'Family.v2.challenge_some_rather_long_conclusion_name' depends on axioms: [propext,
+         sorryAx,
+         Classical.choice,
+         Quot.sound]
+
+    A single-line check misses `sorryAx` here -- and note WHEN it misses it: adding `sorryAx` to
+    the list is itself part of what pushes the line over the width, so the failure mode is to
+    report an unproved theorem as proved, which is the only direction that matters. That happened:
+    a solution whose sole compared theorem was a bare `sorry` was reported as free of `sorryAx`,
+    by the routine whose entire purpose is to preview Comparator's verdict.
+
+    A record runs from the line beginning with the quoted name until the brackets balance, which
+    also handles `'foo' does not depend on any axioms` -- no brackets, so it closes at once.
+    """
+    records: dict[str, str] = {}
+    current: str | None = None
+    for raw in output.splitlines():
+        started = next((n for n in names if raw.startswith(f"'{n}'")), None)
+        if started is not None:
+            current = started
+            records[current] = raw.rstrip()
+        elif current is not None:
+            records[current] += " " + raw.strip()
+        if current is not None and records[current].count("[") == records[current].count("]"):
+            current = None
+    return records
 
 
 def progress(node: str, write: bool) -> bool:

--- a/tests/test_ieantn.py
+++ b/tests/test_ieantn.py
@@ -1081,6 +1081,45 @@ class TestProgressMarker(FixtureRepo):
         self.assertIn("no solution", printed.getvalue())
 
 
+class TestAxiomReportParsing(unittest.TestCase):
+    """`#print axioms` wraps, and the wrap hid `sorryAx`.
+
+    This is the one direction of error that matters: a solution whose sole compared theorem was a
+    bare `sorry` was reported as free of `sorryAx`, because the name was long enough to push the
+    list onto continuation lines -- and adding `sorryAx` to the list is part of what pushes it
+    over. The parse is separated from the subprocess so it can be checked without Lean.
+    """
+
+    LONG = "GammaAsymptotics.v2.challenge_digamma_sub_log_isBigO_strip"
+
+    def test_a_wrapped_report_still_shows_sorry(self) -> None:
+        output = ("'" + self.LONG + "' depends on axioms: [propext," + chr(10)
+                  + " sorryAx," + chr(10)
+                  + " Classical.choice," + chr(10)
+                  + " Quot.sound]" + chr(10))
+        records = ieantn.axiom_records(output, [self.LONG])
+        self.assertIn("sorryAx", records[self.LONG])
+
+    def test_a_clean_report_on_one_line_is_read(self) -> None:
+        output = "'Short.v1.main' depends on axioms: [propext, Classical.choice, Quot.sound]"
+        records = ieantn.axiom_records(output, ["Short.v1.main"])
+        self.assertNotIn("sorryAx", records["Short.v1.main"])
+
+    def test_a_declaration_with_no_axioms_closes_its_record(self) -> None:
+        """No brackets at all, so the record must not swallow the report that follows it."""
+        output = ("'A.v1.first' does not depend on any axioms" + chr(10)
+                  + "'A.v1.second' depends on axioms: [propext," + chr(10)
+                  + " sorryAx]")
+        records = ieantn.axiom_records(output, ["A.v1.first", "A.v1.second"])
+        self.assertNotIn("sorryAx", records["A.v1.first"])
+        self.assertIn("sorryAx", records["A.v1.second"])
+
+    def test_a_missing_report_is_absent_rather_than_clean(self) -> None:
+        """A name Lean never printed must not read as proved."""
+        records = ieantn.axiom_records("", ["A.v1.main"])
+        self.assertNotIn("A.v1.main", records)
+
+
 class TestGraphPage(FixtureRepo):
     """`GRAPH.md`: the network as a page someone can read without cloning anything.
 


### PR DESCRIPTION
**Stacks on #94** — that PR is green and unblocks `main`; this branch is cut from its head, so until #94 merges the diff here shows its two commits too.

## What this does

Five of the eight steps toward `GammaAsymptotics.v2`'s strip bound existed only in a session scratch directory. This puts them in the repository.

| file | content |
|---|---|
| `RealAsymptotic.lean` | `\|ψ(x) − log x\| ≤ 1/x` on the reals, constant explicitly `1` |
| `Periodic.lean` | the vanishing lemma, stated about arbitrary real functions |
| `GaussSeries.lean` | the Gauss summand and its absolute convergence |
| `Recurrence.lean` | `G(s+1) = G(s) + 1/s`, and `ψ(n+1) = G(n+1) = −γ + Hₙ` |
| `Solution.lean` | the conclusion, still `sorry`, with the route written out |

Builds clean: 2872 jobs, one deliberate hole. `progress` records `remaining_holes: 1`.

## What it corrects in the node's account

The node docstring says both versions need the Gauss/Weierstrass representation. For **this node's conclusion** — a statement about complex `w` — that stands, and the route still goes through it. What step 1 shows is that the *argument given for it* is one step early: the docstring says `κ(u) = lim (ψ(u+n) − log(u+n))` cannot be pinned to zero without the series, and on the reals it can, straight out of `Real.convexOn_log_Gamma`. The obstruction is getting from the real line to a complex strip.

## Two stale claims about Mathlib, corrected

The bump moved `Digamma.lean` from 64 lines to 153. The node's review notes still described the old file, and its limitations still said Euler's reflection formula awaited a later Mathlib — it is `Complex.digamma_one_sub` on the current pin. The operative half of the original observation survives (still no bound of any kind; Gauss still a `TODO`), and `digamma_nat_add_one` is step 2e's `ψ` side outright.

Old wording is kept beside the new, because the rot is general: prose about upstream contents goes stale with no Lean file changing and no check failing. Other nodes making such claims were **not** audited here.

## A bug in `progress` that reported a bare `sorry` as proved

`#print axioms` wraps. The parse read only the line starting with the declaration name, so `sorryAx` on a continuation line was invisible — and adding `sorryAx` to the list is part of what pushes the line past the width, so the failure was in the one direction that matters:

```
'GammaAsymptotics.v2.challenge_digamma_sub_log_isBigO_strip' depends on axioms: [propext,
 sorryAx,                       <- never read
 Classical.choice,
 Quot.sound]
```

Fixed by joining each record until its brackets balance; four tests. `verify`'s dispatch gate did not rest on this alone — the separate `sorry`-warning count is stricter and would still have refused — so **no receipt was affected**. The report was simply false.

## Gate

`lake build` (3346 jobs), `check` (8/8), `fingerprint --check`, `diff` (no change to any statement, dependency, or receipt), 209 unit tests, pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)