### PR TITLE
CH2.v1 stage 4: prop_5_2 applied at A = -zeta'/zeta

### DIFF
--- a/Solutions/CH2.v1/Section5.lean
+++ b/Solutions/CH2.v1/Section5.lean
@@ -752,7 +752,7 @@ lemma upperRectangleIntegral'_eq_sumResiduesIn (n : ℕ)
     (h_no_poles_boundary : Disjoint (RectangleBorder ((l.σ n : ℂ) + (l.δ : ℂ) * Complex.I) (1 + (l.T : ℂ) * Complex.I))
       {z | meromorphicOrderAt (fun s ↦ G s * (x : ℂ) ^ s) z < 0})
     (hfin : {z ∈ l.R \ l.RC | meromorphicOrderAt (fun s ↦ G s * (x : ℂ) ^ s) z < 0}.Finite)
-    (hsimple : HasSimplePolesOn (fun s ↦ G s * (x : ℂ) ^ s) l.R) :
+    (hsimple : HasSimplePolesOn (fun s ↦ G s * (x : ℂ) ^ s) (l.Rpos ∪ l.RposBar)) :
     RectangleIntegral' (fun s ↦ G s * (x : ℂ) ^ s) ((l.σ n : ℂ) + (l.δ : ℂ) * Complex.I) (1 + (l.T : ℂ) * Complex.I) =
       sumResiduesIn (fun s ↦ G s * (x : ℂ) ^ s) (Rectangle ((l.σ n : ℂ) + (l.δ : ℂ) * Complex.I) (1 + (l.T : ℂ) * Complex.I) ∩ {z | meromorphicOrderAt (fun s ↦ G s * (x : ℂ) ^ s) z < 0}) := by
   have h_rect_subset_Rpos :
@@ -767,7 +767,7 @@ lemma upperRectangleIntegral'_eq_sumResiduesIn (n : ℕ)
   · exact h_rect_mero
   · exact h_no_poles_boundary
   · exact Set.Finite.subset hfin (upperRectangle_poles_subset_R_minus_RC l n h_no_poles_boundary)
-  · exact HasSimplePolesOn.mono hsimple h_rect_subset_R
+  · exact HasSimplePolesOn.mono hsimple (h_rect_subset_Rpos.trans Set.subset_union_left)
 
 lemma intVSeg_eq_intCnPlus_add_rectangleIntegral (l : LadderParams) (n : ℕ) (F : ℂ → ℂ)
     (h_integrable1 : IntervalIntegrable (fun t : ℝ ↦ F (1 + t * Complex.I) * Complex.I) volume 0 l.δ)
@@ -1179,7 +1179,7 @@ theorem lemma_5_1_a (n : ℕ)
     (hGs_contour : IsBoundedNoPolesOn (fun s ↦ G_star s * (x₀ : ℂ) ^ s) l.admissible_contour)
     (hx : x₀ < x)
     (hfin : {z ∈ l.R \ l.RC | meromorphicOrderAt (fun s ↦ G s * (x : ℂ) ^ s) z < 0}.Finite)
-    (hsimple : HasSimplePolesOn (fun s ↦ G s * (x : ℂ) ^ s) l.R) :
+    (hsimple : HasSimplePolesOn (fun s ↦ G s * (x : ℂ) ^ s) (l.Rpos ∪ l.RposBar)) :
     (2 * (π : ℂ) * Complex.I)⁻¹ * intVSeg 1 0 l.T (fun s ↦ G s * (x : ℂ) ^ s) =
       (2 * (π : ℂ) * Complex.I)⁻¹ * l.intCnPlus n (fun s ↦ G s * (x : ℂ) ^ s) +
       sumResiduesIn (fun s ↦ G s * (x : ℂ) ^ s) (l.Rpos ∩ {z | l.σ n < z.re}) := by
@@ -1563,12 +1563,13 @@ lemma lowerRectangleIntegral'_eq_sumResiduesIn (n : ℕ)
     (h_no_poles_boundary : Disjoint (RectangleBorder ((l.σ n : ℂ) - (l.T : ℂ) * Complex.I) (1 - (l.δ : ℂ) * Complex.I))
       {z | meromorphicOrderAt (fun s ↦ G s * (x : ℂ) ^ s) z < 0})
     (hfin : {z ∈ l.R \ l.RC | meromorphicOrderAt (fun s ↦ G s * (x : ℂ) ^ s) z < 0}.Finite)
-    (hsimple : HasSimplePolesOn (fun s ↦ G s * (x : ℂ) ^ s) l.R) :
+    (hsimple : HasSimplePolesOn (fun s ↦ G s * (x : ℂ) ^ s) (l.Rpos ∪ l.RposBar)) :
     RectangleIntegral' (fun s ↦ G s * (x : ℂ) ^ s) ((l.σ n : ℂ) - (l.T : ℂ) * Complex.I) (1 - (l.δ : ℂ) * Complex.I) =
       sumResiduesIn (fun s ↦ G s * (x : ℂ) ^ s) (Rectangle ((l.σ n : ℂ) - (l.T : ℂ) * Complex.I) (1 - (l.δ : ℂ) * Complex.I) ∩ {z | meromorphicOrderAt (fun s ↦ G s * (x : ℂ) ^ s) z < 0}) := by
   apply RectangleIntegral'_eq_sumResiduesIn (by simpa using l.hσ n) (by simpa using show -l.T ≤ -l.δ by linarith [l.hδ.2, l.hT]) h_rect_mero h_no_poles_boundary
   · exact Set.Finite.subset hfin (lowerRectangle_poles_subset_R_minus_RC l n h_no_poles_boundary)
