### PR TITLE
State Büthe equation (6.2) on ButheNumerics.v1

### DIFF
--- a/GRAPH.md
+++ b/GRAPH.md
@@ -57,7 +57,7 @@ graph LR
   NButhe_v1["<b>Buthe.v1</b><br/>6 claims<br/><i>weakest: cited</i>"]
   NButhe_v2["<b>Buthe.v2</b><br/>2 claims<br/><i>weakest: unjustified</i>"]
   NButhe2016_v1["<b>Buthe2016.v1</b><br/>4 claims<br/><i>weakest: cited</i>"]
-  NButheNumerics_v1["<b>ButheNumerics.v1</b><br/>3 claims<br/><i>weakest: computation</i>"]
+  NButheNumerics_v1["<b>ButheNumerics.v1</b><br/>4 claims<br/><i>weakest: computation</i>"]
   NCH2_v1["<b>CH2.v1</b><br/>4 claims<br/><i>weakest: cited</i>"]
   NCH2_v2["<b>CH2.v2</b><br/>2 claims<br/><i>weakest: verified, stale</i>"]
   NCH2_v3["<b>CH2.v3</b><br/>2 claims<br/><i>weakest: verified</i>"]
@@ -243,6 +243,7 @@ graph LR
     Buthe2016_v1_theorem_2_theta["<b>theorem_2_theta</b><br/><i>cited</i>"]
   end
   subgraph sgButheNumerics_v1["ButheNumerics.v1"]
+    ButheNumerics_v1_eq_6_2["<b>eq_6_2</b><br/><i>computation</i>"]
     ButheNumerics_v1_lemma_3_constant_gt_at_10["<b>lemma_3_constant_gt_at_10</b><br/><i>computation</i>"]
     ButheNumerics_v1_lemma_3_constant_nonpos["<b>lemma_3_constant_nonpos</b><br/><i>computation</i>"]
     ButheNumerics_v1_li_minus_pi_below_1e7["<b>li_minus_pi_below_1e7</b><br/><i>computation</i>"]
@@ -536,7 +537,7 @@ graph LR
   class CH2_v2_proposition_2_4_lower,CH2_v2_proposition_2_4_upper,DudekPlatt_v2_ramanujan_inequality_3915,DudekPlatt_v3_criterion,FKS2_v1_corollary_14,FKS2_v1_corollary_22,FKS2_v1_corollary_23,FKS2_v1_corollary_26,FKS2_v2_proposition_13,FKS2_v2_theorem_3,Lcm_v1_lcmUpto_not_highlyAbundant,Lcm_v2_lcmUpto_not_highlyAbundant_of_primeGap,PrimeInterval_v1_classicalBound_hasPrimeInInterval,PrimeInterval_v1_eTheta_criterion,PrimeInterval_v1_numericalBound_hasPrimeInInterval,PrimeInterval_v1_theta_characterisation,ZeroFreeHeight_v1_classical_region_descends lean_comparator_stale;
   class BKLNW_v1_corollary_5_1,BKLNW_v1_table8_psi_bound,BKLNW_v1_table8_psi_bound_above,BKLNW_v1_theta_error_le_one,Buthe_v1_theorem_2_li_gt_pi,Buthe_v1_theorem_2_li_minus_pi,Buthe_v1_theorem_2_li_minus_riemann_pi,Buthe_v1_theorem_2_psi,Buthe_v1_theorem_2_theta,Buthe_v1_theorem_2_theta_lower,Buthe2016_v1_theorem_2_li_minus_pi,Buthe2016_v1_theorem_2_li_minus_riemann_pi,Buthe2016_v1_theorem_2_psi,Buthe2016_v1_theorem_2_theta,CH2_v1_corollary_1_2_lambda_sum,CH2_v1_corollary_1_2_psi,CH2_v1_corollary_1_3_lambda_sum,CH2_v1_corollary_1_3_psi,DudekPlatt_v1_largest_counterexample_on_rh,DudekPlatt_v1_ramanujan_inequality,Dusart2018_v1_proposition_5_4,FKS_v1_psi_bound_all_x,FKS_v1_psi_classical_bound,Hiary2016_v1_zeta_half_line_bound,KLN_v1_subconvexity_bound,KLN_v1_zero_density,Kadiri2005_v1_zero_free_region,MT_v1_zero_free_region,MT_v1_zero_free_region_sharpened,PlattTrudgian_v1_rh_up_to,PlattTrudgian2021_v1_theorem_1_classical,PlattTrudgian2021_v1_theorem_1_numerical,RosserSchoenfeld_v1_zero_free_region,Trudgian2011_v1_integral_S_bound,ZeroCount_v1_rvm_error_bound,ZeroCount_v1_rvm_error_small literature;
   class Buthe_v2_lemma_3_bounds,Buthe_v2_lemma_3_positivity,ContourIntegration_v1_residue_theorem_rectangle,CotangentSeries_v1_cot_series_zeta_values,GammaAsymptotics_v1_digamma_sub_log_isBigO none_yet;
