### PR TITLE
State Büthe 2016 Theorem 1 from Tables 1 and 2

### DIFF
--- a/GRAPH.md
+++ b/GRAPH.md
@@ -56,7 +56,7 @@ graph LR
   NBrown1967_v1["<b>Brown1967.v1</b><br/><i>nothing stated yet</i>"]
   NButhe_v1["<b>Buthe.v1</b><br/>6 claims<br/><i>weakest: cited</i>"]
   NButhe_v2["<b>Buthe.v2</b><br/>2 claims<br/><i>weakest: unjustified</i>"]
-  NButhe2016_v1["<b>Buthe2016.v1</b><br/>4 claims<br/><i>weakest: cited</i>"]
+  NButhe2016_v1["<b>Buthe2016.v1</b><br/>6 claims<br/><i>weakest: cited</i>"]
   NButheNumerics_v1["<b>ButheNumerics.v1</b><br/>3 claims<br/><i>weakest: computation</i>"]
   NCH2_v1["<b>CH2.v1</b><br/>4 claims<br/><i>weakest: cited</i>"]
   NCH2_v2["<b>CH2.v2</b><br/>2 claims<br/><i>weakest: verified, stale</i>"]
@@ -137,6 +137,7 @@ graph LR
   NPlatt2017_v1 ==>|bridge| NWedeniwski_v1
   style NBKLNW_v1 stroke-dasharray: 8 4;
   style NButhe_v1 stroke-dasharray: 8 4;
+  style NButhe2016_v1 stroke-dasharray: 8 4;
   style NCH2_v1 stroke-dasharray: 8 4;
   style NDudekPlatt_v1 stroke-dasharray: 8 4;
   style NDudekPlattNumerics_v1 stroke-dasharray: 8 4;
@@ -237,6 +238,8 @@ graph LR
     Buthe_v2_lemma_3_positivity["<b>lemma_3_positivity</b><br/><i>unjustified</i>"]
   end
   subgraph sgButhe2016_v1["Buthe2016.v1"]
+    Buthe2016_v1_theorem_1_table1["<b>theorem_1_table1</b><br/><i>computation</i>"]
+    Buthe2016_v1_theorem_1_table2["<b>theorem_1_table2</b><br/><i>computation</i>"]
     Buthe2016_v1_theorem_2_li_minus_pi["<b>theorem_2_li_minus_pi</b><br/><i>cited</i>"]
     Buthe2016_v1_theorem_2_li_minus_riemann_pi["<b>theorem_2_li_minus_riemann_pi</b><br/><i>cited</i>"]
     Buthe2016_v1_theorem_2_psi["<b>theorem_2_psi</b><br/><i>cited</i>"]
@@ -503,6 +506,7 @@ graph LR
   style Buthe_v1_theorem_2_psi stroke-dasharray: 8 4;
   style Buthe_v1_theorem_2_theta stroke-dasharray: 8 4;
   style Buthe_v1_theorem_2_theta_lower stroke-dasharray: 8 4;
+  style Buthe2016_v1_theorem_1_table2 stroke-dasharray: 8 4;
   style CH2_v1_corollary_1_2_lambda_sum stroke-dasharray: 8 4;
   style CH2_v1_corollary_1_2_psi stroke-dasharray: 8 4;
   style CH2_v1_corollary_1_3_lambda_sum stroke-dasharray: 8 4;