-  · exact HasSimplePolesOn.mono hsimple (Set.Subset.trans (l.lowerRectangle_subset_RposBar n) l.RposBar_subset_R)
+  · exact HasSimplePolesOn.mono hsimple
+      ((l.lowerRectangle_subset_RposBar n).trans Set.subset_union_right)
 
 private lemma lowerRectangle_inter_poles_eq (l : LadderParams) (n : ℕ) {P : Set ℂ}
     (h_no_poles_boundary : Disjoint
@@ -1685,7 +1686,7 @@ theorem lemma_5_1_b (n : ℕ)
     (hGs_contour : IsBoundedNoPolesOn (fun s ↦ G_star s * (x₀ : ℂ) ^ s) l.admissible_contour)
     (hx : x₀ < x)
     (hfin : {z ∈ l.R \ l.RC | meromorphicOrderAt (fun s ↦ G s * (x : ℂ) ^ s) z < 0}.Finite)
-    (hsimple : HasSimplePolesOn (fun s ↦ G s * (x : ℂ) ^ s) l.R) :
+    (hsimple : HasSimplePolesOn (fun s ↦ G s * (x : ℂ) ^ s) (l.Rpos ∪ l.RposBar)) :
     (2 * (π : ℂ) * Complex.I)⁻¹ * intVSeg 1 (-l.T) 0 (fun s ↦ G s * (x : ℂ) ^ s) =
       (2 * (π : ℂ) * Complex.I)⁻¹ * l.intCnMinus n (fun s ↦ G s * (x : ℂ) ^ s) +
       sumResiduesIn (fun s ↦ G s * (x : ℂ) ^ s) (l.RposBar ∩ {z | l.σ n < z.re}) := by
@@ -2706,7 +2707,7 @@ theorem lemma_5_1
     -- temporary scaffold: the placeholder `residue` and Mathlib's current residue-theorem API only
     -- handle simple poles, so we assume all poles in `R` are simple (true in the applications;
     -- remove once higher-order residue support lands):
-    (hsimple : HasSimplePolesOn (fun s ↦ G s * (x : ℂ) ^ s) l.R)
+    (hsimple : HasSimplePolesOn (fun s ↦ G s * (x : ℂ) ^ s) (l.Rpos ∪ l.RposBar))
     (hsimple_circ : HasSimplePolesOn (fun s ↦ G_circ s * (x : ℂ) ^ s) l.R) :
     (2 * (π : ℂ) * Complex.I)⁻¹ * l.intVerticalAt 1 (fun s ↦ G s * (x : ℂ) ^ s) =
       (2 * (π : ℂ) * Complex.I)⁻¹ * l.intCinf (fun s ↦ G s * (x : ℂ) ^ s) +
@@ -3813,7 +3814,8 @@ theorem prop_5_2_a
     (hx : x₀ < x)
     (hfin : {z ∈ l.R \ l.RC |
         meromorphicOrderAt (fun s ↦ Phi_lambda lam ε (l.zOf s) * F s * (x : ℂ) ^ s) z < 0}.Finite)
-    (hsimple : HasSimplePolesOn (fun s ↦ Phi_lambda lam ε (l.zOf s) * F s * (x : ℂ) ^ s) l.R)
+    (hsimple : HasSimplePolesOn (fun s ↦ Phi_lambda lam ε (l.zOf s) * F s * (x : ℂ) ^ s)
+      (l.Rpos ∪ l.RposBar))
     (hsimple_circ :
         HasSimplePolesOn
           (fun s ↦ Phi_circ |lam| ε ((Real.sign lam : ℂ) * l.zOf s) * F s * (x : ℂ) ^ s) l.R) :
@@ -3902,7 +3904,8 @@ theorem prop_5_2_b
     (hx : x₀ < x)
     (hfin : {z ∈ l.R \ l.RC |
         meromorphicOrderAt (fun s ↦ Phi_lambda lam ε (l.zOf s) * F s * (x : ℂ) ^ s) z < 0}.Finite)
-    (hsimple : HasSimplePolesOn (fun s ↦ Phi_lambda lam ε (l.zOf s) * F s * (x : ℂ) ^ s) l.R)
+    (hsimple : HasSimplePolesOn (fun s ↦ Phi_lambda lam ε (l.zOf s) * F s * (x : ℂ) ^ s)
+      (l.Rpos ∪ l.RposBar))
     (hsimple_circ :
         HasSimplePolesOn
           (fun s ↦ Phi_circ |lam| ε ((Real.sign lam : ℂ) * l.zOf s) * F s * (x : ℂ) ^ s) l.R) :
@@ -4003,7 +4006,8 @@ theorem prop_5_2
     (hx : x₀ < x)
     (hfin : {z ∈ l.R \ l.RC |
         meromorphicOrderAt (fun s ↦ Phi_lambda lam ε (l.zOf s) * F s * (x : ℂ) ^ s) z < 0}.Finite)
-    (hsimple : HasSimplePolesOn (fun s ↦ Phi_lambda lam ε (l.zOf s) * F s * (x : ℂ) ^ s) l.R)
+    (hsimple : HasSimplePolesOn (fun s ↦ Phi_lambda lam ε (l.zOf s) * F s * (x : ℂ) ^ s)
+      (l.Rpos ∪ l.RposBar))
     (hsimple_circ :
         HasSimplePolesOn
           (fun s ↦ Phi_circ |lam| ε ((Real.sign lam : ℂ) * l.zOf s) * F s * (x : ℂ) ^ s) l.R) :

--- a/Solutions/CH2.v1/ZetaInstance.lean
+++ b/Solutions/CH2.v1/ZetaInstance.lean
@@ -749,6 +749,77 @@ theorem linear_mul_exp_neg_le {a b c u : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b) (hc 
     _ ≤ a * 1 + b * (1 / c) := by gcongr
     _ = a + b / c := by ring
 
+/-- `u² e^{-cu}` is bounded on `u ≥ 0`, and the bound comes free from the linear case.
+
+The trick is `u² e^{-cu} = (u e^{-(c/2)u})²`: halving the rate turns the square of a product into
+a product of squares, and the inner factor is the linear lemma at `c/2`. Doing it this way avoids
+a second calculus argument. -/
+theorem sq_mul_exp_neg_le {c u : ℝ} (hc : 0 < c) (hu : 0 ≤ u) :
+    u ^ 2 * Real.exp (-(c * u)) ≤ (2 / c) ^ 2 := by
+  have hlin : u * Real.exp (-(c / 2 * u)) ≤ 2 / c := by
+    have h := linear_mul_exp_neg_le (a := 0) (b := 1) (c := c / 2) le_rfl zero_le_one
+      (by linarith) hu
+    simpa using h
+  have hexp : Real.exp (-(c / 2 * u)) ^ 2 = Real.exp (-(c * u)) := by
+    rw [sq, ← Real.exp_add]
+    congr 1
+    ring
+  have hEq : u ^ 2 * Real.exp (-(c * u)) = (u * Real.exp (-(c / 2 * u))) ^ 2 := by
+    rw [mul_pow, hexp]
+  rw [hEq]
+  exact pow_le_pow_left₀ (by positivity) hlin 2
+
+/-- **Quadratic growth is also beaten by `x₀ ^ z` on `Re z ≤ 0`.**
+
+The companion to `exists_bound_of_linear_growth_mul_cpow`, needed because `prop_5_2`'s *second*
+boundedness hypothesis carries an extra factor of `zOf s = (s-1)/(iT)`, which turns the linear
+growth of `F` into quadratic growth. The exponential still wins; this is the lemma that says so.
+
+Expanding `(1 + u + C)²` gives a constant, a linear and a quadratic term, handled by
+`linear_mul_exp_neg_le` and `sq_mul_exp_neg_le` respectively. -/
+theorem exists_bound_of_quadratic_growth_mul_cpow {f : ℂ → ℂ} {S : Set ℂ} {x₀ C : ℝ}
+    (hx₀ : 1 < x₀) (hC : 0 ≤ C) (hS : ∀ z ∈ S, z.re ≤ 0)
+    (hbd : ∀ z ∈ S, ‖f z‖ ≤ C * (1 + ‖z‖) ^ 2) (hIm : ∀ z ∈ S, |z.im| ≤ C) :
+    ∃ M, ∀ z ∈ S, ‖f z * (x₀ : ℂ) ^ z‖ ≤ M := by
+  have hx₀pos : (0 : ℝ) < x₀ := by linarith
+  have hlog : 0 < Real.log x₀ := Real.log_pos hx₀
+  refine ⟨(C * (1 + C) ^ 2 + 2 * C * (1 + C) / Real.log x₀)
+    + C * (2 / Real.log x₀) ^ 2, fun z hz ↦ ?_⟩
+  have hre : z.re ≤ 0 := hS z hz
+  set u : ℝ := -z.re with hu_def
+  have hu : 0 ≤ u := by rw [hu_def]; linarith
+  have habs : |z.re| = u := by rw [hu_def, abs_of_nonpos hre]
+  have hnorm : ‖z‖ ≤ u + C := by
+    refine (Complex.norm_le_abs_re_add_abs_im z).trans ?_
+    rw [habs]
+    linarith [hIm z hz]
+  -- `C (1 + ‖z‖)² ≤ C(1+C)² + 2C(1+C) u + C u²`.
+  have hfz : ‖f z‖ ≤ C * (1 + C) ^ 2 + 2 * C * (1 + C) * u + C * u ^ 2 := by
+    refine (hbd z hz).trans ?_
+    have h1 : (1 : ℝ) + ‖z‖ ≤ 1 + C + u := by linarith
+    have h0 : (0 : ℝ) ≤ 1 + ‖z‖ := by positivity
+    have hsq : (1 + ‖z‖) ^ 2 ≤ (1 + C + u) ^ 2 := pow_le_pow_left₀ h0 h1 2
+    calc C * (1 + ‖z‖) ^ 2 ≤ C * (1 + C + u) ^ 2 := mul_le_mul_of_nonneg_left hsq hC
+      _ = C * (1 + C) ^ 2 + 2 * C * (1 + C) * u + C * u ^ 2 := by ring
+  have hcpow : ‖(x₀ : ℂ) ^ z‖ = Real.exp (-(Real.log x₀ * u)) := by
+    rw [Complex.norm_cpow_eq_rpow_re_of_pos hx₀pos, Real.rpow_def_of_pos hx₀pos]
+    congr 1
+    rw [hu_def]; ring
+  rw [norm_mul, hcpow]
+  have hexp_nonneg : (0 : ℝ) ≤ Real.exp (-(Real.log x₀ * u)) := (Real.exp_pos _).le
+  calc ‖f z‖ * Real.exp (-(Real.log x₀ * u))
+      ≤ (C * (1 + C) ^ 2 + 2 * C * (1 + C) * u + C * u ^ 2)
+          * Real.exp (-(Real.log x₀ * u)) := mul_le_mul_of_nonneg_right hfz hexp_nonneg
+    _ = (C * (1 + C) ^ 2 + 2 * C * (1 + C) * u) * Real.exp (-(Real.log x₀ * u))
+          + C * (u ^ 2 * Real.exp (-(Real.log x₀ * u))) := by ring
+    _ ≤ (C * (1 + C) ^ 2 + 2 * C * (1 + C) / Real.log x₀) + C * (2 / Real.log x₀) ^ 2 := by
+        have h1 := linear_mul_exp_neg_le (a := C * (1 + C) ^ 2) (b := 2 * C * (1 + C))
+          (c := Real.log x₀) (by positivity) (by positivity) hlog hu
+        have h2 := sq_mul_exp_neg_le hlog hu
+        have h3 : C * (u ^ 2 * Real.exp (-(Real.log x₀ * u))) ≤ C * (2 / Real.log x₀) ^ 2 :=
+          mul_le_mul_of_nonneg_left h2 hC
+        linarith
+
 /-- **A function of at most linear growth, damped by `x₀ ^ s` with `x₀ > 1`, is bounded on any set
 in the closed left half-plane of bounded height.**
 
@@ -1517,5 +1588,83 @@ theorem isBoundedNoPolesOn_ladder
   exact isBoundedNoPolesOn_union
     (isBoundedNoPolesOn_nearLadder hTfree hδfree (by linarith : (0:ℝ) < x₀))
     (isBoundedNoPolesOn_farLadder hfe hdig hσ hTfree hδfree hx₀)
+
+/-- `‖zOf z‖ ≤ (1 + ‖z‖)/T`: the weight is linear, which is what turns `F`'s linear growth into
+quadratic growth and forces `exists_bound_of_quadratic_growth_mul_cpow`. -/
+theorem norm_zOf_le (l : CH2.LadderParams) (z : ℂ) : ‖l.zOf z‖ ≤ (1 + ‖z‖) / l.T := by
+  have hT : 0 < l.T := l.hT
+  have hnum : ‖z - 1‖ ≤ 1 + ‖z‖ := by
+    refine (norm_sub_le z 1).trans ?_
+    simp [add_comm]
+  have hden : ‖Complex.I * (l.T : ℂ)‖ = l.T := by
+    rw [norm_mul, Complex.norm_I, one_mul, Complex.norm_real, Real.norm_of_nonneg hT.le]
+  show ‖(z - 1) / (Complex.I * (l.T : ℂ))‖ ≤ (1 + ‖z‖) / l.T
+  rw [norm_div, hden]
+  gcongr
+
+/-- **The far half of `prop_5_2`'s second boundedness hypothesis.** -/
+theorem isBoundedNoPolesOn_farLadder_weighted
+    (hfe : ZetaLogDeriv.v1.logDeriv_functional_equation)
+    (hdig : GammaAsymptotics.v2.digamma_sub_log_isBigO_strip)
+    {l : CH2.LadderParams} (hσ : l.σ = sigmaZeta)
+    (hTfree : ∀ z : ℂ, riemannZeta z = 0 → |z.im| ≠ l.T)
+    (hδfree : ∀ z : ℂ, riemannZeta z = 0 → |z.im| ≠ l.δ)
+    {x₀ : ℝ} (hx₀ : 1 < x₀) :
+    CH2.IsBoundedNoPolesOn (fun s ↦ l.zOf s * F s * (x₀ : ℂ) ^ s)
+      ((l.Rboundary ∪ l.admissible_contour ∪ l.L) ∩ {z : ℂ | z.re ≤ -1}) := by
+  have hT : 0 < l.T := l.hT
+  set S : Set ℂ := (l.Rboundary ∪ l.admissible_contour ∪ l.L) ∩ {z : ℂ | z.re ≤ -1} with hS_def
+  have hSre : ∀ z ∈ S, z.re ≤ -1 := fun z hz ↦ hz.2
+  have hSim : ∀ z ∈ S, |z.im| ≤ l.T := fun z hz ↦ abs_im_le_T_of_mem_ladder hz.1
+  obtain ⟨B, hB, hBd⟩ := exists_tan_bound_on_farLadder l hσ
+  have hcos : ∀ z ∈ S, Complex.cos ((Real.pi : ℂ) * (1 - z) / 2) ≠ 0 := fun z hz ↦
+    cos_ne_zero_on_farLadder hσ hz.1 hz.2
+  have htan : ∀ z ∈ S, ‖Complex.tan ((Real.pi : ℂ) * (1 - z) / 2)‖ ≤ B := fun z hz ↦
+    hBd z hz.1 hz.2
+  obtain ⟨C, hC, hCd⟩ := norm_F_le_linear hfe hdig hB hSre hSim hcos htan
+  set C' : ℝ := max (C / l.T) l.T with hC'_def
+  have hC' : 0 ≤ C' := le_trans (div_nonneg hC hT.le) (le_max_left _ _)
+  have hbd : ∀ z ∈ S, ‖l.zOf z * F z‖ ≤ C' * (1 + ‖z‖) ^ 2 := by
+    intro z hz
+    have hnn : (0 : ℝ) ≤ 1 + ‖z‖ := by positivity
+    rw [norm_mul]
+    calc ‖l.zOf z‖ * ‖F z‖ ≤ ((1 + ‖z‖) / l.T) * (C * (1 + ‖z‖)) :=
+          mul_le_mul (norm_zOf_le l z) (hCd z hz) (norm_nonneg _) (by positivity)
+      _ = (C / l.T) * (1 + ‖z‖) ^ 2 := by field_simp
+      _ ≤ C' * (1 + ‖z‖) ^ 2 :=
+          mul_le_mul_of_nonneg_right (le_max_left _ _) (by positivity)
+  have hIm : ∀ z ∈ S, |z.im| ≤ C' := fun z hz ↦ le_trans (hSim z hz) (le_max_right _ _)
+  obtain ⟨M, hM⟩ := exists_bound_of_quadratic_growth_mul_cpow hx₀ hC'
+    (fun z hz ↦ by linarith [hSre z hz]) hbd hIm
+  refine ⟨M, fun z hz ↦ ⟨hM z hz, ?_⟩⟩
+  exact meromorphicOrderAt_nonneg_of_analyticAt
+    (((analyticAt_zOf l z).mul (analyticAt_F_of_mem_farLadder hσ hTfree hδfree hz.1 hz.2)).mul
+      (analyticAt_const_cpow (by linarith : (0:ℝ) < x₀) z))
+
+/-- **`prop_5_2`'s second boundedness hypothesis, closed.**
+
+With this, both boundedness hypotheses are discharged and three of the five outstanding ones are
+gone. What remains is `hfin` and the two `HasSimplePolesOn` conditions, which are about the
+PRODUCT `Φ_λ(zOf s) · F s · x ^ s` rather than about `F`. -/
+theorem isBoundedNoPolesOn_ladder_weighted
+    (hfe : ZetaLogDeriv.v1.logDeriv_functional_equation)
+    (hdig : GammaAsymptotics.v2.digamma_sub_log_isBigO_strip)
+    {l : CH2.LadderParams} (hσ : l.σ = sigmaZeta)
+    (hTfree : ∀ z : ℂ, riemannZeta z = 0 → |z.im| ≠ l.T)
+    (hδfree : ∀ z : ℂ, riemannZeta z = 0 → |z.im| ≠ l.δ)
+    {x₀ : ℝ} (hx₀ : 1 < x₀) :
+    CH2.IsBoundedNoPolesOn (fun s ↦ l.zOf s * F s * (x₀ : ℂ) ^ s)
+      (l.Rboundary ∪ l.admissible_contour ∪ l.L) := by
+  have hcover : (l.Rboundary ∪ l.admissible_contour ∪ l.L)
+      ⊆ nearLadder l.T l.δ ∪
+        ((l.Rboundary ∪ l.admissible_contour ∪ l.L) ∩ {z : ℂ | z.re ≤ -1}) := by
+    intro z hz
+    rcases le_or_gt (-1 : ℝ) z.re with h | h
+    · exact Or.inl (nearLadder_covers hσ ⟨hz, h⟩)
+    · exact Or.inr ⟨hz, le_of_lt h⟩
+  refine isBoundedNoPolesOn_mono ?_ hcover
+  exact isBoundedNoPolesOn_union
+    (isBoundedNoPolesOn_nearLadder_weighted hTfree hδfree (by linarith : (0:ℝ) < x₀))
+    (isBoundedNoPolesOn_farLadder_weighted hfe hdig hσ hTfree hδfree hx₀)
 
 end CH2ZetaInstance

--- a/Solutions/CH2.v1/ZetaInstance.lean
+++ b/Solutions/CH2.v1/ZetaInstance.lean
@@ -1781,30 +1781,22 @@ lemma re_zOf (l : CH2.LadderParams) (w : ℂ) : (l.zOf w).re = w.im / l.T := by
   rw [zOf_eq, Complex.div_ofReal_re]
   simp
 
-/-- **`prop_5_2`'s `hsimple` hypothesis, closed on the set where the port actually uses it.**
+/-- **The order of the integrand, off the real axis, splits as `(weight) + (order of F)`.**
 
-`Rpos` and `RposBar` sit at `|Im s| ≥ δ > 0`, so `Re (zOf s) = Im s / T` has a definite sign on a
-whole neighbourhood and `Phi_lambda` is locally `Phi_circ ± Phi_star` — analytic, by
-`zOf_ne_weight_pole`. The order of the product is then the order of `F`, exactly as in
-`hasSimplePolesOn_circ_ladder`.
+Shared by `hsimple` and `hfin`, which want opposite halves of it: the first that the sum is at
+least `-1`, the second that a negative sum forces `F` to have a pole.
 
-On `l.R` this is unprovable by an order computation, which is why `prop_5_2`'s hypothesis was
-weakened to this set: across the real axis the integrand is genuinely discontinuous, hence not
-meromorphic, and `meromorphicOrderAt` returns its junk value there. -/
-theorem hasSimplePolesOn_lambda_ladder (l : CH2.LadderParams) {lam ε x : ℝ}
-    (hlam : 0 < lam) (hx : 0 < x) :
-    HasSimplePolesOn (fun s ↦ CH2.Phi_lambda lam ε (l.zOf s) * F s * (x : ℂ) ^ s)
-      (l.Rpos ∪ l.RposBar) := by
+Away from the axis `Real.sign (Re (zOf s))` is locally constant, because `Re (zOf s) = Im s / T`,
+so `Phi_lambda` is locally `Phi_circ ± Phi_star`, which `zOf_ne_weight_pole` makes analytic. The
+`x ^ s` factor is analytic and non-vanishing and so contributes `0`. -/
+theorem meromorphicOrderAt_integrand (l : CH2.LadderParams) {lam ε x : ℝ}
+    (hlam : 0 < lam) (hx : 0 < x) {z : ℂ} (hzre : z.re ≤ 1) (him : z.im ≠ 0) :
+    ∃ o : WithTop ℤ, 0 ≤ o ∧
+      meromorphicOrderAt (fun s ↦ CH2.Phi_lambda lam ε (l.zOf s) * F s * (x : ℂ) ^ s) z
+        = o + meromorphicOrderAt F z := by
   have hT : 0 < l.T := l.hT
-  have hδ0 : 0 < l.δ := l.hδ.1
-  intro z hz
   have hxc : ((x : ℝ) : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr hx.ne'
-  -- `z` has `Re z ≤ 1` and `Im z` of a definite sign, bounded away from `0`.
-  obtain ⟨hzre, hsign⟩ : z.re ≤ 1 ∧ (0 < z.im ∨ z.im < 0) := by
-    rcases hz with h | h
-    · exact ⟨h.1, Or.inl (lt_of_lt_of_le hδ0 h.2.1)⟩
-    · exact ⟨h.1, Or.inr (lt_of_le_of_lt h.2.2 (neg_lt_zero.mpr hδ0))⟩
-  -- The sign is locally constant, so the weight is locally `Phi_circ ± Phi_star`.
+  have hsign : 0 < z.im ∨ z.im < 0 := (lt_or_gt_of_ne him).symm
   set σ : ℂ := if 0 < z.im then 1 else -1 with hσ_def
   have hlocal : ∀ᶠ w in nhds z, CH2.Phi_lambda lam ε (l.zOf w)
       = CH2.Phi_circ lam ε (l.zOf w) + σ * CH2.Phi_star lam ε (l.zOf w) := by
@@ -1823,10 +1815,16 @@ theorem hasSimplePolesOn_lambda_ladder (l : CH2.LadderParams) {lam ε x : ℝ}
       push_cast
       ring
     · have hwim : w.im < 0 := hw.2 h
-      rw [if_neg (asymm h), Real.sign_of_neg (by exact div_neg_of_neg_of_pos hwim hT)]
+      rw [if_neg (asymm h), Real.sign_of_neg (div_neg_of_neg_of_pos hwim hT)]
       push_cast
       ring
-  -- Rewrite the order along that local identity.
+  have hPhi : AnalyticAt ℂ
+      (fun w ↦ CH2.Phi_circ lam ε (l.zOf w) + σ * CH2.Phi_star lam ε (l.zOf w)) z :=
+    (analyticAt_Phi_circ_zOf l hlam hzre).add
+      (analyticAt_const.mul (analyticAt_Phi_star_zOf l hlam hzre))
+  have hpow : AnalyticAt ℂ (fun w : ℂ ↦ (x : ℂ) ^ w) z := analyticAt_const_cpow hx z
+  have hpowne : ((x : ℂ) ^ z) ≠ 0 := by simp [hxc]
+  have hFm : MeromorphicAt F z := meromorphicOn_F z (Set.mem_univ z)
   have hcongr : meromorphicOrderAt (fun s ↦ CH2.Phi_lambda lam ε (l.zOf s) * F s * (x : ℂ) ^ s) z
       = meromorphicOrderAt
           (((fun s ↦ CH2.Phi_circ lam ε (l.zOf s) + σ * CH2.Phi_star lam ε (l.zOf s)) * F)
@@ -1834,28 +1832,123 @@ theorem hasSimplePolesOn_lambda_ladder (l : CH2.LadderParams) {lam ε x : ℝ}
     refine meromorphicOrderAt_congr ?_
     filter_upwards [nhdsWithin_le_nhds hlocal] with w hw
     simp only [Pi.mul_apply, hw]
-  rw [hcongr]
-  -- Same computation as for `Phi_circ`: analytic weight, `F`, and a non-vanishing `x ^ s`.
-  have hΦ : AnalyticAt ℂ
-      (fun w ↦ CH2.Phi_circ lam ε (l.zOf w) + σ * CH2.Phi_star lam ε (l.zOf w)) z :=
-    (analyticAt_Phi_circ_zOf l hlam hzre).add
-      (analyticAt_const.mul (analyticAt_Phi_star_zOf l hlam hzre))
-  have hpow : AnalyticAt ℂ (fun w : ℂ ↦ (x : ℂ) ^ w) z := analyticAt_const_cpow hx z
-  have hpowne : ((x : ℂ) ^ z) ≠ 0 := by simp [hxc]
-  have hFm : MeromorphicAt F z := meromorphicOn_F z (Set.mem_univ z)
-  rw [meromorphicOrderAt_mul (hΦ.meromorphicAt.mul hFm) hpow.meromorphicAt,
-    meromorphicOrderAt_mul hΦ.meromorphicAt hFm]
-  have h1 : (0 : WithTop ℤ) ≤ meromorphicOrderAt
-      (fun w ↦ CH2.Phi_circ lam ε (l.zOf w) + σ * CH2.Phi_star lam ε (l.zOf w)) z :=
-    meromorphicOrderAt_nonneg_of_analyticAt hΦ
-  have h2 : ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt F z :=
-    hasSimplePolesOn_F_univ z (Set.mem_univ z)
   have h3 : meromorphicOrderAt (fun w : ℂ ↦ (x : ℂ) ^ w) z = 0 := by
     rw [hpow.meromorphicOrderAt_eq, hpow.analyticOrderAt_eq_zero.mpr hpowne]
     simp
-  rw [h3, add_zero]
+  refine ⟨meromorphicOrderAt
+      (fun w ↦ CH2.Phi_circ lam ε (l.zOf w) + σ * CH2.Phi_star lam ε (l.zOf w)) z,
+    meromorphicOrderAt_nonneg_of_analyticAt hPhi, ?_⟩
+  rw [hcongr, meromorphicOrderAt_mul (hPhi.meromorphicAt.mul hFm) hpow.meromorphicAt,
+    meromorphicOrderAt_mul hPhi.meromorphicAt hFm, h3, add_zero]
+
+/-- **`prop_5_2`'s `hsimple` hypothesis, closed on the set where the port actually uses it.**
+
+`Rpos` and `RposBar` sit at `|Im s| ≥ δ > 0`, off the axis, so `meromorphicOrderAt_integrand`
+applies and the order is at least `0 + (-1)`.
+
+On `l.R` this is unprovable by an order computation, which is why `prop_5_2`'s hypothesis was
+weakened to this set: across the real axis the integrand is genuinely discontinuous, hence not
+meromorphic, and `meromorphicOrderAt` returns its junk value there. -/
+theorem hasSimplePolesOn_lambda_ladder (l : CH2.LadderParams) {lam ε x : ℝ}
+    (hlam : 0 < lam) (hx : 0 < x) :
+    HasSimplePolesOn (fun s ↦ CH2.Phi_lambda lam ε (l.zOf s) * F s * (x : ℂ) ^ s)
+      (l.Rpos ∪ l.RposBar) := by
+  have hd0 : 0 < l.δ := l.hδ.1
+  intro z hz
+  obtain ⟨hzre, him⟩ : z.re ≤ 1 ∧ z.im ≠ 0 := by
+    rcases hz with h | h
+    · exact ⟨h.1, ne_of_gt (lt_of_lt_of_le hd0 h.2.1)⟩
+    · exact ⟨h.1, ne_of_lt (lt_of_le_of_lt h.2.2 (neg_lt_zero.mpr hd0))⟩
+  obtain ⟨o, ho, heq⟩ := meromorphicOrderAt_integrand l hlam hx hzre him
+  rw [heq]
+  have h2 : ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt F z :=
+    hasSimplePolesOn_F_univ z (Set.mem_univ z)
   calc ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt F z := h2
     _ = 0 + meromorphicOrderAt F z := (zero_add _).symm
-    _ ≤ _ := by gcongr
+    _ ≤ o + meromorphicOrderAt F z := by gcongr
+
+/-- The band `{0 ≤ Re ≤ 1, a ≤ |Im| ≤ b}` is compact.
+
+`isCompact_strip_band` is the special case `b = a + 1`, kept because
+`exists_ordinate_free_height` uses it in that form. -/
+lemma isCompact_band (a b : ℝ) :
+    IsCompact {z : ℂ | 0 ≤ z.re ∧ z.re ≤ 1 ∧ a ≤ |z.im| ∧ |z.im| ≤ b} := by
+  rw [Metric.isCompact_iff_isClosed_bounded]
+  constructor
+  · have hEq : {z : ℂ | 0 ≤ z.re ∧ z.re ≤ 1 ∧ a ≤ |z.im| ∧ |z.im| ≤ b}
+        = {z : ℂ | 0 ≤ z.re} ∩ ({z : ℂ | z.re ≤ 1} ∩
+            ({z : ℂ | a ≤ |z.im|} ∩ {z : ℂ | |z.im| ≤ b})) := by
+      ext z; constructor
+      · rintro ⟨h1, h2, h3, h4⟩; exact ⟨h1, h2, h3, h4⟩
+      · rintro ⟨h1, h2, h3, h4⟩; exact ⟨h1, h2, h3, h4⟩
+    rw [hEq]
+    exact (isClosed_le continuous_const Complex.continuous_re).inter
+      ((isClosed_le Complex.continuous_re continuous_const).inter
+        ((isClosed_le continuous_const Complex.continuous_im.abs).inter
+          (isClosed_le Complex.continuous_im.abs continuous_const)))
+  · refine (Metric.isBounded_iff_subset_closedBall 0).mpr ⟨1 + |b|, fun z hz ↦ ?_⟩
+    obtain ⟨h0, h1, _, h3⟩ := hz
+    simp only [Metric.mem_closedBall, dist_zero_right]
+    calc ‖z‖ ≤ |z.re| + |z.im| := Complex.norm_le_abs_re_add_abs_im z
+      _ ≤ 1 + |b| := by
+          have hre : |z.re| = z.re := abs_of_nonneg h0
+          have him : |z.im| ≤ |b| := h3.trans (le_abs_self b)
+          rw [hre]; linarith
+
+/-- **`prop_5_2`'s `hfin` hypothesis, closed — and it needed no modification.**
+
+`RC = {Re z ≤ 1, |Im z| ≤ δ}` is exactly the band around the real axis, so `R \ RC` sits at
+`δ < |Im z| ≤ T`. THAT IS WHAT MAKES THE STATEMENT TRUE, and it is not incidental: `R` is
+unbounded to the left and contains every trivial zero of `ζ` — infinitely many, all at `Im = 0`.
+`RC` removes exactly those, so no exclusion had to be added to the hypothesis.
+
+Off the axis the argument is short. A pole of the integrand is a pole of `F`, by
+`meromorphicOrderAt_integrand`, since the weight contributes a non-negative order; a pole of `F`
+is a zero of `ζ`; and a zero of `ζ` off the real axis lies in `0 ≤ Re ≤ 1`. With `δ < |Im| ≤ T`
+that is a compact band missing `s = 1`, where `ζ` has finitely many zeros. -/
+theorem finite_poles_ladder (l : CH2.LadderParams) {lam ε x : ℝ}
+    (hlam : 0 < lam) (hx : 0 < x) :
+    {z ∈ l.R \ l.RC |
+      meromorphicOrderAt (fun s ↦ CH2.Phi_lambda lam ε (l.zOf s) * F s * (x : ℂ) ^ s) z
+        < 0}.Finite := by
+  have hT : 0 < l.T := l.hT
+  have hd0 : 0 < l.δ := l.hδ.1
+  have h1K : (1 : ℂ) ∉ {z : ℂ | 0 ≤ z.re ∧ z.re ≤ 1 ∧ l.δ ≤ |z.im| ∧ |z.im| ≤ l.T} := by
+    intro h
+    have hm := h.2.2.1
+    simp only [Complex.one_im, abs_zero] at hm
+    linarith
+  refine Set.Finite.subset
+    (finite_zeros_riemannZeta_of_isCompact (isCompact_band l.δ l.T) h1K) ?_
+  rintro z ⟨⟨hzR, hzRC⟩, hord⟩
+  have hzre : z.re ≤ 1 := hzR.1
+  have hzT : |z.im| ≤ l.T := hzR.2
+  have hdlt : l.δ < |z.im| := by
+    by_contra hc
+    exact hzRC ⟨hzre, not_lt.mp hc⟩
+  have him : z.im ≠ 0 := by
+    intro h
+    rw [h] at hdlt
+    simp only [abs_zero] at hdlt
+    linarith
+  obtain ⟨o, ho, heq⟩ := meromorphicOrderAt_integrand l hlam hx hzre him
+  rw [heq] at hord
+  have hFord : meromorphicOrderAt F z < 0 := by
+    by_contra hc
+    push_neg at hc
+    refine absurd hord (not_lt.mpr ?_)
+    calc (0 : WithTop ℤ) = 0 + 0 := (add_zero 0).symm
+      _ ≤ o + meromorphicOrderAt F z := by gcongr
+  have hz1zero : riemannZeta₁ z = 0 := by
+    by_contra hc
+    exact absurd hFord (not_lt.mpr (meromorphicOrderAt_nonneg_of_analyticAt (analyticAt_F hc)))
+  have hz1 : z ≠ 1 := by
+    intro h
+    rw [h] at him
+    simp only [Complex.one_im] at him
+    exact him rfl
+  have hzeta : riemannZeta z = 0 := (riemannZeta_eq_zero_iff_riemannZeta₁ hz1).mpr hz1zero
+  obtain ⟨hre0, hre1⟩ := re_mem_Icc_of_riemannZeta_eq_zero hzeta him
+  exact ⟨⟨hre0, hre1, hdlt.le, hzT⟩, hzeta⟩
 
 end CH2ZetaInstance

--- a/Solutions/CH2.v1/ZetaInstance.lean
+++ b/Solutions/CH2.v1/ZetaInstance.lean
@@ -1951,4 +1951,43 @@ theorem finite_poles_ladder (l : CH2.LadderParams) {lam ε x : ℝ}
   obtain ⟨hre0, hre1⟩ := re_mem_Icc_of_riemannZeta_eq_zero hzeta him
   exact ⟨⟨hre0, hre1, hdlt.le, hzT⟩, hzeta⟩
 
+/-! ### Proposition 5.2, applied
+
+Every hypothesis is now in hand, so the instantiation is a single term. What it says is the
+contour-shift identity of Chirre-Helfgott section 5, specialised to `A(s) = -ζ'(s)/ζ(s)` with its
+pole at `s = 1` removed: the vertical integral at `Re s = 1` differs from the sum of residues
+inside the ladder by at most the two horizontal tails plus the contour term.
+
+`1 < x₀` rather than `prop_5_2`'s `1 ≤ x₀`, because the boundedness hypotheses genuinely need the
+strict inequality — at `x₀ = 1` the damping factor is identically `1` and `ζ'/ζ` is unbounded
+along the ladder. The extra strength is free for the intended consumer, which takes `x₀` well
+above `1`. -/
+theorem prop_5_2_zeta
+    (hfe : ZetaLogDeriv.v1.logDeriv_functional_equation)
+    (hdig : GammaAsymptotics.v2.digamma_sub_log_isBigO_strip)
+    {l : CH2.LadderParams} (hsig : l.σ = sigmaZeta)
+    (hTfree : ∀ z : ℂ, riemannZeta z = 0 → |z.im| ≠ l.T)
+    (hdfree : ∀ z : ℂ, riemannZeta z = 0 → |z.im| ≠ l.δ)
+    {lam ε x₀ x : ℝ} (hlam : 0 < lam) (hε : ε = 1 ∨ ε = -1)
+    (hx₀ : 1 < x₀) (hx : x₀ < x) :
+    ‖(2 * (Real.pi : ℂ) * Complex.I)⁻¹ *
+          l.intVerticalAt 1 (fun s ↦ CH2.Phi_lambda lam ε (l.zOf s) * F s * (x : ℂ) ^ s) -
+        sumResiduesIn (fun s ↦ CH2.Phi_lambda lam ε (l.zOf s) * F s * (x : ℂ) ^ s) (l.R \ l.RC) -
+        l.sumResiduesLim
+          (fun s ↦ CH2.Phi_circ |lam| ε ((Real.sign lam : ℂ) * l.zOf s) * F s * (x : ℂ) ^ s)
+          l.RC‖ ≤
+      (1 / (2 * Real.pi)) *
+        ((1 / l.T) *
+            ((∫ t in Set.Ioi (0 : ℝ), t * ‖F (1 - t + l.T * Complex.I)‖ * x ^ (1 - t)) +
+              ∫ t in Set.Ioi (0 : ℝ), t * ‖F (1 - t - l.T * Complex.I)‖ * x ^ (1 - t)) +
+          2 * ‖l.intC (fun s ↦ CH2.Phi_star |lam| ε ((Real.sign lam : ℂ) * l.zOf s) * F s
+              * (x : ℂ) ^ s)‖) :=
+  CH2.prop_5_2 (fun z _ ↦ meromorphicOn_F z (Set.mem_univ z)) conjSymm_F hlam hε hx₀.le
+    (isBoundedNoPolesOn_ladder hfe hdig hsig hTfree hdfree hx₀)
+    (isBoundedNoPolesOn_ladder_weighted hfe hdig hsig hTfree hdfree hx₀)
+    hx
+    (finite_poles_ladder l hlam (by linarith))
+    (hasSimplePolesOn_lambda_ladder l hlam (by linarith))
+    (hasSimplePolesOn_circ_ladder l hlam (by linarith))
+
 end CH2ZetaInstance

--- a/Solutions/CH2.v1/ZetaInstance.lean
+++ b/Solutions/CH2.v1/ZetaInstance.lean
@@ -1667,4 +1667,50 @@ theorem isBoundedNoPolesOn_ladder_weighted
     (isBoundedNoPolesOn_nearLadder_weighted hTfree hδfree (by linarith : (0:ℝ) < x₀))
     (isBoundedNoPolesOn_farLadder_weighted hfe hdig hσ hTfree hδfree hx₀)
 
+/-! ### The Graham-Vaaler weights have no poles on `R`
+
+`prop_5_2`'s three remaining hypotheses are about the PRODUCT `Φ_λ(zOf s) · F s · x ^ s`, not
+about `F`, so the weight's own poles are suddenly relevant. They turn out not to be, and the
+reason is a sign.
+
+`Phi_circ` and `Phi_star` have poles exactly at `z = n - i ν/(2π)` (`Phi_circ.poles`,
+`Phi_star.poles`). Pulling that back through `zOf s = (s-1)/(iT)` gives
+
+  `s = 1 + T ν/(2π) + i T n`,   so   `Re s = 1 + T ν/(2π) > 1`,
+
+strictly to the right of `l.R = {Re s ≤ 1, |Im s| ≤ T}`. **What decides this is `0 < lam`**, which
+`prop_5_2` assumes: `Real.sign lam = 1`, so the weight is evaluated at `zOf s` rather than at
+`-zOf s`. For negative `lam` the same points would land at `Re s = 1 - T ν/(2π) < 1`, inside `R`,
+and the residue sum would have to account for them. -/
+
+/-- **The weights' poles pull back to `Re s > 1`**, hence off `R`. -/
+theorem zOf_ne_weight_pole (l : CH2.LadderParams) {lam : ℝ} (hlam : 0 < lam) {s : ℂ}
+    (hs : s.re ≤ 1) (n : ℤ) :
+    l.zOf s ≠ (n : ℂ) - Complex.I * (lam : ℂ) / (2 * (Real.pi : ℂ)) := by
+  intro h
+  have hT : 0 < l.T := l.hT
+  have hπ : (0 : ℝ) < Real.pi := Real.pi_pos
+  have hTc : ((l.T : ℝ) : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr hT.ne'
+  have hITne : (Complex.I * (l.T : ℂ)) ≠ 0 := mul_ne_zero Complex.I_ne_zero hTc
+  have h' : s - 1
+      = ((n : ℂ) - Complex.I * (lam : ℂ) / (2 * (Real.pi : ℂ))) * (Complex.I * (l.T : ℂ)) := by
+    rw [← h]
+    show s - 1 = (s - 1) / (Complex.I * (l.T : ℂ)) * (Complex.I * (l.T : ℂ))
+    field_simp
+  have hπc : ((Real.pi : ℂ)) ≠ 0 := Complex.ofReal_ne_zero.mpr hπ.ne'
+  have hval : ((n : ℂ) - Complex.I * (lam : ℂ) / (2 * (Real.pi : ℂ))) * (Complex.I * (l.T : ℂ))
+      = ((l.T * lam / (2 * Real.pi) : ℝ) : ℂ)
+        + Complex.I * ((l.T * (n : ℝ) : ℝ) : ℂ) := by
+    push_cast
+    field_simp
+    linear_combination (-(lam : ℂ)) * Complex.I_sq
+  have hre : (s - 1).re = l.T * lam / (2 * Real.pi) := by
+    rw [h', hval]
+    simp only [Complex.add_re, Complex.ofReal_re, Complex.mul_re, Complex.I_re, Complex.I_im,
+      Complex.ofReal_im]
+    ring
+  simp only [Complex.sub_re, Complex.one_re] at hre
+  have hpos : 0 < l.T * lam / (2 * Real.pi) := by positivity
+  linarith
+
 end CH2ZetaInstance

--- a/Solutions/CH2.v1/ZetaInstance.lean
+++ b/Solutions/CH2.v1/ZetaInstance.lean
@@ -1766,4 +1766,96 @@ theorem hasSimplePolesOn_circ_ladder (l : CH2.LadderParams) {lam ε x : ℝ}
     _ ≤ meromorphicOrderAt (fun w ↦ CH2.Phi_circ lam ε (l.zOf w)) z + meromorphicOrderAt F z := by
         gcongr
 
+/-- `zOf` written so its real part is visible: `zOf w = -i(w-1)/T`. -/
+lemma zOf_eq (l : CH2.LadderParams) (w : ℂ) :
+    l.zOf w = -(Complex.I * (w - 1)) / (l.T : ℂ) := by
+  have hT : 0 < l.T := l.hT
+  have hTc : ((l.T : ℝ) : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr hT.ne'
+  show (w - 1) / (Complex.I * (l.T : ℂ)) = -(Complex.I * (w - 1)) / (l.T : ℂ)
+  rw [div_eq_div_iff (by simp [hTc]) hTc]
+  linear_combination ((w - 1) * (l.T : ℂ)) * Complex.I_sq
+
+/-- **`Re (zOf w) = Im w / T`.** This is why `Phi_lambda`'s sign factor is a discontinuity across
+the REAL AXIS in `s`, and why the ladder's `δ > 0` keeps `Rpos` and `RposBar` clear of it. -/
+lemma re_zOf (l : CH2.LadderParams) (w : ℂ) : (l.zOf w).re = w.im / l.T := by
+  rw [zOf_eq, Complex.div_ofReal_re]
+  simp
+
+/-- **`prop_5_2`'s `hsimple` hypothesis, closed on the set where the port actually uses it.**
+
+`Rpos` and `RposBar` sit at `|Im s| ≥ δ > 0`, so `Re (zOf s) = Im s / T` has a definite sign on a
+whole neighbourhood and `Phi_lambda` is locally `Phi_circ ± Phi_star` — analytic, by
+`zOf_ne_weight_pole`. The order of the product is then the order of `F`, exactly as in
+`hasSimplePolesOn_circ_ladder`.
+
+On `l.R` this is unprovable by an order computation, which is why `prop_5_2`'s hypothesis was
+weakened to this set: across the real axis the integrand is genuinely discontinuous, hence not
+meromorphic, and `meromorphicOrderAt` returns its junk value there. -/
+theorem hasSimplePolesOn_lambda_ladder (l : CH2.LadderParams) {lam ε x : ℝ}
+    (hlam : 0 < lam) (hx : 0 < x) :
+    HasSimplePolesOn (fun s ↦ CH2.Phi_lambda lam ε (l.zOf s) * F s * (x : ℂ) ^ s)
+      (l.Rpos ∪ l.RposBar) := by
+  have hT : 0 < l.T := l.hT
+  have hδ0 : 0 < l.δ := l.hδ.1
+  intro z hz
+  have hxc : ((x : ℝ) : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr hx.ne'
+  -- `z` has `Re z ≤ 1` and `Im z` of a definite sign, bounded away from `0`.
+  obtain ⟨hzre, hsign⟩ : z.re ≤ 1 ∧ (0 < z.im ∨ z.im < 0) := by
+    rcases hz with h | h
+    · exact ⟨h.1, Or.inl (lt_of_lt_of_le hδ0 h.2.1)⟩
+    · exact ⟨h.1, Or.inr (lt_of_le_of_lt h.2.2 (neg_lt_zero.mpr hδ0))⟩
+  -- The sign is locally constant, so the weight is locally `Phi_circ ± Phi_star`.
+  set σ : ℂ := if 0 < z.im then 1 else -1 with hσ_def
+  have hlocal : ∀ᶠ w in nhds z, CH2.Phi_lambda lam ε (l.zOf w)
+      = CH2.Phi_circ lam ε (l.zOf w) + σ * CH2.Phi_star lam ε (l.zOf w) := by
+    have hopen : ∀ᶠ w in nhds z, (0 < z.im → 0 < w.im) ∧ (z.im < 0 → w.im < 0) := by
+      rcases hsign with h | h
+      · filter_upwards [(isOpen_lt continuous_const Complex.continuous_im).mem_nhds h] with w hw
+        exact ⟨fun _ ↦ hw, fun hc ↦ absurd h (asymm hc)⟩
+      · filter_upwards [(isOpen_lt Complex.continuous_im continuous_const).mem_nhds h] with w hw
+        exact ⟨fun hc ↦ absurd h (asymm hc), fun _ ↦ hw⟩
+    filter_upwards [hopen] with w hw
+    have hre : (l.zOf w).re = w.im / l.T := re_zOf l w
+    simp only [CH2.Phi_lambda, abs_of_pos hlam, Real.sign_of_pos hlam, hσ_def, hre]
+    rcases hsign with h | h
+    · have hwim : 0 < w.im := hw.1 h
+      rw [if_pos h, Real.sign_of_pos (by positivity)]
+      push_cast
+      ring
+    · have hwim : w.im < 0 := hw.2 h
+      rw [if_neg (asymm h), Real.sign_of_neg (by exact div_neg_of_neg_of_pos hwim hT)]
+      push_cast
+      ring
+  -- Rewrite the order along that local identity.
+  have hcongr : meromorphicOrderAt (fun s ↦ CH2.Phi_lambda lam ε (l.zOf s) * F s * (x : ℂ) ^ s) z
+      = meromorphicOrderAt
+          (((fun s ↦ CH2.Phi_circ lam ε (l.zOf s) + σ * CH2.Phi_star lam ε (l.zOf s)) * F)
+            * (fun s : ℂ ↦ (x : ℂ) ^ s)) z := by
+    refine meromorphicOrderAt_congr ?_
+    filter_upwards [nhdsWithin_le_nhds hlocal] with w hw
+    simp only [Pi.mul_apply, hw]
+  rw [hcongr]
+  -- Same computation as for `Phi_circ`: analytic weight, `F`, and a non-vanishing `x ^ s`.
+  have hΦ : AnalyticAt ℂ
+      (fun w ↦ CH2.Phi_circ lam ε (l.zOf w) + σ * CH2.Phi_star lam ε (l.zOf w)) z :=
+    (analyticAt_Phi_circ_zOf l hlam hzre).add
+      (analyticAt_const.mul (analyticAt_Phi_star_zOf l hlam hzre))
+  have hpow : AnalyticAt ℂ (fun w : ℂ ↦ (x : ℂ) ^ w) z := analyticAt_const_cpow hx z
+  have hpowne : ((x : ℂ) ^ z) ≠ 0 := by simp [hxc]
+  have hFm : MeromorphicAt F z := meromorphicOn_F z (Set.mem_univ z)
+  rw [meromorphicOrderAt_mul (hΦ.meromorphicAt.mul hFm) hpow.meromorphicAt,
+    meromorphicOrderAt_mul hΦ.meromorphicAt hFm]
+  have h1 : (0 : WithTop ℤ) ≤ meromorphicOrderAt
+      (fun w ↦ CH2.Phi_circ lam ε (l.zOf w) + σ * CH2.Phi_star lam ε (l.zOf w)) z :=
+    meromorphicOrderAt_nonneg_of_analyticAt hΦ
+  have h2 : ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt F z :=
+    hasSimplePolesOn_F_univ z (Set.mem_univ z)
+  have h3 : meromorphicOrderAt (fun w : ℂ ↦ (x : ℂ) ^ w) z = 0 := by
+    rw [hpow.meromorphicOrderAt_eq, hpow.analyticOrderAt_eq_zero.mpr hpowne]
+    simp
+  rw [h3, add_zero]
+  calc ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt F z := h2
+    _ = 0 + meromorphicOrderAt F z := (zero_add _).symm
+    _ ≤ _ := by gcongr
+
 end CH2ZetaInstance

--- a/Solutions/CH2.v1/ZetaInstance.lean
+++ b/Solutions/CH2.v1/ZetaInstance.lean
@@ -1713,4 +1713,57 @@ theorem zOf_ne_weight_pole (l : CH2.LadderParams) {lam : ℝ} (hlam : 0 < lam) {
   have hpos : 0 < l.T * lam / (2 * Real.pi) := by positivity
   linarith
 
+/-- Both weights are analytic at `zOf s` for every `s` in `R`, by `zOf_ne_weight_pole`. -/
+theorem analyticAt_Phi_circ_zOf (l : CH2.LadderParams) {lam ε : ℝ} (hlam : 0 < lam) {s : ℂ}
+    (hs : s.re ≤ 1) : AnalyticAt ℂ (fun w ↦ CH2.Phi_circ lam ε (l.zOf w)) s :=
+  (CH2.Phi_circ.analyticAt_of_not_pole lam ε (l.zOf s)
+    (fun n ↦ zOf_ne_weight_pole l hlam hs n)).comp (analyticAt_zOf l s)
+
+theorem analyticAt_Phi_star_zOf (l : CH2.LadderParams) {lam ε : ℝ} (hlam : 0 < lam) {s : ℂ}
+    (hs : s.re ≤ 1) : AnalyticAt ℂ (fun w ↦ CH2.Phi_star lam ε (l.zOf w)) s :=
+  (CH2.Phi_star.analyticAt_of_not_pole lam ε (l.zOf s)
+    (fun n ↦ zOf_ne_weight_pole l hlam hs n)).comp (analyticAt_zOf l s)
+
+/-- **`prop_5_2`'s `hsimple_circ` hypothesis, closed.**
+
+`Phi_circ` carries no sign factor, so unlike `Phi_lambda` it is analytic across the real axis as
+well, and the order of the product is just the order of `F`, which
+`hasSimplePolesOn_F_univ` already bounds below by `-1`. -/
+theorem hasSimplePolesOn_circ_ladder (l : CH2.LadderParams) {lam ε x : ℝ}
+    (hlam : 0 < lam) (hx : 0 < x) :
+    HasSimplePolesOn
+      (fun s ↦ CH2.Phi_circ |lam| ε ((Real.sign lam : ℂ) * l.zOf s) * F s * (x : ℂ) ^ s) l.R := by
+  intro z hz
+  have hzre : z.re ≤ 1 := hz.1
+  have hxc : ((x : ℝ) : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr hx.ne'
+  -- `|lam| = lam` and `Real.sign lam = 1`, so the weight is evaluated at `zOf s` itself.
+  have hsimp : (fun s ↦ CH2.Phi_circ |lam| ε ((Real.sign lam : ℂ) * l.zOf s) * F s * (x : ℂ) ^ s)
+      = ((fun s ↦ CH2.Phi_circ lam ε (l.zOf s)) * F) * (fun s : ℂ ↦ (x : ℂ) ^ s) := by
+    funext s
+    simp only [Pi.mul_apply]
+    rw [abs_of_pos hlam, Real.sign_of_pos hlam]
+    norm_num
+  rw [hsimp]
+  -- The three factors, and their orders.
+  have hΦ : AnalyticAt ℂ (fun w ↦ CH2.Phi_circ lam ε (l.zOf w)) z :=
+    analyticAt_Phi_circ_zOf l hlam hzre
+  have hpow : AnalyticAt ℂ (fun w : ℂ ↦ (x : ℂ) ^ w) z := analyticAt_const_cpow hx z
+  have hpowne : ((x : ℂ) ^ z) ≠ 0 := by
+    simp [hxc]
+  have hFm : MeromorphicAt F z := meromorphicOn_F z (Set.mem_univ z)
+  rw [meromorphicOrderAt_mul (hΦ.meromorphicAt.mul hFm) hpow.meromorphicAt,
+    meromorphicOrderAt_mul hΦ.meromorphicAt hFm]
+  have h1 : (0 : WithTop ℤ) ≤ meromorphicOrderAt (fun w ↦ CH2.Phi_circ lam ε (l.zOf w)) z :=
+    meromorphicOrderAt_nonneg_of_analyticAt hΦ
+  have h2 : ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt F z :=
+    hasSimplePolesOn_F_univ z (Set.mem_univ z)
+  have h3 : meromorphicOrderAt (fun w : ℂ ↦ (x : ℂ) ^ w) z = 0 := by
+    rw [hpow.meromorphicOrderAt_eq, hpow.analyticOrderAt_eq_zero.mpr hpowne]
+    simp
+  rw [h3, add_zero]
+  calc ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt F z := h2
+    _ = 0 + meromorphicOrderAt F z := (zero_add _).symm
+    _ ≤ meromorphicOrderAt (fun w ↦ CH2.Phi_circ lam ε (l.zOf w)) z + meromorphicOrderAt F z := by
+        gcongr
+
 end CH2ZetaInstance

--- a/Solutions/CH2.v1/progress.yaml
+++ b/Solutions/CH2.v1/progress.yaml
@@ -106,12 +106,32 @@ stages:
   - stage: "instantiating section 5 at A(s) = -zeta'/zeta"
     files: [ZetaInstance.lean]
     state: >-
-      partial -- three of prop_5_2's five hypotheses closed unconditionally on all of C; of the
-      remaining two, the no-poles half is done, and of the boundedness half the compact pieces and
-      the Re w >= 2 input are done, as are F itself, choosing T and delta off the zero ordinates,
-      the damping estimate for the leftward rays, a concrete LadderParams whose ladder and contour
-      miss every zero, and the linear growth bound on F. NO ESTIMATE REMAINS UNPROVED; what is
-      left is the application of prop_5_2 itself.
+      DONE. Every hypothesis of prop_5_2 is discharged and prop_5_2_zeta applies it at
+      A(s) = -zeta'/zeta with the pole at s = 1 divided out, for any LadderParams whose abscissas
+      are sigmaZeta and whose T and delta miss the zero ordinates -- which exists_ladderParams_zeta
+      supplies.
+    what_it_took: >-
+      Meromorphy and conjugation symmetry came almost free from the port. The other five did not.
+      THE TWO BOUNDEDNESS CONDITIONS needed the ladder cut at Re = -1: to the right it is a union
+      of five boxes, four degenerate, handled by compactness; to the left by the growth bound on F
+      damped by x0^s. The weighted one needed a quadratic version of that damping, since the extra
+      factor zOf s = (s-1)/(iT) turns linear growth into quadratic -- obtained free from the linear
+      case by u^2 exp(-cu) = (u exp(-(c/2)u))^2.
+      THE TWO SIMPLE-POLE CONDITIONS needed the Graham-Vaaler weights to have no poles on R, which
+      holds because zOf pulls their poles back to Re s = 1 + T lam/(2 pi) > 1 -- and that in turn
+      holds because prop_5_2 assumes 0 < lam, which had looked like a free parameter.
+      hsimple additionally forced prop_5_2's own hypothesis to be weakened; see below.
+      hfin needed nothing new: RC removes exactly the real axis, which is where all the trivial
+      zeros of zeta sit, and off the axis the poles lie in a compact band with finitely many.
+    one_edit_to_the_ported_section_5: >-
+      prop_5_2's hsimple hypothesis was stated on l.R and is now on l.Rpos u l.RposBar. It was
+      never CONSUMED outside that set -- it reaches its uses through HasSimplePolesOn.mono onto the
+      upper and lower rectangles, which sit at |Im s| >= delta > 0 -- and on l.R it is not provable
+      by an order computation at all: Phi_lambda contains Real.sign (Re z) and
+      Re (zOf s) = Im s / T, so the integrand is discontinuous across the real axis, hence not
+      meromorphic there, and meromorphicOrderAt returns its junk value 0. Proving the l.R form
+      would have meant establishing a vacuity. Eight binders and two mono proofs changed; no proof
+      body did, and weakening a hypothesis strengthens the theorem.
     note: >-
       Done first because it is the smallest thing that tests whether the section 5 port is USABLE
       rather than merely compiling. It is: ConjSymm falls straight out of the ported


### PR DESCRIPTION
**Stage 4 of `CH2.v1` is complete.** `prop_5_2_zeta` instantiates the contour-shift proposition at `A(s) = -ζ'(s)/ζ(s)`, with its pole at `s = 1` divided out, for any `LadderParams` whose abscissas are `sigmaZeta` and whose `T` and `δ` miss the zero ordinates — which `exists_ladderParams_zeta` supplies.

All seven hypotheses of `prop_5_2` are discharged, so the application is a single term.

| hypothesis | how |
|---|---|
| `hF_mero`, `hF_symm` | already proved (earlier work) |
| `hF_bdd` | ladder cut at `Re = -1`: compactness right, damped growth left |
| `hFw_bdd` | the same, with a **quadratic** damping lemma |
| `hsimple_circ` | weights pole-free on `R`; order reduces to `F`'s |
| `hsimple` | ditto, off the axis — plus one edit to the port (below) |
| `hfin` | `RC` already removes the real axis, where the trivial zeros sit |

## Three things worth reading the diff for

**The quadratic damping came free.** `hFw_bdd` carries an extra `zOf s = (s-1)/(iT)`, which turns `F`'s linear growth into quadratic, and the existing lemma covered only linear. The companion cost almost nothing because of one identity:

```
u² e^(-cu) = (u e^(-(c/2)u))²
```

Halving the rate turns a square of a product into a product of squares, and the inner factor *is* the existing linear lemma at `c/2`. No new calculus.

**A free parameter turned out to be load-bearing.** The two simple-pole conditions need the Graham–Vaaler weights to have no poles on `R`. `Phi_circ` and `Phi_star` have poles exactly at `z = n - iν/(2π)`; pulling back through `zOf` gives `Re s = 1 + Tν/(2π) > 1`, outside `R`. That depends on `Real.sign lam = 1`, i.e. on `prop_5_2`'s `0 < lam` — which had looked incidental. For negative `lam` the same points land *inside* `R` and the residue sum would have to account for them.

**`hfin` needed no modification**, contrary to expectation. `R` is unbounded to the left and contains every trivial zero of ζ — infinitely many, all at `Im = 0` — and `RC = {Re z ≤ 1, |Im z| ≤ δ}` removes precisely those. The exclusion was already in the statement; it just wasn't visible until `RC` was read.

## One edit to the ported §5

`prop_5_2`'s `hsimple` moves from `l.R` to `l.Rpos ∪ l.RposBar`.

That set is already the only place the port *consumes* it — it reaches its uses via `HasSimplePolesOn.mono` onto the upper and lower rectangles, which sit at `|Im s| ≥ δ > 0`. And on `l.R` it is **not provable by an order computation at all**: `Phi_lambda` contains `Real.sign (Re z)` and `Re (zOf s) = Im s / T`, so the integrand is discontinuous across the real axis, hence not meromorphic there, and `meromorphicOrderAt` returns its junk value `0`. Proving the stated form would have meant establishing a vacuity.

Eight binders and two `.mono` proofs changed. **No proof body changed**, and weakening a hypothesis strengthens the theorem, so nothing downstream can break. `Section5.lean` typechecks with no errors and no newly-unused hypotheses.

## Also in here

- First build of `Solutions/CH2.v1` against the **bumped Mathlib**. Its own checkout was still pre-bump while its manifest named the new revision. It builds; the only fallout is deprecation warnings (`push_neg`, `Set.mem_setOf_eq`, `Set.Infinite.diff`), left alone since solutions are exempt from the style linter and CI does not build them.
- `norm_tan_le_one_of_sin_re_eq_zero`, the estimate the roadmap said did not exist. The old `tan` bound is `coth |Im w|`, which diverges as `Im w → 0`, and the ladder columns pass through the axis. On a column the bound is `1`, with no dependence on the height.

## Gate

`lake build` in the solution: 3838 jobs, no errors. `progress`: still exactly the four corollary holes, confirmed mechanically rather than by inspection. `ieantn.py check` 8/8; `diff` reports no change to any statement, dependency or receipt.

## What this does not do

`CH2.v1`'s four conclusions are still open, and stage 6 — the residue sum over zeros under RH up to `T` — remains the real work and is untouched. Stage 4 was the smallest thing that tests whether the §5 port is *usable*. It is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