-  class ButheNumerics_v1_lemma_3_constant_gt_at_10,ButheNumerics_v1_lemma_3_constant_nonpos,ButheNumerics_v1_li_minus_pi_below_1e7,DudekPlattNumerics_v1_pi_two_sided_paper,DudekPlattNumerics_v2_pi_two_sided_pnt,FKBJ_v1_rh_up_to,FKS2Numerics_v1_corollary_22_mid_range,FKS2Numerics_v1_corollary_23_mid_range,FKS2Numerics_v1_nu_asymp_e30_le,FKS2Numerics_v1_table6_row2_floor,FKS2Numerics_v1_theta_asymp_ge_one_below_e30,LowZeroes_v1_sum_inv_ordinates_below_2e4,Platt2015_v1_rh_up_to,Platt2017_v1_rh_up_to,ZetaLogDerivValues_v1_deriv_logDeriv_neg_one,ZetaLogDerivValues_v1_logDeriv_laurent_alternating,ZetaLogDerivValues_v1_logDeriv_neg_one,ZetaLogDerivValues_v1_logDeriv_three_halves,ZetaLogDerivValues_v1_logDeriv_two numerical;
+  class ButheNumerics_v1_eq_6_2,ButheNumerics_v1_lemma_3_constant_gt_at_10,ButheNumerics_v1_lemma_3_constant_nonpos,ButheNumerics_v1_li_minus_pi_below_1e7,DudekPlattNumerics_v1_pi_two_sided_paper,DudekPlattNumerics_v2_pi_two_sided_pnt,FKBJ_v1_rh_up_to,FKS2Numerics_v1_corollary_22_mid_range,FKS2Numerics_v1_corollary_23_mid_range,FKS2Numerics_v1_nu_asymp_e30_le,FKS2Numerics_v1_table6_row2_floor,FKS2Numerics_v1_theta_asymp_ge_one_below_e30,LowZeroes_v1_sum_inv_ordinates_below_2e4,Platt2015_v1_rh_up_to,Platt2017_v1_rh_up_to,ZetaLogDerivValues_v1_deriv_logDeriv_neg_one,ZetaLogDerivValues_v1_logDeriv_laurent_alternating,ZetaLogDerivValues_v1_logDeriv_neg_one,ZetaLogDerivValues_v1_logDeriv_three_halves,ZetaLogDerivValues_v1_logDeriv_two numerical;
   click BKLNW_v1_corollary_5_1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#corollary_5_1" _blank
   click BKLNW_v1_table8_psi_bound href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#table8_psi_bound" _blank
   click BKLNW_v1_table8_psi_bound_above href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#table8_psi_bound_above" _blank
@@ -553,6 +554,7 @@ graph LR
   click Buthe2016_v1_theorem_2_li_minus_riemann_pi href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe2016-v1.md#theorem_2_li_minus_riemann_pi" _blank
   click Buthe2016_v1_theorem_2_psi href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe2016-v1.md#theorem_2_psi" _blank
   click Buthe2016_v1_theorem_2_theta href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe2016-v1.md#theorem_2_theta" _blank
+  click ButheNumerics_v1_eq_6_2 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/ButheNumerics-v1.md#eq_6_2" _blank
   click ButheNumerics_v1_lemma_3_constant_gt_at_10 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/ButheNumerics-v1.md#lemma_3_constant_gt_at_10" _blank
   click ButheNumerics_v1_lemma_3_constant_nonpos href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/ButheNumerics-v1.md#lemma_3_constant_nonpos" _blank
   click ButheNumerics_v1_li_minus_pi_below_1e7 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/ButheNumerics-v1.md#li_minus_pi_below_1e7" _blank