@@ -536,7 +540,7 @@ graph LR
   class CH2_v2_proposition_2_4_lower,CH2_v2_proposition_2_4_upper,DudekPlatt_v2_ramanujan_inequality_3915,DudekPlatt_v3_criterion,FKS2_v1_corollary_14,FKS2_v1_corollary_22,FKS2_v1_corollary_23,FKS2_v1_corollary_26,FKS2_v2_proposition_13,FKS2_v2_theorem_3,Lcm_v1_lcmUpto_not_highlyAbundant,Lcm_v2_lcmUpto_not_highlyAbundant_of_primeGap,PrimeInterval_v1_classicalBound_hasPrimeInInterval,PrimeInterval_v1_eTheta_criterion,PrimeInterval_v1_numericalBound_hasPrimeInInterval,PrimeInterval_v1_theta_characterisation,ZeroFreeHeight_v1_classical_region_descends lean_comparator_stale;
   class BKLNW_v1_corollary_5_1,BKLNW_v1_table8_psi_bound,BKLNW_v1_table8_psi_bound_above,BKLNW_v1_theta_error_le_one,Buthe_v1_theorem_2_li_gt_pi,Buthe_v1_theorem_2_li_minus_pi,Buthe_v1_theorem_2_li_minus_riemann_pi,Buthe_v1_theorem_2_psi,Buthe_v1_theorem_2_theta,Buthe_v1_theorem_2_theta_lower,Buthe2016_v1_theorem_2_li_minus_pi,Buthe2016_v1_theorem_2_li_minus_riemann_pi,Buthe2016_v1_theorem_2_psi,Buthe2016_v1_theorem_2_theta,CH2_v1_corollary_1_2_lambda_sum,CH2_v1_corollary_1_2_psi,CH2_v1_corollary_1_3_lambda_sum,CH2_v1_corollary_1_3_psi,DudekPlatt_v1_largest_counterexample_on_rh,DudekPlatt_v1_ramanujan_inequality,Dusart2018_v1_proposition_5_4,FKS_v1_psi_bound_all_x,FKS_v1_psi_classical_bound,Hiary2016_v1_zeta_half_line_bound,KLN_v1_subconvexity_bound,KLN_v1_zero_density,Kadiri2005_v1_zero_free_region,MT_v1_zero_free_region,MT_v1_zero_free_region_sharpened,PlattTrudgian_v1_rh_up_to,PlattTrudgian2021_v1_theorem_1_classical,PlattTrudgian2021_v1_theorem_1_numerical,RosserSchoenfeld_v1_zero_free_region,Trudgian2011_v1_integral_S_bound,ZeroCount_v1_rvm_error_bound,ZeroCount_v1_rvm_error_small literature;
   class Buthe_v2_lemma_3_bounds,Buthe_v2_lemma_3_positivity,ContourIntegration_v1_residue_theorem_rectangle,CotangentSeries_v1_cot_series_zeta_values,GammaAsymptotics_v1_digamma_sub_log_isBigO none_yet;
-  class ButheNumerics_v1_lemma_3_constant_gt_at_10,ButheNumerics_v1_lemma_3_constant_nonpos,ButheNumerics_v1_li_minus_pi_below_1e7,DudekPlattNumerics_v1_pi_two_sided_paper,DudekPlattNumerics_v2_pi_two_sided_pnt,FKBJ_v1_rh_up_to,FKS2Numerics_v1_corollary_22_mid_range,FKS2Numerics_v1_corollary_23_mid_range,FKS2Numerics_v1_nu_asymp_e30_le,FKS2Numerics_v1_table6_row2_floor,FKS2Numerics_v1_theta_asymp_ge_one_below_e30,LowZeroes_v1_sum_inv_ordinates_below_2e4,Platt2015_v1_rh_up_to,Platt2017_v1_rh_up_to,ZetaLogDerivValues_v1_deriv_logDeriv_neg_one,ZetaLogDerivValues_v1_logDeriv_laurent_alternating,ZetaLogDerivValues_v1_logDeriv_neg_one,ZetaLogDerivValues_v1_logDeriv_three_halves,ZetaLogDerivValues_v1_logDeriv_two numerical;
+  class Buthe2016_v1_theorem_1_table1,Buthe2016_v1_theorem_1_table2,ButheNumerics_v1_lemma_3_constant_gt_at_10,ButheNumerics_v1_lemma_3_constant_nonpos,ButheNumerics_v1_li_minus_pi_below_1e7,DudekPlattNumerics_v1_pi_two_sided_paper,DudekPlattNumerics_v2_pi_two_sided_pnt,FKBJ_v1_rh_up_to,FKS2Numerics_v1_corollary_22_mid_range,FKS2Numerics_v1_corollary_23_mid_range,FKS2Numerics_v1_nu_asymp_e30_le,FKS2Numerics_v1_table6_row2_floor,FKS2Numerics_v1_theta_asymp_ge_one_below_e30,LowZeroes_v1_sum_inv_ordinates_below_2e4,Platt2015_v1_rh_up_to,Platt2017_v1_rh_up_to,ZetaLogDerivValues_v1_deriv_logDeriv_neg_one,ZetaLogDerivValues_v1_logDeriv_laurent_alternating,ZetaLogDerivValues_v1_logDeriv_neg_one,ZetaLogDerivValues_v1_logDeriv_three_halves,ZetaLogDerivValues_v1_logDeriv_two numerical;
   click BKLNW_v1_corollary_5_1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#corollary_5_1" _blank
   click BKLNW_v1_table8_psi_bound href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#table8_psi_bound" _blank
   click BKLNW_v1_table8_psi_bound_above href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#table8_psi_bound_above" _blank
