### PR TITLE
GammaAsymptotics.v2: the Gauss representation, on the positive reals

### DIFF
--- a/IEANTN/Nodes/GammaAsymptotics/v2/formalization.yaml
+++ b/IEANTN/Nodes/GammaAsymptotics/v2/formalization.yaml
@@ -72,7 +72,6 @@ conclusions:
     solution: Solutions/GammaAsymptotics.v2/
     state: in-progress
     remaining_holes: 1
-
 sources:
 - title: "The digamma asymptotic expansion"
   authors: ["folklore"]

--- a/Solutions/GammaAsymptotics.v2/ComplexToReal.lean
+++ b/Solutions/GammaAsymptotics.v2/ComplexToReal.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2026 IEANTN contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Tao
+-/
+import RealAsymptotic
+import Mathlib.Analysis.SpecialFunctions.Gamma.Digamma
+
+/-!
+# Glue: `Complex.digamma` on the real axis
+
+Stage 1 proves `|ψ(x) - log x| ≤ 1/x` for the *real* function `deriv (fun t ↦ log (Γ t))`, because
+Mathlib has no `Real.digamma` and the convexity argument is real-variable throughout. The node's
+conclusion is about `Complex.digamma`. This file is the one step between them:
+
+  `Complex.digamma x = ↑(deriv (fun t ↦ Real.log (Real.Gamma t)) x)` for real `x > 0`.
+
+Both sides are `Γ'/Γ`; the content is that `Complex.Gamma` differentiated along the real axis is
+the real `Γ'`, which is not automatic — a complex-differentiable function agreeing with a real one
+on `ℝ` has a complex derivative that *happens* to be real there, and saying so takes an argument.
+
+**Mathlib has that argument and keeps it `private`.** `HasDerivAt.complex_of_real` in
+`NumberTheory/Harmonic/GammaDeriv.lean` is exactly it, marked `private`, so it cannot be imported
+and is reproved here verbatim. If any of this goes upstream, that lemma losing its `private` is
+the first thing to ask for; `Complex.digamma_ofReal` below is the second.
+-/
+
+namespace GammaSolution
+
+open Complex
+
+/-- A complex-differentiable `f` agreeing with a real `g` on `ℝ` has `g`'s derivative there.
+
+Reproved from Mathlib's `private HasDerivAt.complex_of_real`. -/
+theorem hasDerivAt_complex_of_real {f : ℂ → ℂ} {g : ℝ → ℝ} {g' s : ℝ}
+    (hf : DifferentiableAt ℂ f s) (hg : HasDerivAt g g' s) (hfg : ∀ s : ℝ, f ↑s = ↑(g s)) :
+    HasDerivAt f ↑g' s := by
+  refine HasDerivAt.congr_deriv hf.hasDerivAt ?_
+  rw [← (funext hfg ▸ hf.hasDerivAt.comp_ofReal.deriv :)]
+  exact hg.ofReal_comp.deriv
+
+/-- A positive real is not a pole of `Γ`. -/
+theorem ofReal_ne_neg_natCast {x : ℝ} (hx : 0 < x) (m : ℕ) : (x : ℂ) ≠ -(m : ℂ) := by
+  intro h
+  have hx' : x = -(m : ℝ) := by exact_mod_cast h
+  have : (0 : ℝ) ≤ (m : ℝ) := Nat.cast_nonneg m
+  linarith
+
+theorem differentiableAt_real_Gamma {x : ℝ} (hx : 0 < x) : DifferentiableAt ℝ Real.Gamma x :=
+  Real.differentiableAt_Gamma (fun m ↦ by
+    intro hcon
+    have : (0 : ℝ) ≤ (m : ℝ) := Nat.cast_nonneg m
+    rw [hcon] at hx
+    linarith)
+
+/-- `Γ` differentiated along the real axis is the real `Γ'`. -/
+theorem hasDerivAt_Gamma_ofReal {x : ℝ} (hx : 0 < x) :
+    HasDerivAt Complex.Gamma ((deriv Real.Gamma x : ℝ) : ℂ) (x : ℂ) :=
+  hasDerivAt_complex_of_real
+    (Complex.differentiableAt_Gamma _ (ofReal_ne_neg_natCast hx))
+    (differentiableAt_real_Gamma hx).hasDerivAt
+    Complex.Gamma_ofReal
+
+/-- The real logarithmic derivative of `Γ`, in the form `Γ'/Γ`. -/
+theorem deriv_log_Gamma_eq {x : ℝ} (hx : 0 < x) :
+    deriv (fun t ↦ Real.log (Real.Gamma t)) x = deriv Real.Gamma x / Real.Gamma x := by
+  have hpos := Real.Gamma_pos_of_pos hx
+  have h := (Real.hasDerivAt_log hpos.ne').comp x (differentiableAt_real_Gamma hx).hasDerivAt
+  simp only [Function.comp_def] at h
+  rw [h.deriv]
+  ring
+
+/-- **`Complex.digamma` on the positive real axis is Stage 1's real derivative.** -/
+theorem digamma_ofReal {x : ℝ} (hx : 0 < x) :
+    Complex.digamma (x : ℂ) = ((deriv (fun t ↦ Real.log (Real.Gamma t)) x : ℝ) : ℂ) := by
+  have hpos := Real.Gamma_pos_of_pos hx
+  rw [Complex.digamma_def, logDeriv_apply, (hasDerivAt_Gamma_ofReal hx).deriv,
+    Complex.Gamma_ofReal, deriv_log_Gamma_eq hx]
+  push_cast
+  ring
+
+end GammaSolution

--- a/Solutions/GammaAsymptotics.v2/Oscillation.lean
+++ b/Solutions/GammaAsymptotics.v2/Oscillation.lean
@@ -1,0 +1,254 @@
+/-
+Copyright (c) 2026 IEANTN contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Tao
+-/
+import Recurrence
+import ComplexToReal
+
+/-!
+# Stage 2f: `E = ψ - G` varies by `O(1/n)` across a unit interval
+
+The third and last hypothesis of `eq_zero_of_periodic_of_nat_of_oscillation`. For `a, b ≥ n ≥ 1`
+at distance at most one,
+
+  `‖E a - E b‖ ≤ 5/n`.
+
+The two sides are bounded quite differently:
+
+* **the `ψ` side, `≤ 3/n`**, comes from Stage 1. Writing
+  `ψ(a) - ψ(b) = (ψ(a) - log a) + (log a - log b) - (ψ(b) - log b)`, the two outer brackets are at
+  most `1/a` and `1/b` by `abs_deriv_log_Gamma_sub_log_le`, and `|log a - log b| ≤ |a - b| / n`
+  from `log(1 + t) ≤ t`.
+* **the `G` side, `≤ 2/n`**, is a series computation. Termwise
+  `gaussTerm a k - gaussTerm b k = (a - b) / ((k+a)(k+b))`, so the `1/(k+1)` that carries the
+  divergence cancels and what is left is `O(1/k²)`, summing to `O(1/n)` rather than `O(1)`. The
+  comparison used is `1/((k+a)(k+b)) ≤ 2/((k+n)(k+n+1))`, whose right side telescopes to `2/n`
+  exactly — no `p`-series constant survives into the answer, and the same `hasSum_sub_succ` from
+  `Recurrence.lean` does the work one type down, which is why that lemma is stated over an
+  arbitrary complete normed group.
+
+Note which direction the difficulty runs. The `O(1/n)` is not a refinement for its own sake: a
+bound of `O(1)` on either side would leave `E` merely bounded, which no amount of periodicity
+turns into `E = 0`. The whole argument turns on the oscillation shrinking.
+-/
+
+namespace GammaSolution
+
+open Complex
+
+/-! ### The telescoping sum, over `ℝ` -/
+
+/-- The differences `1/(k+t) - 1/(k+t+1) = 1/((k+t)(k+t+1))` are summable, by comparison with
+`1/k²` past `k = 1`. -/
+theorem summable_telescope {t : ℝ} (ht : 1 ≤ t) :
+    Summable (fun k : ℕ ↦ (((k : ℝ) + t) * ((k : ℝ) + t + 1))⁻¹) := by
+  have hcomp : Summable (fun k : ℕ ↦ 1 / (k : ℝ) ^ 2) :=
+    Real.summable_one_div_nat_pow.mpr one_lt_two
+  refine Summable.of_norm_bounded_eventually_nat hcomp ?_
+  filter_upwards [Filter.eventually_ge_atTop 1] with k hk
+  have hk1 : (1 : ℝ) ≤ (k : ℝ) := by exact_mod_cast hk
+  have hsq : (0 : ℝ) < (k : ℝ) ^ 2 := by nlinarith
+  have hpos : (0 : ℝ) < ((k : ℝ) + t) * ((k : ℝ) + t + 1) := by nlinarith
+  rw [Real.norm_of_nonneg (by positivity), inv_eq_one_div, div_le_div_iff₀ hpos hsq]
+  nlinarith
+
+/-- **The telescoping value**: `∑ₖ 1/((k+t)(k+t+1)) = 1/t`.
+
+This is what replaces a `p`-series constant in the bound below: the comparison series can be
+summed exactly, so the final `2/n` carries no anonymous constant. -/
+theorem tsum_telescope {t : ℝ} (ht : 1 ≤ t) :
+    ∑' k : ℕ, (((k : ℝ) + t) * ((k : ℝ) + t + 1))⁻¹ = t⁻¹ := by
+  set f : ℕ → ℝ := fun k ↦ ((k : ℝ) + t)⁻¹ with hf
+  have hne : ∀ k : ℕ, (0 : ℝ) < (k : ℝ) + t := fun k ↦ by
+    have : (0 : ℝ) ≤ (k : ℝ) := Nat.cast_nonneg k
+    linarith
+  have hdiff : ∀ k : ℕ, f k - f (k + 1) = (((k : ℝ) + t) * ((k : ℝ) + t + 1))⁻¹ := by
+    intro k
+    have h1 : ((k : ℝ) + t) ≠ 0 := (hne k).ne'
+    have h2 : (((k : ℕ) + 1 : ℕ) : ℝ) + t ≠ 0 := (hne (k + 1)).ne'
+    simp only [hf]
+    push_cast at h2 ⊢
+    field_simp
+    ring
+  have hsum : Summable (fun k : ℕ ↦ f k - f (k + 1)) := by
+    simpa only [hdiff] using summable_telescope ht
+  have hlim : Filter.Tendsto f Filter.atTop (nhds 0) := by
+    simp only [hf]
+    exact Filter.Tendsto.inv_tendsto_atTop
+      (Filter.tendsto_atTop_add_const_right _ t tendsto_natCast_atTop_atTop)
+  have h := hasSum_sub_succ hsum hlim
+  have hf0 : f 0 = t⁻¹ := by simp [hf]
+  rw [hf0] at h
+  simpa only [hdiff] using h.tsum_eq
+
+/-- The comparison series, with its sum: `∑ₖ |a-b| * 2/((k+n)(k+n+1)) = |a-b| * (2/n)`. -/
+theorem hasSum_comparison {t : ℝ} (ht : 1 ≤ t) (c : ℝ) :
+    HasSum (fun k : ℕ ↦ c * (2 * (((k : ℝ) + t) * ((k : ℝ) + t + 1))⁻¹)) (c * (2 * t⁻¹)) := by
+  have h : HasSum (fun k : ℕ ↦ (((k : ℝ) + t) * ((k : ℝ) + t + 1))⁻¹) t⁻¹ := by
+    rw [← tsum_telescope ht]
+    exact (summable_telescope ht).hasSum
+  exact (h.mul_left 2).mul_left c
+
+/-! ### The `G` side -/
+
+/-- Termwise, `gaussTerm a k - gaussTerm b k = (a - b)/((k+a)(k+b))`: the divergent `1/(k+1)`
+cancels, which is the whole reason the difference is `O(1/n)` and each series alone is not. -/
+theorem gaussTerm_sub {a b : ℝ} (ha : 0 < a) (hb : 0 < b) (k : ℕ) :
+    gaussTerm (a : ℂ) k - gaussTerm (b : ℂ) k
+      = ((a : ℂ) - b) / (((k : ℂ) + a) * ((k : ℂ) + b)) := by
+  have hkn : (0 : ℝ) ≤ (k : ℝ) := Nat.cast_nonneg k
+  have h1 : ((k : ℂ) + a) ≠ 0 := by
+    intro h
+    have : (k : ℝ) + a = 0 := by exact_mod_cast congrArg Complex.re h
+    linarith
+  have h2 : ((k : ℂ) + b) ≠ 0 := by
+    intro h
+    have : (k : ℝ) + b = 0 := by exact_mod_cast congrArg Complex.re h
+    linarith
+  simp only [gaussTerm]
+  field_simp
+  ring
+
+/-- **The `G` side of the oscillation**: `‖G a - G b‖ ≤ |a - b| * (2/n)`.
+
+The comparison is `1/((k+a)(k+b)) ≤ 2/((k+n)(k+n+1))`, valid because `a, b ≥ n ≥ 1` makes
+`(k+a)(k+b) ≥ (k+n)²` and `(k+n+1) ≤ 2(k+n)`. -/
+theorem norm_gaussSum_sub_le {n : ℕ} (hn : 1 ≤ n) {a b : ℝ}
+    (ha : (n : ℝ) ≤ a) (hb : (n : ℝ) ≤ b) :
+    ‖gaussSum (a : ℂ) - gaussSum (b : ℂ)‖ ≤ |a - b| * (2 / n) := by
+  have hn1 : (1 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+  have hnpos : (0 : ℝ) < (n : ℝ) := by linarith
+  have hapos : (0 : ℝ) < a := by linarith
+  have hbpos : (0 : ℝ) < b := by linarith
+  have habs : (0 : ℝ) ≤ |a - b| := abs_nonneg _
+  have hsa : ∀ m : ℕ, (a : ℂ) ≠ -m := fun m h ↦ by
+    have h' : a = -(m : ℝ) := by exact_mod_cast h
+    have : (0 : ℝ) ≤ (m : ℝ) := Nat.cast_nonneg m
+    linarith
+  have hsb : ∀ m : ℕ, (b : ℂ) ≠ -m := fun m h ↦ by
+    have h' : b = -(m : ℝ) := by exact_mod_cast h
+    have : (0 : ℝ) ≤ (m : ℝ) := Nat.cast_nonneg m
+    linarith
+  -- The difference of the two series, term by term.
+  have hHS : HasSum (fun k ↦ gaussTerm (a : ℂ) k - gaussTerm (b : ℂ) k)
+      (gaussSum (a : ℂ) - gaussSum (b : ℂ)) := by
+    have h := (summable_gaussTerm hsa).hasSum.sub (summable_gaussTerm hsb).hasSum
+    simpa only [gaussSum, add_sub_add_left_eq_sub] using h
+  -- Each term, bounded by the telescoping comparison scaled by `|a - b|`.
+  have hbound : ∀ k : ℕ, ‖gaussTerm (a : ℂ) k - gaussTerm (b : ℂ) k‖
+      ≤ |a - b| * (2 * (((k : ℝ) + n) * ((k : ℝ) + n + 1))⁻¹) := by
+    intro k
+    have hkn : (0 : ℝ) ≤ (k : ℝ) := Nat.cast_nonneg k
+    have hka : (0 : ℝ) < (k : ℝ) + a := by linarith
+    have hkb : (0 : ℝ) < (k : ℝ) + b := by linarith
+    have hknpos : (0 : ℝ) < (k : ℝ) + n := by linarith
+    have hprod : (0 : ℝ) < ((k : ℝ) + a) * ((k : ℝ) + b) := mul_pos hka hkb
+    have hnprod : (0 : ℝ) < ((k : ℝ) + n) * ((k : ℝ) + n + 1) := by positivity
+    rw [gaussTerm_sub hapos hbpos k, norm_div, norm_mul]
+    have hna : ‖((k : ℂ) + a)‖ = (k : ℝ) + a := by
+      have hc : ((k : ℂ) + a) = (((k : ℝ) + a : ℝ) : ℂ) := by push_cast; ring
+      rw [hc, Complex.norm_real, Real.norm_of_nonneg hka.le]
+    have hnb : ‖((k : ℂ) + b)‖ = (k : ℝ) + b := by
+      have hc : ((k : ℂ) + b) = (((k : ℝ) + b : ℝ) : ℂ) := by push_cast; ring
+      rw [hc, Complex.norm_real, Real.norm_of_nonneg hkb.le]
+    have hnum : ‖((a : ℂ) - b)‖ = |a - b| := by
+      have hc : ((a : ℂ) - b) = ((a - b : ℝ) : ℂ) := by push_cast; ring
+      rw [hc, Complex.norm_real, Real.norm_eq_abs]
+    rw [hna, hnb, hnum]
+    have hcmp : 1 / (((k : ℝ) + a) * ((k : ℝ) + b))
+        ≤ 2 / (((k : ℝ) + n) * ((k : ℝ) + n + 1)) := by
+      rw [div_le_div_iff₀ hprod hnprod]
+      nlinarith
+    calc |a - b| / (((k : ℝ) + a) * ((k : ℝ) + b))
+        = |a - b| * (1 / (((k : ℝ) + a) * ((k : ℝ) + b))) := by ring
+      _ ≤ |a - b| * (2 / (((k : ℝ) + n) * ((k : ℝ) + n + 1))) :=
+          mul_le_mul_of_nonneg_left hcmp habs
+      _ = |a - b| * (2 * (((k : ℝ) + n) * ((k : ℝ) + n + 1))⁻¹) := by ring
+  have hle := hHS.norm_le_of_bounded (hasSum_comparison hn1 |a - b|) hbound
+  refine hle.trans_eq ?_
+  field_simp
+
+/-! ### The `ψ` side -/
+
+/-- `|log a - log b| ≤ |a - b| / n` for `a, b ≥ n > 0`, from `log(1 + t) ≤ t`. -/
+theorem abs_log_sub_log_le {n : ℝ} (hn : 0 < n) {a b : ℝ} (ha : n ≤ a) (hb : n ≤ b) :
+    |Real.log a - Real.log b| ≤ |a - b| / n := by
+  -- Symmetric in `a` and `b`, so it is enough to do the case `b ≤ a`.
+  have key : ∀ u v : ℝ, n ≤ u → n ≤ v → v ≤ u → Real.log u - Real.log v ≤ (u - v) / n := by
+    intro u v hu hv hvu
+    have hvpos : (0 : ℝ) < v := lt_of_lt_of_le hn hv
+    have hupos : (0 : ℝ) < u := lt_of_lt_of_le hn hu
+    rw [← Real.log_div hupos.ne' hvpos.ne']
+    have h1 : Real.log (u / v) ≤ u / v - 1 := Real.log_le_sub_one_of_pos (by positivity)
+    have h2 : u / v - 1 = (u - v) / v := by field_simp
+    have h3 : (u - v) / v ≤ (u - v) / n := by gcongr
+    linarith
+  rcases le_total b a with h | h
+  · have hlog : Real.log b ≤ Real.log a := Real.log_le_log (lt_of_lt_of_le hn hb) h
+    rw [abs_of_nonneg (by linarith), abs_of_nonneg (by linarith)]
+    exact key a b ha hb h
+  · have hlog : Real.log a ≤ Real.log b := Real.log_le_log (lt_of_lt_of_le hn ha) h
+    rw [abs_sub_comm, abs_sub_comm a b, abs_of_nonneg (by linarith),
+      abs_of_nonneg (by linarith)]
+    exact key b a hb ha h
+
+/-- **The `ψ` side of the oscillation**: `|ψ a - ψ b| ≤ 3/n`, from Stage 1. -/
+theorem abs_deriv_log_Gamma_sub_le {n : ℕ} (hn : 1 ≤ n) {a b : ℝ}
+    (ha : (n : ℝ) ≤ a) (hb : (n : ℝ) ≤ b) (hab : |a - b| ≤ 1) :
+    |deriv (fun t ↦ Real.log (Real.Gamma t)) a - deriv (fun t ↦ Real.log (Real.Gamma t)) b|
+      ≤ 3 / n := by
+  have hn1 : (1 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+  have hnpos : (0 : ℝ) < (n : ℝ) := by linarith
+  have hapos : (0 : ℝ) < a := by linarith
+  have hbpos : (0 : ℝ) < b := by linarith
+  have h1 := abs_deriv_log_Gamma_sub_log_le hapos
+  have h2 := abs_deriv_log_Gamma_sub_log_le hbpos
+  have h3 := abs_log_sub_log_le hnpos ha hb
+  have h1n : (1 : ℝ) / a ≤ 1 / n := by gcongr
+  have h2n : (1 : ℝ) / b ≤ 1 / n := by gcongr
+  have h3n : |a - b| / n ≤ 1 / n := by gcongr
+  -- Two triangle inequalities through `log a` and `log b`.
+  have t1 := abs_sub_le (deriv (fun t ↦ Real.log (Real.Gamma t)) a) (Real.log a)
+    (deriv (fun t ↦ Real.log (Real.Gamma t)) b)
+  have t2 := abs_sub_le (Real.log a) (Real.log b)
+    (deriv (fun t ↦ Real.log (Real.Gamma t)) b)
+  have t3 : |Real.log b - deriv (fun t ↦ Real.log (Real.Gamma t)) b|
+      = |deriv (fun t ↦ Real.log (Real.Gamma t)) b - Real.log b| := abs_sub_comm _ _
+  have hthree : (3 : ℝ) / n = 1 / n + 1 / n + 1 / n := by ring
+  linarith
+
+/-! ### The two sides together -/
+
+/-- **Stage 2f**: `E = ψ - G` varies by at most `5/n` across a unit interval to the right of `n`.
+
+This is the third and last hypothesis of `eq_zero_of_periodic_of_nat_of_oscillation`, with
+`C = 5`. -/
+theorem norm_error_sub_le {n : ℕ} (hn : 1 ≤ n) {a b : ℝ}
+    (ha : (n : ℝ) ≤ a) (hb : (n : ℝ) ≤ b) (hab : |a - b| ≤ 1) :
+    ‖(Complex.digamma (a : ℂ) - gaussSum (a : ℂ))
+        - (Complex.digamma (b : ℂ) - gaussSum (b : ℂ))‖ ≤ 5 / n := by
+  have hn1 : (1 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+  have hnpos : (0 : ℝ) < (n : ℝ) := by linarith
+  have hapos : (0 : ℝ) < a := by linarith
+  have hbpos : (0 : ℝ) < b := by linarith
+  -- Split into the `ψ` difference and the `G` difference.
+  have hsplit : (Complex.digamma (a : ℂ) - gaussSum (a : ℂ))
+      - (Complex.digamma (b : ℂ) - gaussSum (b : ℂ))
+      = (Complex.digamma (a : ℂ) - Complex.digamma (b : ℂ))
+        - (gaussSum (a : ℂ) - gaussSum (b : ℂ)) := by ring
+  -- The `ψ` difference is real, and Stage 1 bounds it.
+  have hpsi : ‖Complex.digamma (a : ℂ) - Complex.digamma (b : ℂ)‖ ≤ 3 / n := by
+    rw [digamma_ofReal hapos, digamma_ofReal hbpos, ← Complex.ofReal_sub, Complex.norm_real,
+      Real.norm_eq_abs]
+    exact abs_deriv_log_Gamma_sub_le hn ha hb hab
+  have hG : ‖gaussSum (a : ℂ) - gaussSum (b : ℂ)‖ ≤ 2 / n := by
+    refine (norm_gaussSum_sub_le hn ha hb).trans ?_
+    have hle : |a - b| * (2 / n) ≤ 1 * (2 / n) := by gcongr
+    simpa using hle
+  have hfive : (5 : ℝ) / n = 3 / n + 2 / n := by ring
+  rw [hsplit]
+  refine (norm_sub_le _ _).trans ?_
+  linarith
+
+end GammaSolution

--- a/Solutions/GammaAsymptotics.v2/Periodic.lean
+++ b/Solutions/GammaAsymptotics.v2/Periodic.lean
@@ -3,14 +3,15 @@ Copyright (c) 2026 IEANTN contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Terence Tao
 -/
-import Mathlib.Algebra.Ring.Periodic
+import Mathlib.Analysis.Normed.Group.Basic
 import Mathlib.Analysis.SpecificLimits.Basic
 
 /-!
 # The vanishing lemma
 
-A 1-periodic function that vanishes at the naturals and varies by `O(1/n)` across unit intervals
-far out is identically zero on the positive reals.
+A function on the reals that reproduces itself under `x ↦ x + 1` to the right of the origin,
+vanishes at the naturals, and varies by `O(1/n)` across unit intervals far out, is identically
+zero on the positive reals.
 
 This is the whole content of identifying `ψ` with its Gauss series on the reals, isolated from the
 series so it can be checked on its own. Periodicity lets any point be pushed arbitrarily far
@@ -24,20 +25,46 @@ vanishing on `ℤ` is otherwise entirely unconstrained. The oscillation hypothes
 between the integers, and it is supplied on both sides by Stage 1 (`ψ` fluctuates by `O(1/x)`
 across a unit interval) and by a telescoping comparison for the series.
 
-Nothing here is about `Γ`; it is a statement about real functions, and it is stated that way
-deliberately so that the analytic input and the soft argument can be audited apart.
+## Two things this asks for less of than the obvious statement, both because it must
+
+* **Periodicity only to the right of the origin.** The hypothesis is `E (x + 1) = E x` *for
+  `x > 0`*, not `Function.Periodic E 1`. Full periodicity is FALSE for the intended `E = ψ - G`:
+  at `x = -1` both `ψ` and the Gauss series are junk values — `Γ(-1) = 0`, so `logDeriv` divides
+  by zero, and the series is not summable, so `tsum` is `0` — and nothing relates `E(0)` to
+  `E(-1)`. The recurrences that make `E` periodic (`digamma_apply_add_one`, `gaussSum_add_one`)
+  both carry the hypothesis `s ∉ {0, -1, -2, …}`, so a statement demanding periodicity everywhere
+  could not have been discharged. Shifting right is all the proof uses.
+* **Values in a normed group, not `ℝ`.** `Complex.digamma` is complex-valued, and restricting it
+  to the real axis does not make it a real-valued function in Lean's sense.
+
+Nothing here is about `Γ`; it is a statement about functions on the reals, and it is stated that
+way deliberately so that the analytic input and the soft argument can be audited apart.
 -/
 
 namespace GammaSolution
 
-/-- **A 1-periodic function vanishing at the naturals, with `O(1/n)` oscillation, is zero.** -/
-theorem eq_zero_of_periodic_of_nat_of_oscillation {E : ℝ → ℝ} {C : ℝ}
-    (hper : Function.Periodic E 1)
+/-- **A function shift-invariant and vanishing at the naturals, with `O(1/n)` oscillation, is
+zero on the positive reals.** -/
+theorem eq_zero_of_periodic_of_nat_of_oscillation {F : Type*} [NormedAddCommGroup F]
+    {E : ℝ → F} {C : ℝ}
+    (hper : ∀ x : ℝ, 0 < x → E (x + 1) = E x)
     (hnat : ∀ n : ℕ, E ((n : ℝ) + 1) = 0)
     (hosc : ∀ n : ℕ, 1 ≤ n → ∀ a b : ℝ, (n : ℝ) ≤ a → (n : ℝ) ≤ b → |a - b| ≤ 1 →
-      |E a - E b| ≤ C / n)
+      ‖E a - E b‖ ≤ C / n)
     {x : ℝ} (hx : 0 < x) : E x = 0 := by
-  have key : ∀ n : ℕ, 1 ≤ n → |E x| ≤ C / n := by
+  -- Shifting right by one integer at a time, which is all the recurrences give.
+  have hshift : ∀ n : ℕ, ∀ y : ℝ, 0 < y → E (y + n) = E y := by
+    intro n
+    induction n with
+    | zero => simp
+    | succ n ih =>
+      intro y hy
+      have hyn : (0 : ℝ) < y + n := by
+        have : (0 : ℝ) ≤ (n : ℝ) := Nat.cast_nonneg n
+        linarith
+      have hre : y + ((n + 1 : ℕ) : ℝ) = (y + (n : ℝ)) + 1 := by push_cast; ring
+      rw [hre, hper (y + n) hyn, ih y hy]
+  have key : ∀ n : ℕ, 1 ≤ n → ‖E x‖ ≤ C / n := by
     intro n hn
     set m : ℕ := ⌊x⌋₊ with hm
     have hmx : (m : ℝ) ≤ x := Nat.floor_le hx.le
@@ -45,7 +72,7 @@ theorem eq_zero_of_periodic_of_nat_of_oscillation {E : ℝ → ℝ} {C : ℝ}
     have hmnn : (0 : ℝ) ≤ (m : ℝ) := Nat.cast_nonneg m
     have hnnn : (0 : ℝ) ≤ (n : ℝ) := Nat.cast_nonneg n
     -- Push `x` right by `n`; compare with the zero of `E` at `m + n + 1`.
-    have hEx : E x = E (x + n) := by simpa using (hper.nat_mul n x).symm
+    have hEx : E x = E (x + n) := (hshift n x hx).symm
     have hzero : E (((m + n : ℕ) : ℝ) + 1) = 0 := hnat (m + n)
     have hle_a : (n : ℝ) ≤ x + n := by linarith
     have hle_b : (n : ℝ) ≤ ((m + n : ℕ) : ℝ) + 1 := by push_cast; linarith
@@ -58,8 +85,8 @@ theorem eq_zero_of_periodic_of_nat_of_oscillation {E : ℝ → ℝ} {C : ℝ}
   -- `C / n → 0`, so a quantity below all of them is at most zero.
   have hlim : Filter.Tendsto (fun n : ℕ ↦ C / (n : ℝ)) Filter.atTop (nhds 0) :=
     tendsto_const_div_atTop_nhds_zero_nat C
-  have hle : |E x| ≤ 0 :=
+  have hle : ‖E x‖ ≤ 0 :=
     ge_of_tendsto hlim (Filter.eventually_atTop.mpr ⟨1, fun n hn ↦ key n hn⟩)
-  exact abs_nonpos_iff.mp hle
+  exact norm_le_zero_iff.mp hle
 
 end GammaSolution

--- a/Solutions/GammaAsymptotics.v2/RealIdentity.lean
+++ b/Solutions/GammaAsymptotics.v2/RealIdentity.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2026 IEANTN contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Tao
+-/
+import Oscillation
+import Periodic
+
+/-!
+# `ψ = G` on the positive real axis
+
+The payoff of stages 1 and 2a–2f: the three hypotheses of
+`eq_zero_of_periodic_of_nat_of_oscillation` are now all available for `E := ψ - G`, so `E` is
+identically zero to the right of the origin.
+
+| hypothesis | supplied by |
+|---|---|
+| `E(x+1) = E x` for `x > 0` | `Complex.digamma_apply_add_one` and `gaussSum_add_one` (2b, 2d) |
+| `E(n+1) = 0` | `digamma_eq_gaussSum_nat_add_one` (2e) |
+| `‖E a - E b‖ ≤ 5/n` | `norm_error_sub_le` (2f) |
+
+**This is the Gauss representation on the reals**, which is the fact Mathlib's `Digamma.lean`
+lists as a `TODO`, and the thing the node's docstring correctly identified as the obstruction.
+What remains for the node is transport: the identity theorem carries it to `ℂ` (2g), and the
+estimate then follows on a strip (Stage 3).
+-/
+
+namespace GammaSolution
+
+open Complex
+
+/-- The error `E = ψ - G`, as a function on the reals. -/
+noncomputable def gaussError (x : ℝ) : ℂ :=
+  Complex.digamma (x : ℂ) - gaussSum (x : ℂ)
+
+/-- A positive real avoids every pole of `ψ` and of `G`. -/
+theorem ofReal_ne_neg_nat {x : ℝ} (hx : 0 < x) (m : ℕ) : (x : ℂ) ≠ -(m : ℂ) :=
+  ofReal_ne_neg_natCast hx m
+
+/-- **2d, the shift**: `E(x+1) = E(x)` for `x > 0`, because `ψ` and `G` satisfy the same
+recurrence.
+
+Note this is a *shift to the right of the origin*, not periodicity on all of `ℝ`: both
+recurrences carry the hypothesis `s ∉ {0, -1, -2, …}`, and at a pole both sides are junk. -/
+theorem gaussError_add_one {x : ℝ} (hx : 0 < x) : gaussError (x + 1) = gaussError x := by
+  have hne := ofReal_ne_neg_nat hx
+  have hcast : ((x + 1 : ℝ) : ℂ) = (x : ℂ) + 1 := by push_cast; ring
+  have hx0 : (x : ℂ) ≠ 0 := by simpa using hne 0
+  simp only [gaussError, hcast]
+  rw [Complex.digamma_apply_add_one _ hne, gaussSum_add_one hne]
+  ring
+
+/-- **2e, the vanishing at the naturals**, restated for `E`. -/
+theorem gaussError_nat_add_one (n : ℕ) : gaussError ((n : ℝ) + 1) = 0 := by
+  have hcast : (((n : ℝ) + 1 : ℝ) : ℂ) = (n : ℂ) + 1 := by push_cast; ring
+  simp only [gaussError, hcast]
+  rw [digamma_eq_gaussSum_nat_add_one n, sub_self]
+
+/-- **2f, the oscillation**, restated for `E`. -/
+theorem norm_gaussError_sub_le {n : ℕ} (hn : 1 ≤ n) {a b : ℝ}
+    (ha : (n : ℝ) ≤ a) (hb : (n : ℝ) ≤ b) (hab : |a - b| ≤ 1) :
+    ‖gaussError a - gaussError b‖ ≤ 5 / n :=
+  norm_error_sub_le hn ha hb hab
+
+/-- **The Gauss representation on the positive reals**:
+`ψ(x) = -γ + ∑ₖ (1/(k+1) - 1/(k+x))` for every real `x > 0`. -/
+theorem digamma_eq_gaussSum_of_pos {x : ℝ} (hx : 0 < x) :
+    Complex.digamma (x : ℂ) = gaussSum (x : ℂ) := by
+  have h : gaussError x = 0 :=
+    eq_zero_of_periodic_of_nat_of_oscillation
+      (fun y hy ↦ gaussError_add_one hy)
+      gaussError_nat_add_one
+      (fun n hn a b ha hb hab ↦ norm_gaussError_sub_le hn ha hb hab)
+      hx
+  rwa [gaussError, sub_eq_zero] at h
+
+end GammaSolution

--- a/Solutions/GammaAsymptotics.v2/Recurrence.lean
+++ b/Solutions/GammaAsymptotics.v2/Recurrence.lean
@@ -47,8 +47,11 @@ noncomputable def gaussSum (s : ℂ) : ℂ :=
 /-- **A telescoping series**: if `f n → 0` and the differences are summable, they sum to `f 0`.
 
 Stated for its own sake rather than inlined, because the argument is entirely about partial sums
-and has nothing to do with `Γ`. -/
-theorem hasSum_sub_succ {f : ℕ → ℂ} (hsum : Summable fun k ↦ f k - f (k + 1))
+and has nothing to do with `Γ` — and stated over an arbitrary complete normed group because it is
+used twice at different types: over `ℂ` for the recurrence below, and over `ℝ` in
+`Oscillation.lean`, where the same telescoping sums `1/((k+t)(k+t+1))` to `1/t`. -/
+theorem hasSum_sub_succ {F : Type*} [NormedAddCommGroup F] [CompleteSpace F] {f : ℕ → F}
+    (hsum : Summable fun k ↦ f k - f (k + 1))
     (hlim : Filter.Tendsto f Filter.atTop (nhds 0)) :
     HasSum (fun k ↦ f k - f (k + 1)) (f 0) := by
   have hpart : ∀ n : ℕ, ∑ i ∈ Finset.range n, (f i - f (i + 1)) = f 0 - f n :=

--- a/Solutions/GammaAsymptotics.v2/Solution.lean
+++ b/Solutions/GammaAsymptotics.v2/Solution.lean
@@ -7,6 +7,7 @@ import RealAsymptotic
 import Periodic
 import GaussSeries
 import Recurrence
+import RealIdentity
 import IEANTN.Nodes.GammaAsymptotics.v2.Conclusions
 
 /-!
@@ -31,22 +32,30 @@ the order of work. The plan is now:
 2. **The Gauss series on `ℂ`.** Write `G s := -γ + ∑ₖ gaussTerm s k`.
    * a. the series converges — `GaussSeries.lean`, **done**;
    * b. the recurrence `G(s+1) = G(s) + 1/s` — `Recurrence.lean`, **done**, by telescoping;
-   * c. `G` is analytic off the non-positive integers;
-   * d. hence `E := ψ - G` is 1-periodic on the reals;
+   * d. hence `E := ψ - G` reproduces itself under `x ↦ x + 1` for `x > 0` —
+        `RealIdentity.lean`, **done**;
    * e. `ψ(n+1) = G(n+1)`, both being `-γ + Hₙ` — `Recurrence.lean`, **done**;
-   * f. `E` oscillates by `O(1/n)` across unit intervals — Stage 1 handles the `ψ` side, a
-        telescoping comparison the `G` side — so `eq_zero_of_periodic_of_nat_of_oscillation`
-        (`Periodic.lean`, **done**) gives `E ≡ 0` on the positive reals;
-   * g. the identity theorem carries `ψ = G` from a set with a limit point to all of `ℂ`.
+   * f. `E` oscillates by `≤ 5/n` across unit intervals — `Oscillation.lean`, **done**: Stage 1
+        gives the `ψ` side `3/n` (through `ComplexToReal.lean`), and a telescoping comparison
+        gives the `G` side `2/n`;
+   * **so `ψ = G` on the positive reals** — `RealIdentity.lean`, **done**, by
+     `eq_zero_of_periodic_of_nat_of_oscillation`. *This is the Gauss representation, the fact
+     Mathlib's `Digamma.lean` lists as a `TODO`, and the obstruction the node docstring named.*
+   * c. `G` is analytic off the non-positive integers — **to do**;
+   * g. the identity theorem carries `ψ = G` from the positive reals, which have a limit point,
+        to all of `ℂ` — **to do**, and needs (c).
 3. **The strip bound.** With the representation in hand, `‖ψ w - log w‖ ≤ C_H / ‖w‖` for
-   `Re w ≥ 1`, `|Im w| ≤ H`.
+   `Re w ≥ 1`, `|Im w| ≤ H` — **to do**.
+
+Step (c) moved after the real identity rather than before it, because nothing up to and including
+the identity needs `G` to be analytic — the whole argument runs on the real axis, where `G` is
+just a convergent series of real terms. Analyticity is needed only to *transport* the identity,
+which is step (g)'s business.
 
 The two steps that looked hardest going in — the real asymptotic and the periodic-vanishing
-argument — are the two that were finished first, and neither used the representation.
-
-Of the vanishing lemma's three hypotheses, two are now in hand (2b gives periodicity once paired
-with `Complex.digamma_apply_add_one`; 2e is the vanishing at integers outright). The oscillation
-bound, 2f, is the one still to write, and Stage 1 already supplies its harder half.
+argument — were the two that finished first, and neither used the representation. What was
+actually awkward was neither: it was `ComplexToReal.lean`, one lemma relating `Complex.digamma` on
+the real axis to Stage 1's real derivative, whose Mathlib counterpart exists but is `private`.
 
 ## What the constant does
 

--- a/Solutions/GammaAsymptotics.v2/lakefile.toml
+++ b/Solutions/GammaAsymptotics.v2/lakefile.toml
@@ -1,5 +1,5 @@
 name = "solution_GammaAsymptotics_v2"
-defaultTargets = ["RealAsymptotic", "Periodic", "GaussSeries", "Recurrence", "Solution"]
+defaultTargets = ["RealAsymptotic", "Periodic", "GaussSeries", "Recurrence", "ComplexToReal", "Oscillation", "RealIdentity", "Solution"]
 
 [[require]]
 name = "IEANTN"
@@ -20,6 +20,18 @@ roots = ["GaussSeries"]
 [[lean_lib]]
 name = "Recurrence"
 roots = ["Recurrence"]
+
+[[lean_lib]]
+name = "ComplexToReal"
+roots = ["ComplexToReal"]
+
+[[lean_lib]]
+name = "Oscillation"
+roots = ["Oscillation"]
+
+[[lean_lib]]
+name = "RealIdentity"
+roots = ["RealIdentity"]
 
 [[lean_lib]]
 name = "Solution"

--- a/Solutions/GammaAsymptotics.v2/progress.yaml
+++ b/Solutions/GammaAsymptotics.v2/progress.yaml
@@ -5,7 +5,7 @@
 # judgement and should read like it.
 
 solution: Solutions/GammaAsymptotics.v2/
-state: in-progress   # one hole, the conclusion itself; five of the eight sub-steps closed
+state: in-progress   # one hole, the conclusion itself; the Gauss representation holds on the reals
 
 # --------------------------------------------------------------------------------------------
 # WHAT THE MATHLIB BUMP CHANGED, and what the node still records.
@@ -94,10 +94,19 @@ steps:
     file: Periodic.lean
     state: done
     what: >-
-      A 1-periodic real function that vanishes at the naturals and varies by O(1/n) across unit
-      intervals far out is identically zero on the positive reals. Periodicity pushes any point
-      arbitrarily far right, where the oscillation bound is arbitrarily tight and a zero always sits
-      within distance one.
+      A function that reproduces itself under x -> x+1 to the right of the origin, vanishes at the
+      naturals, and varies by O(1/n) across unit intervals far out, is identically zero on the
+      positive reals. The shift pushes any point arbitrarily far right, where the oscillation bound
+      is arbitrarily tight and a zero always sits within distance one.
+    weakened_twice_when_it_met_its_consumer: >-
+      As first written it asked for Function.Periodic E 1 and for E real-valued. BOTH WERE WRONG FOR
+      THE ACTUAL E. Full periodicity is FALSE for psi - G: at x = -1 both are junk (Gamma(-1) = 0,
+      so logDeriv divides by zero; the series is not summable, so tsum is 0), and the recurrences
+      that would give periodicity carry the hypothesis s not in {0, -1, -2, ...}. And E is
+      complex-valued, since restricting Complex.digamma to the real axis does not make it a real
+      function in Lean's sense. The proof needed neither, so the statement now asks for the rightward
+      shift only and takes values in any normed group. Worth recording as a pattern: a lemma proved
+      before its consumer exists will be over-specified in whatever direction was not thought about.
     why_it_is_stated_alone: >-
       THE NAIVE VERSION DOES NOT WORK, and an earlier draft of the node docstring believed it did:
       periodicity spreads E(1) = 0 to the integers and NOWHERE ELSE, since a 1-periodic function
@@ -117,17 +126,17 @@ steps:
       is the first hypothesis of the vanishing lemma.
     exports: [gaussSum, hasSum_sub_succ, tendsto_inv_natCast_add, gaussSum_add_one]
 
-  - id: "2c"
-    name: Analyticity of G
-    state: todo
-    what: >-
-      G is analytic off the non-positive integers, by differentiableOn_tsum_of_summable_norm with
-      the O(1/k^2) bound from 2a made locally uniform.
-
   - id: "2d"
-    name: E is 1-periodic
-    state: todo
-    what: "E := psi - G is 1-periodic, from 2b and Complex.digamma_apply_add_one."
+    name: E reproduces itself under a unit shift
+    file: RealIdentity.lean
+    state: done
+    what: >-
+      E := psi - G satisfies E(x+1) = E(x) for x > 0, from 2b and Complex.digamma_apply_add_one.
+      NOT full periodicity, and the difference matters: both recurrences carry the hypothesis
+      s not in {0, -1, -2, ...}, and at a pole both psi and G are junk values (Gamma(-1) = 0, so
+      logDeriv divides by zero; the series is not summable, so tsum is 0). The vanishing lemma was
+      restated to ask only for the rightward shift, which is all its proof uses.
+    exports: [gaussError, gaussError_add_one]
 
   - id: "2e"
     name: E vanishes at the naturals
@@ -140,18 +149,73 @@ steps:
 
   - id: "2f"
     name: The oscillation bound
+    file: Oscillation.lean
+    state: done
+    what: >-
+      ||E(a) - E(b)|| <= 5/n for a, b >= n >= 1 at distance at most 1, so C = 5. The psi side is
+      3/n from Stage 1: writing psi(a) - psi(b) as (psi(a) - log a) + (log a - log b) -
+      (psi(b) - log b), the outer brackets are 1/a and 1/b and the middle is |a-b|/n from
+      log(1+t) <= t. The G side is 2/n: termwise the difference is (a-b)/((k+a)(k+b)), the
+      divergent 1/(k+1) having cancelled, and 1/((k+a)(k+b)) <= 2/((k+n)(k+n+1)) whose right side
+      TELESCOPES TO 2/n EXACTLY -- so no p-series constant survives into the answer.
+    exports:
+      - summable_telescope
+      - tsum_telescope
+      - hasSum_comparison
+      - gaussTerm_sub
+      - norm_gaussSum_sub_le
+      - abs_log_sub_log_le
+      - abs_deriv_log_Gamma_sub_le
+      - norm_error_sub_le
+
+  - id: "2-glue"
+    name: Complex.digamma on the real axis
+    file: ComplexToReal.lean
+    state: done
+    what: >-
+      Complex.digamma x = the real deriv (fun t => log (Gamma t)) x, for real x > 0, which is what
+      lets Stage 1 feed the psi side of 2f. Both sides are Gamma'/Gamma; the content is that
+      Complex.Gamma differentiated ALONG THE REAL AXIS is the real Gamma', which is not automatic.
+      THE AWKWARD PART OF THE WHOLE STAGE, and not for mathematical reasons: Mathlib has exactly
+      this argument as HasDerivAt.complex_of_real in NumberTheory/Harmonic/GammaDeriv.lean, marked
+      `private`, so it cannot be imported and is reproved here verbatim. If any of this goes
+      upstream, that lemma losing its `private` is the first thing to ask for.
+    exports:
+      - hasDerivAt_complex_of_real
+      - ofReal_ne_neg_natCast
+      - differentiableAt_real_Gamma
+      - hasDerivAt_Gamma_ofReal
+      - deriv_log_Gamma_eq
+      - digamma_ofReal
+
+  - id: "2-real"
+    name: THE GAUSS REPRESENTATION ON THE POSITIVE REALS
+    file: RealIdentity.lean
+    state: done
+    what: >-
+      psi(x) = -gamma + sum_k (1/(k+1) - 1/(k+x)) for every real x > 0, by feeding 2d, 2e and 2f to
+      eq_zero_of_periodic_of_nat_of_oscillation. This is the fact Mathlib's Digamma.lean lists as a
+      TODO and the obstruction the node's docstring correctly named. What remains for the node is
+      transport to the complex plane and the estimate, not this.
+    exports: [gaussError, gaussError_nat_add_one, norm_gaussError_sub_le, digamma_eq_gaussSum_of_pos]
+
+  - id: "2c"
+    name: Analyticity of G
     state: todo
     what: >-
-      |E(a) - E(b)| = O(1/n) for a, b >= n at distance at most 1. Stage 1 gives the psi side; the G
-      side is |G(a) - G(b)| <= |a-b| * sum_k 1/(k+n)^2 by comparison with a telescoping series.
-      With 2d and 2e this closes E = 0 on the positive reals.
+      G is analytic off the non-positive integers, by differentiableOn_tsum_of_summable_norm with
+      the O(1/k^2) bound from 2a made locally uniform.
+      MOVED AFTER THE REAL IDENTITY rather than before it. Nothing up to and including the identity
+      needs G to be analytic: the whole argument runs on the real axis, where G is a convergent
+      series of real terms. Analyticity is needed only to TRANSPORT the identity, which is 2g.
 
   - id: "2g"
     name: To the complex plane
     state: todo
     what: >-
-      psi = G on the positive reals, a set with a limit point; both sides are analytic on the
-      connected slit plane; the identity theorem does the rest.
+      psi = G on the positive reals -- now PROVED rather than planned, see 2-real -- and that set
+      has a limit point; both sides are analytic on the connected slit plane; the identity theorem
+      does the rest. Needs 2c.
 
   - id: "3"
     name: The strip bound

--- a/Solutions/GammaAsymptotics.v2/progress.yaml
+++ b/Solutions/GammaAsymptotics.v2/progress.yaml
@@ -229,6 +229,17 @@ consumer: >-
   |Im s| <= T. The strip is not a compromise for that consumer; it is everything it ever asked for.
 
 upstream: >-
-  Steps 1, 2a and 2f-lemma are stated about Mathlib objects only and have no IEANTN import between
-  them. Once 2g lands, the natural Mathlib contribution is the representation itself -- the TODO in
-  Mathlib/Analysis/SpecialFunctions/Gamma/Digamma.lean -- with step 1 a plausible second PR.
+  Every file here is stated about Mathlib objects only; nothing in stages 1 and 2 imports anything
+  from IEANTN. Three asks, in the order they are worth making.
+  ONE: the representation itself, psi(x) = -gamma + sum_k (1/(k+1) - 1/(k+x)). This is the TODO in
+  Mathlib/Analysis/SpecialFunctions/Gamma/Digamma.lean. The real case is now PROVED here
+  (digamma_eq_gaussSum_of_pos); the complex case needs 2c and 2g, which is where the identity
+  theorem comes in, so it is worth waiting for those before opening a PR.
+  TWO: drop `private` from HasDerivAt.complex_of_real in NumberTheory/Harmonic/GammaDeriv.lean. It
+  is the fact that a complex-differentiable function agreeing with a real one on R has that
+  function's derivative there, it is four lines, and it is exactly what ComplexToReal.lean needs and
+  reproves verbatim. A one-line PR that costs upstream nothing, and worth sending FIRST because it
+  is independent of everything else here.
+  THREE: step 1, |psi(x) - log x| <= 1/x on the reals from Real.convexOn_log_Gamma alone, with the
+  constant explicit. Independent of the representation, and arguably the more useful of the two for
+  a reader who wants an effective bound rather than an identity.


### PR DESCRIPTION
Stage 2f, and with it the whole real-line half of the node.

Mathlib's `Digamma.lean` lists

> `psi(u) = -gamma + sum_k (1/(k+1) - 1/(k+u))`

as a `TODO`, and the node's docstring correctly named it as the obstruction. `digamma_eq_gaussSum_of_pos` now has it for every real `x > 0`.

| file | content |
|---|---|
| `Oscillation.lean` | `‖E a - E b‖ ≤ 5/n` for `a, b ≥ n` at distance `≤ 1` |
| `ComplexToReal.lean` | `Complex.digamma` on the real axis is Stage 1's derivative |
| `RealIdentity.lean` | the three hypotheses fed to the vanishing lemma |

## The oscillation splits 3/n + 2/n

The `ψ` side is Stage 1 plus `log(1+t) ≤ t`. The `G` side is the series: termwise the difference is `(a-b)/((k+a)(k+b))` — **the divergent `1/(k+1)` cancels** — and `1/((k+a)(k+b)) ≤ 2/((k+n)(k+n+1))`, whose right side *telescopes to `2/n` exactly*, so no `p`-series constant survives into the answer. The same `hasSum_sub_succ` does that, generalized here from `ℂ` to any complete normed group.

The `O(1/n)` is not a refinement for its own sake: `O(1)` on either side would leave `E` merely bounded, which no amount of periodicity turns into `E = 0`.

## Two things the vanishing lemma was asking for and could not have had

It demanded `Function.Periodic E 1`. **That is false for `E = ψ - G`**: at `x = -1` both are junk values — `Γ(-1) = 0`, so `logDeriv` divides by zero; the series is not summable, so `tsum` is `0` — and both recurrences carry the hypothesis `s ∉ {0,-1,-2,…}`. It also demanded `E` real-valued, and restricting `Complex.digamma` to the real axis does not make it a real function in Lean's sense.

The proof needed neither. It now asks for the rightward shift only, over any normed group. Worth recording as a pattern: **a lemma proved before its consumer exists will be over-specified in whatever direction nobody thought about.**

## The awkward step was not mathematical

Relating `Complex.digamma` on the real axis to Stage 1's real derivative needs that `Complex.Gamma` differentiated along `ℝ` is the real `Γ'`. Mathlib has exactly that argument — `HasDerivAt.complex_of_real` in `NumberTheory/Harmonic/GammaDeriv.lean` — marked `private`, so it cannot be imported and is reproved here verbatim. If any of this goes upstream, that lemma losing its `private` is the first thing to ask for.

## Reordering

Step 2c (analyticity of `G`) moved *after* the identity. Nothing up to and including the real identity needs `G` analytic — the whole argument runs on the real axis, where `G` is a convergent series of real terms. Analyticity is needed only to transport, which is 2g.

**Remaining**: 2c, 2g, and the strip bound. The node's conclusion is still `sorry`, as it must be until Stage 3.

## Gate

Solution builds (2878 jobs, one deliberate hole); `check` 8/8; `fingerprint --check`; `diff` reports no change to any statement, dependency or receipt; 209 unit tests; pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)