@@ -687,6 +689,8 @@ A line is one claim, indented under whatever assumes it.
 - [`Buthe2016.v1.theorem_2_li_minus_riemann_pi`](docs/nodes/Buthe2016-v1.md#theorem_2_li_minus_riemann_pi) — cited
 
 - [`Buthe2016.v1.theorem_2_theta`](docs/nodes/Buthe2016-v1.md#theorem_2_theta) — cited
+
+- [`ButheNumerics.v1.eq_6_2`](docs/nodes/ButheNumerics-v1.md#eq_6_2) — computation
 
 - [`CH2.v1.corollary_1_3_lambda_sum`](docs/nodes/CH2-v1.md#corollary_1_3_lambda_sum) — cited — *sources known, not all drawable*
   - [`CH2.v1.corollary_1_2_lambda_sum`](docs/nodes/CH2-v1.md#corollary_1_2_lambda_sum) — cited — *sources known, not all drawable*
@@ -933,6 +937,7 @@ rather than maintained.
 | [`Buthe2016.v1.theorem_2_li_minus_pi`](docs/nodes/Buthe2016-v1.md#theorem_2_li_minus_pi) | cited | 0 | none |
 | [`Buthe2016.v1.theorem_2_li_minus_riemann_pi`](docs/nodes/Buthe2016-v1.md#theorem_2_li_minus_riemann_pi) | cited | 0 | none |
 | [`Buthe2016.v1.theorem_2_theta`](docs/nodes/Buthe2016-v1.md#theorem_2_theta) | cited | 0 | none |
+| [`ButheNumerics.v1.eq_6_2`](docs/nodes/ButheNumerics-v1.md#eq_6_2) | computation | 0 | none |
 | [`CH2.v1.corollary_1_3_lambda_sum`](docs/nodes/CH2-v1.md#corollary_1_3_lambda_sum) | cited | 0 | known, not all drawable |
 | [`CH2.v1.corollary_1_3_psi`](docs/nodes/CH2-v1.md#corollary_1_3_psi) | cited | 0 | known, not all drawable |
 | [`DudekPlatt.v1.largest_counterexample_on_rh`](docs/nodes/DudekPlatt-v1.md#largest_counterexample_on_rh) | cited | 0 | known, not all drawable |

--- a/IEANTN/Nodes/ButheNumerics/v1/Challenge.lean
+++ b/IEANTN/Nodes/ButheNumerics/v1/Challenge.lean
@@ -24,3 +24,6 @@ theorem ButheNumerics.v1.challenge_li_minus_pi_below_1e7 : ButheNumerics.v1.li_m
 
 theorem ButheNumerics.v1.challenge_lemma_3_constant_gt_at_10 : ButheNumerics.v1.lemma_3_constant_gt_at_10 := by
   sorry
+
+theorem ButheNumerics.v1.challenge_eq_6_2 : ButheNumerics.v1.eq_6_2 := by
+  sorry

--- a/IEANTN/Nodes/ButheNumerics/v1/Conclusions.lean
+++ b/IEANTN/Nodes/ButheNumerics/v1/Conclusions.lean
@@ -118,4 +118,20 @@ here would point the wrong way. -/
 noncomputable def lemma_3_constant_gt_at_10 : Prop :=
   0.1 < primeCounting 10 - li 10 + (10 - Chebyshev.theta 10) / Real.log 10
 
+/-- **Equation (6.2).** The Eratosthenes-sieve bound on the normalised remainder
+`R_ψ(t) = (t − ψ(t)) / √t`.
+
+Büthe records `-0.8 ≤ R_ψ(t) ≤ 0.81` for every `100 ≤ t ≤ 5 · 10¹⁰`, obtained by sieving rather
+than by the analytic algorithm. Together with Table 1 this is what implies Theorem 2's (1.5) on
+`11 < t ≤ 10¹⁹` (the remaining `11 < t < 100` being a direct check).
+
+Transcribed from arXiv:1511.02032v2, equation (6.2), including the asymmetric constants and the
+closed interval. This is the "sieve bound of Section 6" that `Buthe.v1`'s limitations list as
+unstated. It lives here rather than on `Buthe.v1` because it is a finite computation, not an
+analytic claim. -/
+def eq_6_2 : Prop :=
+  ∀ t : ℝ, 100 ≤ t → t ≤ 5 * 10 ^ (10 : ℕ) →
+    -0.8 ≤ (t - Chebyshev.psi t) / Real.sqrt t ∧
+      (t - Chebyshev.psi t) / Real.sqrt t ≤ 0.81
+
 end ButheNumerics.v1

--- a/IEANTN/Nodes/ButheNumerics/v1/formalization.yaml
+++ b/IEANTN/Nodes/ButheNumerics/v1/formalization.yaml
@@ -93,6 +93,25 @@ conclusions:
       a solution that conflates the two points proves nothing. Imports `none`: three evaluations at a
       single point consume no other result in the network.
   designated: buthe-computation
+- id: eq_6_2
+  declaration: ButheNumerics.v1.eq_6_2
+  challenge: ButheNumerics.v1.challenge_eq_6_2
+  imports: []
+  imports_status: none
+  justifications:
+  - id: buthe-computation
+    kind: numerical
+    source: Buthe
+    locator: Equation (6.2)
+    note: >-
+      A finite check rather than an argument, so `numerical`. Buthe records -0.8 <= R_psi(t) <= 0.81
+      for 100 <= t <= 5e10, "calculated using the Eratosthenes sieve". Together with Table 1 this
+      implies Theorem 2's (1.5); the remaining 11 < t < 100 is a direct check. Transcribed from
+      arXiv:1511.02032v2, including the asymmetric constants and the closed interval. Imports `none`:
+      a bounded-range sieve consumes no other result in the network. This is the sieve bound of
+      Section 6 that Buthe.v1's limitations list as unstated; it lives on this node because it is a
+      computation, not an analytic claim.
+  designated: buthe-computation
 
 sources:
 - title: "An analytic method for bounding psi(x)"

--- a/STATE.md
+++ b/STATE.md
@@ -7,7 +7,7 @@ column says what a receipt is presently worth, not merely what was claimed for i
 reason a receipt has stopped standing is below, and `python scripts/ieantn.py status`
 adds the environment detail.
 
-47 node version(s), 91 conclusion(s).  3 state nothing yet.
+47 node version(s), 92 conclusion(s).  3 state nothing yet.
 
 ## Evidence
 
@@ -18,7 +18,7 @@ adds the environment detail.
 | `lean-comparator` | 29 |
 | `literature` | 36 |
 | `none-yet` | 5 |
-| `numerical` | 19 |
+| `numerical` | 20 |
 
 ## Nodes
 
@@ -44,6 +44,7 @@ adds the environment detail.
 | `ButheNumerics.v1` | stub | `lemma_3_constant_nonpos` | numerical | 0 | - |
 | `ButheNumerics.v1` | stub | `li_minus_pi_below_1e7` | numerical | 0 | - |
 | `ButheNumerics.v1` | stub | `lemma_3_constant_gt_at_10` | numerical | 0 | - |
+| `ButheNumerics.v1` | stub | `eq_6_2` | numerical | 0 | - |
 | `CH2.v1` | awaiting-solution | `corollary_1_2_psi` | literature | 2 | - |
 | `CH2.v1` | awaiting-solution | `corollary_1_2_lambda_sum` | literature | 2 | - |
 | `CH2.v1` | awaiting-solution | `corollary_1_3_psi` | literature | 2 | - |

--- a/docs/nodes/ButheNumerics-v1.md
+++ b/docs/nodes/ButheNumerics-v1.md
@@ -135,6 +135,41 @@ noncomputable def lemma_3_constant_gt_at_10 : Prop :=
 
 > A finite check rather than an argument, so `numerical`. Buthe proves Lemma 3's positivity clause -- that x - theta(x) > 0 throughout [2, T] forces li(x) - pi(x) > 0 there -- by "taking a = 10 in (6.17) since pi(10) - li(10) + (10 - theta(10))/log 10 > 0.1". That inequality is displayed inside the proof but is not a stated result, and nothing else in the network carries it. It is the second hidden numerical input in this paper, the first being the sign of the same functional at a = 1500. Note the signs differ: A(10) > 0.1 and A(1500) <= 0. Not a contradiction -- A varies with a -- but a solution that conflates the two points proves nothing. Imports `none`: three evaluations at a single point consume no other result in the network.
 
+### `eq_6_2`
+
+**Equation (6.2).** The Eratosthenes-sieve bound on the normalised remainder
+`R_ψ(t) = (t − ψ(t)) / √t`.
+
+Büthe records `-0.8 ≤ R_ψ(t) ≤ 0.81` for every `100 ≤ t ≤ 5 · 10¹⁰`, obtained by sieving rather
+than by the analytic algorithm. Together with Table 1 this is what implies Theorem 2's (1.5) on
+`11 < t ≤ 10¹⁹` (the remaining `11 < t < 100` being a direct check).
+
+Transcribed from arXiv:1511.02032v2, equation (6.2), including the asymmetric constants and the
+closed interval. This is the "sieve bound of Section 6" that `Buthe.v1`'s limitations list as
+unstated. It lives here rather than on `Buthe.v1` because it is a finite computation, not an
+analytic claim.
+
+```lean
+def eq_6_2 : Prop :=
+  ∀ t : ℝ, 100 ≤ t → t ≤ 5 * 10 ^ (10 : ℕ) →
+    -0.8 ≤ (t - Chebyshev.psi t) / Real.sqrt t ∧
+      (t - Chebyshev.psi t) / Real.sqrt t ≤ 0.81
+```
+
+| | |
+|---|---|
+| Lean name | `ButheNumerics.v1.eq_6_2` |
+| Challenge | `ButheNumerics.v1.challenge_eq_6_2` |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/ButheNumerics/v1/Conclusions.lean#L132) |
+| Evidence | computation (`numerical`) |
+| Sources traced | none |
+| Assumes | nothing recorded |
+| Assumed by | nothing yet |
+
+**Justification `buthe-computation`** — **designated** — numerical, Equation (6.2)
+
+> A finite check rather than an argument, so `numerical`. Buthe records -0.8 <= R_psi(t) <= 0.81 for 100 <= t <= 5e10, "calculated using the Eratosthenes sieve". Together with Table 1 this implies Theorem 2's (1.5); the remaining 11 < t < 100 is a direct check. Transcribed from arXiv:1511.02032v2, including the asymmetric constants and the closed interval. Imports `none`: a bounded-range sieve consumes no other result in the network. This is the sieve bound of Section 6 that Buthe.v1's limitations list as unstated; it lives on this node because it is a computation, not an analytic claim.
+
 ## Limitations
 
 Recorded by the node itself, not derived.

--- a/docs/nodes/README.md
+++ b/docs/nodes/README.md
@@ -11,7 +11,7 @@ One page per node: what it claims, in Lean and in prose, and everything recorded
 | [`Buthe.v1`](Buthe-v1.md) | paper | 6 | cited |
 | [`Buthe.v2`](Buthe-v2.md) | pipeline | 2 | unjustified |
 | [`Buthe2016.v1`](Buthe2016-v1.md) | paper | 4 | cited |
-| [`ButheNumerics.v1`](ButheNumerics-v1.md) | computation | 3 | computation |
+| [`ButheNumerics.v1`](ButheNumerics-v1.md) | computation | 4 | computation |
 | [`CH2.v1`](CH2-v1.md) | paper | 4 | cited |
 | [`CH2.v2`](CH2-v2.md) | pipeline | 2 | verified, stale |
 | [`CH2.v3`](CH2-v3.md) | pipeline | 2 | verified |

--- a/fingerprints.json
+++ b/fingerprints.json
@@ -15,6 +15,7 @@
   "Buthe2016.v1.theorem_2_li_minus_riemann_pi": "1707a5556e79d07a87637b4794e477c34c66e17ed0c987d826a098153313aeb7",
   "Buthe2016.v1.theorem_2_psi": "63455dc36bfc713e6f49b2eff9c9168baaf82a98f123dab9f77aecb7c4c011ce",
   "Buthe2016.v1.theorem_2_theta": "e42d6b01041d0e584271ad5973428bfcdc80e18ee3df8b5b4d69928bb145f978",
+  "ButheNumerics.v1.eq_6_2": "e611abce336e0a6a69eab8c72c85119bb8780a381f31894a726f6bdb1de9f47e",
   "ButheNumerics.v1.lemma_3_constant_gt_at_10": "1a994e5c3e841ecf8fd751d26cf0dddef365f9bd962f1234c261c9960de9fba0",
   "ButheNumerics.v1.lemma_3_constant_nonpos": "b2501571bd4cb5fd7daa5d8e50371ac070c4a02587d0cc941849bd8f0375a5a5",
   "ButheNumerics.v1.li_minus_pi_below_1e7": "d589c14ed5383fb4fe145dd6b23c12993a3a7de7697ff4719552f016ec040b95",


### PR DESCRIPTION
Refs #56.

Adds `ButheNumerics.v1.eq_6_2`: `-0.8 ≤ (t − ψ(t))/√t ≤ 0.81` for `100 ≤ t ≤ 5·10¹⁰`, the Eratosthenes-sieve bound from Büthe 2018 eq. (6.2). This is the Section 6 sieve bound that `Buthe.v1`'s limitations still list as unstated. It lives on the numerics node because it is a finite computation, not an analytic claim.

Challenge, fingerprint, state, graph, and the generated node page were regenerated. Distinct from #85 (Table 1 interval rows on `Buthe.v1`).