@@ -549,6 +553,8 @@ graph LR
   click Buthe_v1_theorem_2_theta_lower href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe-v1.md#theorem_2_theta_lower" _blank
   click Buthe_v2_lemma_3_bounds href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe-v2.md#lemma_3_bounds" _blank
   click Buthe_v2_lemma_3_positivity href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe-v2.md#lemma_3_positivity" _blank
+  click Buthe2016_v1_theorem_1_table1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe2016-v1.md#theorem_1_table1" _blank
+  click Buthe2016_v1_theorem_1_table2 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe2016-v1.md#theorem_1_table2" _blank
   click Buthe2016_v1_theorem_2_li_minus_pi href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe2016-v1.md#theorem_2_li_minus_pi" _blank
   click Buthe2016_v1_theorem_2_li_minus_riemann_pi href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe2016-v1.md#theorem_2_li_minus_riemann_pi" _blank
   click Buthe2016_v1_theorem_2_psi href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe2016-v1.md#theorem_2_psi" _blank
@@ -681,6 +687,10 @@ A line is one claim, indented under whatever assumes it.
 
 - [`Buthe.v1.theorem_2_psi`](docs/nodes/Buthe-v1.md#theorem_2_psi) — cited — *sources known, not all drawable*
   - [`FKBJ.v1.rh_up_to`](docs/nodes/FKBJ-v1.md#rh_up_to) — computation — *sources known, not all drawable*
+
+- [`Buthe2016.v1.theorem_1_table1`](docs/nodes/Buthe2016-v1.md#theorem_1_table1) — computation
+
+- [`Buthe2016.v1.theorem_1_table2`](docs/nodes/Buthe2016-v1.md#theorem_1_table2) — computation — *sources known, not all drawable*
 
 - [`Buthe2016.v1.theorem_2_li_minus_pi`](docs/nodes/Buthe2016-v1.md#theorem_2_li_minus_pi) — cited
 
@@ -930,6 +940,8 @@ rather than maintained.
 | [`Buthe.v1.theorem_2_li_minus_pi`](docs/nodes/Buthe-v1.md#theorem_2_li_minus_pi) | cited | 0 | traced |
 | [`Buthe.v1.theorem_2_li_minus_riemann_pi`](docs/nodes/Buthe-v1.md#theorem_2_li_minus_riemann_pi) | cited | 0 | known, not all drawable |
 | [`Buthe.v1.theorem_2_psi`](docs/nodes/Buthe-v1.md#theorem_2_psi) | cited | 0 | known, not all drawable |
+| [`Buthe2016.v1.theorem_1_table1`](docs/nodes/Buthe2016-v1.md#theorem_1_table1) | computation | 0 | none |
+| [`Buthe2016.v1.theorem_1_table2`](docs/nodes/Buthe2016-v1.md#theorem_1_table2) | computation | 0 | known, not all drawable |
 | [`Buthe2016.v1.theorem_2_li_minus_pi`](docs/nodes/Buthe2016-v1.md#theorem_2_li_minus_pi) | cited | 0 | none |
 | [`Buthe2016.v1.theorem_2_li_minus_riemann_pi`](docs/nodes/Buthe2016-v1.md#theorem_2_li_minus_riemann_pi) | cited | 0 | none |
 | [`Buthe2016.v1.theorem_2_theta`](docs/nodes/Buthe2016-v1.md#theorem_2_theta) | cited | 0 | none |

--- a/IEANTN/Nodes.lean
+++ b/IEANTN/Nodes.lean
@@ -8,6 +8,7 @@ import IEANTN.Nodes.BKLNW.v1.Challenge
 import IEANTN.Nodes.Brown1967.v1.Challenge
 import IEANTN.Nodes.Buthe.v1.Challenge
 import IEANTN.Nodes.Buthe.v2.Challenge
+import IEANTN.Nodes.Buthe2016.v1.Tables
 import IEANTN.Nodes.Buthe2016.v1.Challenge
 import IEANTN.Nodes.ButheNumerics.v1.Challenge
 import IEANTN.Nodes.CH2.v1.Challenge

--- a/IEANTN/Nodes/Buthe2016/v1/Challenge.lean
+++ b/IEANTN/Nodes/Buthe2016/v1/Challenge.lean
@@ -27,3 +27,9 @@ theorem Buthe2016.v1.challenge_theorem_2_li_minus_riemann_pi : Buthe2016.v1.theo
 
 theorem Buthe2016.v1.challenge_theorem_2_li_minus_pi : Buthe2016.v1.theorem_2_li_minus_pi := by
   sorry
+
+theorem Buthe2016.v1.challenge_theorem_1_table1 : Buthe2016.v1.theorem_1_table1 := by
+  sorry
+
+theorem Buthe2016.v1.challenge_theorem_1_table2 : Buthe2016.v1.theorem_1_table2 := by
+  sorry

--- a/IEANTN/Nodes/Buthe2016/v1/Conclusions.lean
+++ b/IEANTN/Nodes/Buthe2016/v1/Conclusions.lean
@@ -6,6 +6,8 @@ Authors: Terence Tao
 import IEANTN.Vocabulary.Zeta
 import IEANTN.Vocabulary.PrimeCounting
 import IEANTN.Vocabulary.ErrorTerms
+import IEANTN.Vocabulary.Numerics
+import IEANTN.Nodes.Buthe2016.v1.Tables
 
 /-!
 # Node `Buthe2016.v1`
@@ -32,6 +34,9 @@ Table 8, and `Platt–Trudgian`'s error-term paper cites it for the same purpose
 The conclusions below are stated as the paper states them: universally quantified in `T`, with the
 verification as a hypothesis rather than an import. So this node imports nothing, and that is a
 genuine `none` rather than an untraced `undetermined`.
+
+Theorem 1 — a relative-error bound of a different shape from Theorem 2 — is recorded through the
+paper's Tables 1 and 2 in `Tables.lean`. The Logan-kernel display of Theorem 1 is not stated.
 
 ## Watch the logarithmic integral
 
@@ -88,5 +93,24 @@ from a partial verification. Note the threshold `2657` and that the comparison i
 def theorem_2_li_minus_pi : Prop :=
   ∀ T : ℝ, RiemannHypothesisUpTo T → ∀ x : ℝ, 2657 < x → withinRange T x →
     |primeCounting x - li x| ≤ Real.sqrt x * Real.log x / (8 * Real.pi)
+
+/-- **Theorem 1, as Table 1 records it.** If the Riemann hypothesis holds up to the row's height
+`T`, then `|ψ(x) − x| ≤ δ₀ x` for every `x ≥ e^b`.
+
+This is a different shape from Theorem 2: a plain relative error `δ₀`, not Schoenfeld's
+`√x (log x)² / (8π)`. Theorem 1 itself is parameterised by the Logan kernel; the table is the
+output the paper actually uses, and is what a consumer can cite without that vocabulary.
+
+Each `δ₀` carries `margin 0` — a site, not a weakening — because the entries are computed upper
+bounds for `e^{αε}(ℰ₁+ℰ₂+ℰ₃)`, not displayed closed forms. -/
+def theorem_1_table1 : Prop :=
+  ∀ p ∈ table1, RiemannHypothesisUpTo p.2.1 → ∀ x : ℝ, Real.exp (p.1 : ℝ) ≤ x →
+    |Chebyshev.psi x - x| ≤ margin 0 * p.2.2 * x
+
+/-- **Theorem 1, as Table 2 records it.** Same claim as `theorem_1_table1`, at the larger
+verification heights of the paper's Table 2 (up to `2.445 × 10¹²`). -/
+def theorem_1_table2 : Prop :=
+  ∀ p ∈ table2, RiemannHypothesisUpTo p.2.1 → ∀ x : ℝ, Real.exp (p.1 : ℝ) ≤ x →
+    |Chebyshev.psi x - x| ≤ margin 0 * p.2.2 * x
 
 end Buthe2016.v1

--- a/IEANTN/Nodes/Buthe2016/v1/Tables.lean
+++ b/IEANTN/Nodes/Buthe2016/v1/Tables.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 IEANTN contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Taksh Kothari
+-/
+import Mathlib.Data.Real.Basic
+
+/-!
+# Tables: `Buthe2016.v1`
+
+Data from Büthe, *Estimating π(x) and related functions under partial RH assumptions*,
+Math. Comp. **85** (2016), 2483–2498. Data only — what is claimed *about* it is in
+`Conclusions.lean`.
+
+These are the tabulated outputs of the paper's **Theorem 1**: for each row, `δ₀` is an upper bound
+for `e^{αε}(ℰ₁ + ℰ₂ + ℰ₃)` at the printed parameters, and the theorem then gives
+`|ψ(x) − x| ≤ δ₀ x` for all `x ≥ e^{αε} x₀`, assuming the Riemann hypothesis up to the printed
+height `T` (with `ε = c/T`).
+
+The general statement of Theorem 1 is parameterised by the Logan kernel and Bessel ratios, which
+are not yet Vocabulary. The tables are the part a consumer can cite without that machinery, and
+they are the "explicit bound of a different shape from Theorem 2" that the node had recorded as
+unstated.
+-/
+
+namespace Buthe2016.v1
+
+/-- **Table 1**: bounds under a verification to height at most `3.061 × 10¹⁰`.
+
+Each triple is `(b, T, δ₀)` where the bound is claimed for `x ≥ e^b` if the Riemann hypothesis
+holds up to height `T`. Extracted from the typeset table on arXiv:1410.7015. -/
+def table1 : List (ℕ × ℝ × ℝ) :=
+  [
+    (45, 3.5e9, 1.11742e-8),
+    (50, 3.061e10, 1.16465e-9),
+    (55, 3.061e10, 2.88434e-10),
+    (60, 3.061e10, 2.08162e-10),
+    (65, 3.061e10, 1.96865e-10),
+    (70, 3.061e10, 1.91910e-10),
+    (80, 3.061e10, 1.84848e-10),
+    (90, 3.061e10, 1.79330e-10),
+    (100, 3.061e10, 1.75185e-10),
+    (500, 3.061e10, 1.47067e-10),
+    (1000, 3.061e10, 1.43770e-10),
+    (3000, 3.061e10, 1.41594e-10)
+  ]
+
+/-- **Table 2**: bounds under a verification to height at most `2.445 × 10¹²`.
+
+Same shape as `table1`. The paper attributes this height to Gourdon (2004); the network has no
+node for that computation yet, so a consumer must supply the verification as a hypothesis. -/
+def table2 : List (ℕ × ℝ × ℝ) :=
+  [
+    (55, 8.5e11, 1.12494e-10),
+    (60, 2.445e12, 1.22147e-11),
+    (65, 2.445e12, 3.57125e-12),
+    (70, 2.445e12, 2.79233e-12),
+    (75, 2.445e12, 2.70358e-12),
+    (80, 2.445e12, 2.61079e-12),
+    (90, 2.445e12, 2.52129e-12),
+    (100, 2.445e12, 2.45229e-12),
+    (500, 2.445e12, 1.99986e-12),
+    (1000, 2.445e12, 1.94751e-12),
+    (2000, 2.445e12, 1.92155e-12),
+    (3000, 2.445e12, 1.91298e-12),
+    (4000, 2.445e12, 1.90866e-12)
+  ]
+
+end Buthe2016.v1

--- a/IEANTN/Nodes/Buthe2016/v1/formalization.yaml
+++ b/IEANTN/Nodes/Buthe2016/v1/formalization.yaml
@@ -105,6 +105,40 @@ conclusions:
       the statement. The paper's headline. Stated against li, the un-offset logarithmic integral, not
       Li.
   designated: buthe2016-paper
+- id: theorem_1_table1
+  declaration: Buthe2016.v1.theorem_1_table1
+  challenge: Buthe2016.v1.challenge_theorem_1_table1
+  imports: []
+  imports_status: none
+  justifications:
+  - id: buthe2016-table1
+    kind: numerical
+    source: Buthe2016
+    locator: Theorem 1, via Table 1
+    note: >-
+      The tabulated output of Theorem 1 at heights up to 3.061e10, transcribed from arXiv:1410.7015.
+      Kind `numerical` because each delta_0 is a computed upper bound for e^{alpha epsilon}(E1+E2+E3),
+      not a closed-form argument. Imports none: the verification height T is a hypothesis on each row,
+      the same shape as this node's Theorem 2. The Logan-kernel statement of Theorem 1 is not recorded
+      here -- the table is the part that can be stated without new Vocabulary. margin 0 is a site on
+      the computed constants.
+  designated: buthe2016-table1
+- id: theorem_1_table2
+  declaration: Buthe2016.v1.theorem_1_table2
+  challenge: Buthe2016.v1.challenge_theorem_1_table2
+  imports: []
+  imports_status: traced
+  justifications:
+  - id: buthe2016-table2
+    kind: numerical
+    source: Buthe2016
+    locator: Theorem 1, via Table 2
+    note: >-
+      Same claim as theorem_1_table1, at the paper's Table 2 heights (up to 2.445e12). The paper
+      attributes that height to Gourdon (2004). The network has no node for that computation, so the
+      verification remains a hypothesis and the import status is `traced` rather than `none`: the
+      input is known and named, but is not yet an edge.
+  designated: buthe2016-table2
 sources:
 - title: Estimating pi(x) and related functions under partial RH assumptions
   authors:
@@ -137,11 +171,12 @@ limitations:
 - >-
   Every conclusion rests on the cited paper; none is proved in Lean here.
 - >-
-  All four are stated against li rather than Li, as the paper states them. A node consuming them alongside
-  FKS2, which works with Li, must do the conversion; li 2 is about 1.045 and the bounds are of size sqrt(x)
-  log x / (8 pi).
+  The four Theorem 2 conclusions are stated against li rather than Li, as the paper states them. A node
+  consuming them alongside FKS2, which works with Li, must do the conversion; li 2 is about 1.045 and
+  the bounds are of size sqrt(x) log x / (8 pi).
 - >-
-  Theorem 1 of the paper, an explicit bound with a different shape, is not stated; nothing in the network
-  consumes it yet.
+  Theorem 1 is stated through Tables 1 and 2, not in the Logan-kernel form of the theorem display. That
+  form needs Vocabulary this node does not yet justify promoting. Table 2's height 2.445e12 is Gourdon
+  (2004), which is not a node.
 - >-
   No novelty is claimed. The results are Buthe's.

--- a/STATE.md
+++ b/STATE.md
@@ -7,7 +7,7 @@ column says what a receipt is presently worth, not merely what was claimed for i
 reason a receipt has stopped standing is below, and `python scripts/ieantn.py status`
 adds the environment detail.
 
-47 node version(s), 91 conclusion(s).  3 state nothing yet.
+47 node version(s), 93 conclusion(s).  3 state nothing yet.
 
 ## Evidence
 
@@ -18,7 +18,7 @@ adds the environment detail.
 | `lean-comparator` | 29 |
 | `literature` | 36 |
 | `none-yet` | 5 |
-| `numerical` | 19 |
+| `numerical` | 21 |
 
 ## Nodes
 
@@ -41,6 +41,8 @@ adds the environment detail.
 | `Buthe2016.v1` | stub | `theorem_2_theta` | literature | 0 | - |
 | `Buthe2016.v1` | stub | `theorem_2_li_minus_riemann_pi` | literature | 0 | - |
 | `Buthe2016.v1` | stub | `theorem_2_li_minus_pi` | literature | 0 | - |
+| `Buthe2016.v1` | stub | `theorem_1_table1` | numerical | 0 | - |
+| `Buthe2016.v1` | stub | `theorem_1_table2` | numerical | 0 | - |
 | `ButheNumerics.v1` | stub | `lemma_3_constant_nonpos` | numerical | 0 | - |
 | `ButheNumerics.v1` | stub | `li_minus_pi_below_1e7` | numerical | 0 | - |
 | `ButheNumerics.v1` | stub | `lemma_3_constant_gt_at_10` | numerical | 0 | - |

--- a/docs/nodes/Buthe2016-v1.md
+++ b/docs/nodes/Buthe2016-v1.md
@@ -37,7 +37,7 @@ def theorem_2_psi : Prop :=
 |---|---|
 | Lean name | `Buthe2016.v1.theorem_2_psi` |
 | Challenge | `Buthe2016.v1.challenge_theorem_2_psi` |
-| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe2016/v1/Conclusions.lean#L60) |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe2016/v1/Conclusions.lean#L65) |
 | Evidence | cited (`literature`) |
 | Sources traced | none |
 | Assumes | nothing recorded |
@@ -64,7 +64,7 @@ def theorem_2_theta : Prop :=
 |---|---|
 | Lean name | `Buthe2016.v1.theorem_2_theta` |
 | Challenge | `Buthe2016.v1.challenge_theorem_2_theta` |
-| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe2016/v1/Conclusions.lean#L68) |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe2016/v1/Conclusions.lean#L73) |
 | Evidence | cited (`literature`) |
 | Sources traced | none |
 | Assumes | nothing recorded |
@@ -93,7 +93,7 @@ def theorem_2_li_minus_riemann_pi : Prop :=
 |---|---|
 | Lean name | `Buthe2016.v1.theorem_2_li_minus_riemann_pi` |
 | Challenge | `Buthe2016.v1.challenge_theorem_2_li_minus_riemann_pi` |
-| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe2016/v1/Conclusions.lean#L78) |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe2016/v1/Conclusions.lean#L83) |
 | Evidence | cited (`literature`) |
 | Sources traced | none |
 | Assumes | nothing recorded |
@@ -122,7 +122,7 @@ def theorem_2_li_minus_pi : Prop :=
 |---|---|
 | Lean name | `Buthe2016.v1.theorem_2_li_minus_pi` |
 | Challenge | `Buthe2016.v1.challenge_theorem_2_li_minus_pi` |
-| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe2016/v1/Conclusions.lean#L88) |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe2016/v1/Conclusions.lean#L93) |
 | Evidence | cited (`literature`) |
 | Sources traced | none |
 | Assumes | nothing recorded |
@@ -132,13 +132,70 @@ def theorem_2_li_minus_pi : Prop :=
 
 > Asserted on the authority of the paper, transcribed from arXiv:1410.7015v4. Imports none, and this is a real `none` rather than an untraced `undetermined`: Theorem 2 is stated as a conditional, universally quantified in the height T with the verification as a hypothesis, so a consumer supplies it rather than this node importing one. The paper notes that Platt's verification (T about 3.061e10) instantiates it, which is Platt2015.v1 -- but that is an instantiation a consumer makes, not a dependency of the statement. The paper's headline. Stated against li, the un-offset logarithmic integral, not Li.
 
+### `theorem_1_table1`
+
+**Theorem 1, as Table 1 records it.** If the Riemann hypothesis holds up to the row's height
+`T`, then `|ψ(x) − x| ≤ δ₀ x` for every `x ≥ e^b`.
+
+This is a different shape from Theorem 2: a plain relative error `δ₀`, not Schoenfeld's
+`√x (log x)² / (8π)`. Theorem 1 itself is parameterised by the Logan kernel; the table is the
+output the paper actually uses, and is what a consumer can cite without that vocabulary.
+
+Each `δ₀` carries `margin 0` — a site, not a weakening — because the entries are computed upper
+bounds for `e^{αε}(ℰ₁+ℰ₂+ℰ₃)`, not displayed closed forms.
+
+```lean
+def theorem_1_table1 : Prop :=
+  ∀ p ∈ table1, RiemannHypothesisUpTo p.2.1 → ∀ x : ℝ, Real.exp (p.1 : ℝ) ≤ x →
+    |Chebyshev.psi x - x| ≤ margin 0 * p.2.2 * x
+```
+
+| | |
+|---|---|
+| Lean name | `Buthe2016.v1.theorem_1_table1` |
+| Challenge | `Buthe2016.v1.challenge_theorem_1_table1` |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe2016/v1/Conclusions.lean#L106) |
+| Evidence | computation (`numerical`) |
+| Sources traced | none |
+| Assumes | nothing recorded |
+| Assumed by | nothing yet |
+
+**Justification `buthe2016-table1`** — **designated** — numerical, Theorem 1, via Table 1
+
+> The tabulated output of Theorem 1 at heights up to 3.061e10, transcribed from arXiv:1410.7015. Kind `numerical` because each delta_0 is a computed upper bound for e^{alpha epsilon}(E1+E2+E3), not a closed-form argument. Imports none: the verification height T is a hypothesis on each row, the same shape as this node's Theorem 2. The Logan-kernel statement of Theorem 1 is not recorded here -- the table is the part that can be stated without new Vocabulary. margin 0 is a site on the computed constants.
+
+### `theorem_1_table2`
+
+**Theorem 1, as Table 2 records it.** Same claim as `theorem_1_table1`, at the larger
+verification heights of the paper's Table 2 (up to `2.445 × 10¹²`).
+
+```lean
+def theorem_1_table2 : Prop :=
+  ∀ p ∈ table2, RiemannHypothesisUpTo p.2.1 → ∀ x : ℝ, Real.exp (p.1 : ℝ) ≤ x →
+    |Chebyshev.psi x - x| ≤ margin 0 * p.2.2 * x
+```
+
+| | |
+|---|---|
+| Lean name | `Buthe2016.v1.theorem_1_table2` |
+| Challenge | `Buthe2016.v1.challenge_theorem_1_table2` |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/Buthe2016/v1/Conclusions.lean#L112) |
+| Evidence | computation (`numerical`) |
+| Sources traced | traced |
+| Assumes | nothing recorded |
+| Assumed by | nothing yet |
+
+**Justification `buthe2016-table2`** — **designated** — numerical, Theorem 1, via Table 2
+
+> Same claim as theorem_1_table1, at the paper's Table 2 heights (up to 2.445e12). The paper attributes that height to Gourdon (2004). The network has no node for that computation, so the verification remains a hypothesis and the import status is `traced` rather than `none`: the input is known and named, but is not yet an edge.
+
 ## Limitations
 
 Recorded by the node itself, not derived.
 
 - Every conclusion rests on the cited paper; none is proved in Lean here.
-- All four are stated against li rather than Li, as the paper states them. A node consuming them alongside FKS2, which works with Li, must do the conversion; li 2 is about 1.045 and the bounds are of size sqrt(x) log x / (8 pi).
-- Theorem 1 of the paper, an explicit bound with a different shape, is not stated; nothing in the network consumes it yet.
+- The four Theorem 2 conclusions are stated against li rather than Li, as the paper states them. A node consuming them alongside FKS2, which works with Li, must do the conversion; li 2 is about 1.045 and the bounds are of size sqrt(x) log x / (8 pi).
+- Theorem 1 is stated through Tables 1 and 2, not in the Logan-kernel form of the theorem display. That form needs Vocabulary this node does not yet justify promoting. Table 2's height 2.445e12 is Gourdon (2004), which is not a node.
 - No novelty is claimed. The results are Buthe's.
 
 ## How this node was made

--- a/docs/nodes/README.md
+++ b/docs/nodes/README.md
@@ -10,7 +10,7 @@ One page per node: what it claims, in Lean and in prose, and everything recorded
 | [`Brown1967.v1`](Brown1967-v1.md) | paper | 0 | — |
 | [`Buthe.v1`](Buthe-v1.md) | paper | 6 | cited |
 | [`Buthe.v2`](Buthe-v2.md) | pipeline | 2 | unjustified |
-| [`Buthe2016.v1`](Buthe2016-v1.md) | paper | 4 | cited |
+| [`Buthe2016.v1`](Buthe2016-v1.md) | paper | 6 | cited |
 | [`ButheNumerics.v1`](ButheNumerics-v1.md) | computation | 3 | computation |
 | [`CH2.v1`](CH2-v1.md) | paper | 4 | cited |
 | [`CH2.v2`](CH2-v2.md) | pipeline | 2 | verified, stale |

--- a/fingerprints.json
+++ b/fingerprints.json
@@ -11,6 +11,8 @@
   "Buthe.v1.theorem_2_theta_lower": "35ce365b117b8b012e43d64b94970b2b5b9f3e259ddaec8ae8aea60725583f0e",
   "Buthe.v2.lemma_3_bounds": "a647323f6ca3162bb8aa5c46cb63f166c113d700bc764134bcc3920a81a6a247",
   "Buthe.v2.lemma_3_positivity": "b03abb3a6cdb7d4da5d9c1b9dd40f1a7ba54c776386582c9e0b31a5b46faba8f",
+  "Buthe2016.v1.theorem_1_table1": "15c897738faa02ef23e7d50a99084eadd0dcbfad8abbbfa20c45d4e62026a297",
+  "Buthe2016.v1.theorem_1_table2": "4e9396955355cbff316d36b618c92a6ec3c67e63d8f487eded10b421d6875a49",
   "Buthe2016.v1.theorem_2_li_minus_pi": "207c0810e6f0b32c2de0cdf221348833e8ef4a600e6f8a8cb7af2be923a125e3",
   "Buthe2016.v1.theorem_2_li_minus_riemann_pi": "1707a5556e79d07a87637b4794e477c34c66e17ed0c987d826a098153313aeb7",
   "Buthe2016.v1.theorem_2_psi": "63455dc36bfc713e6f49b2eff9c9168baaf82a98f123dab9f77aecb7c4c011ce",


### PR DESCRIPTION
## Summary
- Add Büthe 2016 Tables 1 and 2 as node data on `Buthe2016.v1`.
- State Theorem 1 as the table-driven relative-error bounds (not the Logan-kernel form already on other PRs).

Refs #56.

## Test plan
- [ ] `python scripts/ieantn.py check`
- [ ] CI build / fingerprint check