### PR TITLE
Record the FKS A and C rescaling gaps

### DIFF
--- a/GRAPH.md
+++ b/GRAPH.md
@@ -72,7 +72,7 @@ graph LR
   NDudekPlattNumerics_v2["<b>DudekPlattNumerics.v2</b><br/>1 claim<br/><i>weakest: computation</i>"]
   NDusart2018_v1["<b>Dusart2018.v1</b><br/>1 claim<br/><i>weakest: cited</i>"]
   NFKBJ_v1["<b>FKBJ.v1</b><br/>1 claim<br/><i>weakest: computation</i>"]
-  NFKS_v1["<b>FKS.v1</b><br/>2 claims<br/><i>weakest: cited</i>"]
+  NFKS_v1["<b>FKS.v1</b><br/>4 claims<br/><i>weakest: cited</i>"]
   NFKS2_v1["<b>FKS2.v1</b><br/>4 claims<br/><i>weakest: verified, stale</i>"]
   NFKS2_v2["<b>FKS2.v2</b><br/>2 claims<br/><i>weakest: verified, stale</i>"]
   NFKS2Numerics_v1["<b>FKS2Numerics.v1</b><br/>5 claims<br/><i>weakest: computation</i>"]
@@ -296,6 +296,8 @@ graph LR
   subgraph sgFKS_v1["FKS.v1"]
     FKS_v1_psi_bound_all_x["<b>psi_bound_all_x</b><br/><i>cited</i>"]
     FKS_v1_psi_classical_bound["<b>psi_classical_bound</b><br/><i>cited</i>"]
+    FKS_v1_rescaled_A_exceeds_printed["<b>rescaled_A_exceeds_printed</b><br/><i>computation</i>"]
+    FKS_v1_rescaled_C_is_short_of_two["<b>rescaled_C_is_short_of_two</b><br/><i>computation</i>"]
   end
   subgraph sgFKS2_v1["FKS2.v1"]
     FKS2_v1_corollary_14["<b>corollary_14</b><br/><i>verified, stale</i>"]
@@ -536,7 +538,7 @@ graph LR
   class CH2_v2_proposition_2_4_lower,CH2_v2_proposition_2_4_upper,DudekPlatt_v2_ramanujan_inequality_3915,DudekPlatt_v3_criterion,FKS2_v1_corollary_14,FKS2_v1_corollary_22,FKS2_v1_corollary_23,FKS2_v1_corollary_26,FKS2_v2_proposition_13,FKS2_v2_theorem_3,Lcm_v1_lcmUpto_not_highlyAbundant,Lcm_v2_lcmUpto_not_highlyAbundant_of_primeGap,PrimeInterval_v1_classicalBound_hasPrimeInInterval,PrimeInterval_v1_eTheta_criterion,PrimeInterval_v1_numericalBound_hasPrimeInInterval,PrimeInterval_v1_theta_characterisation,ZeroFreeHeight_v1_classical_region_descends lean_comparator_stale;
   class BKLNW_v1_corollary_5_1,BKLNW_v1_table8_psi_bound,BKLNW_v1_table8_psi_bound_above,BKLNW_v1_theta_error_le_one,Buthe_v1_theorem_2_li_gt_pi,Buthe_v1_theorem_2_li_minus_pi,Buthe_v1_theorem_2_li_minus_riemann_pi,Buthe_v1_theorem_2_psi,Buthe_v1_theorem_2_theta,Buthe_v1_theorem_2_theta_lower,Buthe2016_v1_theorem_2_li_minus_pi,Buthe2016_v1_theorem_2_li_minus_riemann_pi,Buthe2016_v1_theorem_2_psi,Buthe2016_v1_theorem_2_theta,CH2_v1_corollary_1_2_lambda_sum,CH2_v1_corollary_1_2_psi,CH2_v1_corollary_1_3_lambda_sum,CH2_v1_corollary_1_3_psi,DudekPlatt_v1_largest_counterexample_on_rh,DudekPlatt_v1_ramanujan_inequality,Dusart2018_v1_proposition_5_4,FKS_v1_psi_bound_all_x,FKS_v1_psi_classical_bound,Hiary2016_v1_zeta_half_line_bound,KLN_v1_subconvexity_bound,KLN_v1_zero_density,Kadiri2005_v1_zero_free_region,MT_v1_zero_free_region,MT_v1_zero_free_region_sharpened,PlattTrudgian_v1_rh_up_to,PlattTrudgian2021_v1_theorem_1_classical,PlattTrudgian2021_v1_theorem_1_numerical,RosserSchoenfeld_v1_zero_free_region,Trudgian2011_v1_integral_S_bound,ZeroCount_v1_rvm_error_bound,ZeroCount_v1_rvm_error_small literature;
   class Buthe_v2_lemma_3_bounds,Buthe_v2_lemma_3_positivity,ContourIntegration_v1_residue_theorem_rectangle,CotangentSeries_v1_cot_series_zeta_values,GammaAsymptotics_v1_digamma_sub_log_isBigO none_yet;
-  class ButheNumerics_v1_lemma_3_constant_gt_at_10,ButheNumerics_v1_lemma_3_constant_nonpos,ButheNumerics_v1_li_minus_pi_below_1e7,DudekPlattNumerics_v1_pi_two_sided_paper,DudekPlattNumerics_v2_pi_two_sided_pnt,FKBJ_v1_rh_up_to,FKS2Numerics_v1_corollary_22_mid_range,FKS2Numerics_v1_corollary_23_mid_range,FKS2Numerics_v1_nu_asymp_e30_le,FKS2Numerics_v1_table6_row2_floor,FKS2Numerics_v1_theta_asymp_ge_one_below_e30,LowZeroes_v1_sum_inv_ordinates_below_2e4,Platt2015_v1_rh_up_to,Platt2017_v1_rh_up_to,ZetaLogDerivValues_v1_deriv_logDeriv_neg_one,ZetaLogDerivValues_v1_logDeriv_laurent_alternating,ZetaLogDerivValues_v1_logDeriv_neg_one,ZetaLogDerivValues_v1_logDeriv_three_halves,ZetaLogDerivValues_v1_logDeriv_two numerical;
+  class ButheNumerics_v1_lemma_3_constant_gt_at_10,ButheNumerics_v1_lemma_3_constant_nonpos,ButheNumerics_v1_li_minus_pi_below_1e7,DudekPlattNumerics_v1_pi_two_sided_paper,DudekPlattNumerics_v2_pi_two_sided_pnt,FKBJ_v1_rh_up_to,FKS_v1_rescaled_A_exceeds_printed,FKS_v1_rescaled_C_is_short_of_two,FKS2Numerics_v1_corollary_22_mid_range,FKS2Numerics_v1_corollary_23_mid_range,FKS2Numerics_v1_nu_asymp_e30_le,FKS2Numerics_v1_table6_row2_floor,FKS2Numerics_v1_theta_asymp_ge_one_below_e30,LowZeroes_v1_sum_inv_ordinates_below_2e4,Platt2015_v1_rh_up_to,Platt2017_v1_rh_up_to,ZetaLogDerivValues_v1_deriv_logDeriv_neg_one,ZetaLogDerivValues_v1_logDeriv_laurent_alternating,ZetaLogDerivValues_v1_logDeriv_neg_one,ZetaLogDerivValues_v1_logDeriv_three_halves,ZetaLogDerivValues_v1_logDeriv_two numerical;
   click BKLNW_v1_corollary_5_1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#corollary_5_1" _blank
   click BKLNW_v1_table8_psi_bound href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#table8_psi_bound" _blank
   click BKLNW_v1_table8_psi_bound_above href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#table8_psi_bound_above" _blank
@@ -578,6 +580,8 @@ graph LR
   click FKBJ_v1_rh_up_to href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/FKBJ-v1.md#rh_up_to" _blank
   click FKS_v1_psi_bound_all_x href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/FKS-v1.md#psi_bound_all_x" _blank
   click FKS_v1_psi_classical_bound href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/FKS-v1.md#psi_classical_bound" _blank
+  click FKS_v1_rescaled_A_exceeds_printed href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/FKS-v1.md#rescaled_A_exceeds_printed" _blank
+  click FKS_v1_rescaled_C_is_short_of_two href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/FKS-v1.md#rescaled_C_is_short_of_two" _blank
   click FKS2_v1_corollary_14 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/FKS2-v1.md#corollary_14" _blank
   click FKS2_v1_corollary_22 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/FKS2-v1.md#corollary_22" _blank
   click FKS2_v1_corollary_23 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/FKS2-v1.md#corollary_23" _blank
@@ -732,6 +736,10 @@ A line is one claim, indented under whatever assumes it.
       - [`Wedeniwski.v1.rh_up_to`](docs/nodes/Wedeniwski-v1.md#rh_up_to) — asserted — *sources not traced*
     - [`PlattTrudgian.v1.rh_up_to`](docs/nodes/PlattTrudgian-v1.md#rh_up_to) — cited — *sources known, not all drawable*
   - [`PlattTrudgian.v1.rh_up_to`](docs/nodes/PlattTrudgian-v1.md#rh_up_to) — cited *(above)* — *sources known, not all drawable*
+
+- [`FKS.v1.rescaled_A_exceeds_printed`](docs/nodes/FKS-v1.md#rescaled_A_exceeds_printed) — computation
+
+- [`FKS.v1.rescaled_C_is_short_of_two`](docs/nodes/FKS-v1.md#rescaled_C_is_short_of_two) — computation
 
 - [`FKS2.v1.corollary_14`](docs/nodes/FKS2-v1.md#corollary_14) — verified, stale
   - [`FKS.v1.psi_classical_bound`](docs/nodes/FKS-v1.md#psi_classical_bound) — cited
@@ -938,6 +946,8 @@ rather than maintained.
 | [`DudekPlatt.v1.largest_counterexample_on_rh`](docs/nodes/DudekPlatt-v1.md#largest_counterexample_on_rh) | cited | 0 | known, not all drawable |
 | [`DudekPlatt.v1.ramanujan_inequality`](docs/nodes/DudekPlatt-v1.md#ramanujan_inequality) | cited | 0 | traced |
 | [`FKS.v1.psi_bound_all_x`](docs/nodes/FKS-v1.md#psi_bound_all_x) | cited | 0 | traced |
+| [`FKS.v1.rescaled_A_exceeds_printed`](docs/nodes/FKS-v1.md#rescaled_A_exceeds_printed) | computation | 0 | none |
+| [`FKS.v1.rescaled_C_is_short_of_two`](docs/nodes/FKS-v1.md#rescaled_C_is_short_of_two) | computation | 0 | none |
 | [`GammaAsymptotics.v1.digamma_sub_log_isBigO`](docs/nodes/GammaAsymptotics-v1.md#digamma_sub_log_isBigO) | unjustified | 0 | none |
 | [`LowZeroes.v1.sum_inv_ordinates_below_2e4`](docs/nodes/LowZeroes-v1.md#sum_inv_ordinates_below_2e4) | computation | 0 | none |
 | [`PlattTrudgian2021.v1.theorem_1_classical`](docs/nodes/PlattTrudgian2021-v1.md#theorem_1_classical) | cited | 0 | traced |

--- a/IEANTN/Nodes/FKS/v1/Challenge.lean
+++ b/IEANTN/Nodes/FKS/v1/Challenge.lean
@@ -32,3 +32,9 @@ theorem FKS.v1.challenge_psi_classical_bound
     (platttrudgian_v1_rh_up_to : PlattTrudgian.v1.rh_up_to) :
     FKS.v1.psi_classical_bound := by
   sorry
+
+theorem FKS.v1.challenge_rescaled_A_exceeds_printed : FKS.v1.rescaled_A_exceeds_printed := by
+  sorry
+
+theorem FKS.v1.challenge_rescaled_C_is_short_of_two : FKS.v1.rescaled_C_is_short_of_two := by
+  sorry

--- a/IEANTN/Nodes/FKS/v1/Conclusions.lean
+++ b/IEANTN/Nodes/FKS/v1/Conclusions.lean
@@ -53,6 +53,9 @@ A note here once put the rescaled `A` at `≈ 121.0916` and called the discrepan
 figure was wrong — it is `121.09602` — and so was the gloss: the difference is not a benign
 rounding but a gap in the direction that breaks the derivation.
 
+The two conclusions `rescaled_A_exceeds_printed` and `rescaled_C_is_short_of_two` record those
+gaps as claims rather than only as comments.
+
 Keeping the printed form means the transcription can be checked against the paper by eye. -/
 def psi_bound_all_x : Prop :=
   ∀ x > (2 : ℝ), Eψ x < 9.22022 * (Real.log x) ^ ((3 : ℝ) / 2) *

--- a/IEANTN/Nodes/FKS/v1/Conclusions.lean
+++ b/IEANTN/Nodes/FKS/v1/Conclusions.lean
@@ -76,4 +76,19 @@ re-run. -/
 def psi_classical_bound : Prop :=
   HasClassicalBound Eψ 121.096 (3 / 2) 2 5.5666305 (Real.exp 30)
 
+/-- Rescaling the all-`x` bound into the `R = 5.5666305` shape overshoots the printed `A`.
+
+`9.22022 · R^{3/2} = 121.09602174… > 121.096`. So the printed classical constant is *not*
+the rescaling of Corollary 1.4, and a derivation that treats it as one fails. Recorded as a
+conclusion so the gap is a claim, not only a docstring. -/
+def rescaled_A_exceeds_printed : Prop :=
+  (9.22022 : ℝ) * (5.5666305 : ℝ) ^ ((3 : ℝ) / 2) > 121.096
+
+/-- The matching gap in `C`: `0.8476836 · √R = 1.99999992… < 2`.
+
+A larger `C` is a stronger decay, so the printed `C = 2` is again a strengthening of the
+rescaling, not a rounding of it. -/
+def rescaled_C_is_short_of_two : Prop :=
+  (0.8476836 : ℝ) * Real.sqrt 5.5666305 < 2
+
 end FKS.v1

--- a/IEANTN/Nodes/FKS/v1/formalization.yaml
+++ b/IEANTN/Nodes/FKS/v1/formalization.yaml
@@ -41,7 +41,7 @@ conclusions:
   - id: fks-paper
     kind: literature
     source: FKS
-    locator: arXiv:2204.02588v2, Corollary 1.4
+    locator: arXiv:2204.02588v2, Corollary 1.4 (preprint numbering, checked)
     note: >-
       Asserted on the authority of the paper, and transcribed from the preprint in the paper's own normalisation
       rather than converted to the admissible-bound shape. The conversion is not free: with R = 5.5666305
@@ -109,6 +109,36 @@ conclusions:
   designated: fks-paper
 
   imports_status: identified
+- id: rescaled_A_exceeds_printed
+  declaration: FKS.v1.rescaled_A_exceeds_printed
+  challenge: FKS.v1.challenge_rescaled_A_exceeds_printed
+  imports: []
+  imports_status: none
+  justifications:
+  - id: fks-rescaling-A
+    kind: numerical
+    source: FKS
+    locator: Corollary 1.4 versus the printed A = 121.096
+    note: >-
+      Closed-form comparison of the two printed constants at R = 5.5666305. Imports none. This is the
+      A-gap recorded on psi_bound_all_x: the rescaling overshoots 121.096, so the classical bound is
+      not derivable from the all-x bound by converting R. The preprint's proof of Corollary 1.4 checks
+      the other direction, 121.096 / R^{3/2} < 9.22022, which is the same inequality.
+  designated: fks-rescaling-A
+- id: rescaled_C_is_short_of_two
+  declaration: FKS.v1.rescaled_C_is_short_of_two
+  challenge: FKS.v1.challenge_rescaled_C_is_short_of_two
+  imports: []
+  imports_status: none
+  justifications:
+  - id: fks-rescaling-C
+    kind: numerical
+    source: FKS
+    locator: Corollary 1.4 versus the printed C = 2
+    note: >-
+      The companion gap in C. 0.8476836 * sqrt(R) is strictly less than 2, so the printed classical
+      decay is a strengthening of the rescaling rather than a rounding of it.
+  designated: fks-rescaling-C
 sources:
 - title: "Sharper bounds for the Chebyshev function psi(x)"
   authors: ["Andrew Fiori", "Habiba Kadiri", "Joshua Swidinsky"]
@@ -140,9 +170,12 @@ limitations:
 - >-
   Both conclusions rest on the cited paper; neither is proved in Lean here.
 - >-
-  The preprint and the published version number their results differently, and the second conclusion's
-  locator is taken from FKS2's citation rather than read directly. It is flagged for confirmation in the
-  node and in the module docstring.
+  The preprint (arXiv:2204.02588v2) numbers the all-x bound as Corollary 1.4; that is now checked
+  against the rendered preprint. The second conclusion's locator remains FKS2's "[8, Corollary 1.3]"
+  for the published numbering, which the preprint does not use.
+- >-
+  psi_classical_bound is not derivable from psi_bound_all_x by rescaling at R = 5.5666305. The two
+  new conclusions record the A and C gaps as claims.
 - >-
   R = 5.5666305 is not this paper's constant but Mossinghoff and Trudgian's, J. Number Theory 157 (2015).
   A sharper value is available from MTY.v1 and is the first thing to change when the chain is re-run.

--- a/STATE.md
+++ b/STATE.md
@@ -7,7 +7,7 @@ column says what a receipt is presently worth, not merely what was claimed for i
 reason a receipt has stopped standing is below, and `python scripts/ieantn.py status`
 adds the environment detail.
 
-47 node version(s), 91 conclusion(s).  3 state nothing yet.
+47 node version(s), 93 conclusion(s).  3 state nothing yet.
 
 ## Evidence
 
@@ -18,7 +18,7 @@ adds the environment detail.
 | `lean-comparator` | 29 |
 | `literature` | 36 |
 | `none-yet` | 5 |
-| `numerical` | 19 |
+| `numerical` | 21 |
 
 ## Nodes
 
@@ -67,6 +67,8 @@ adds the environment detail.
 | `FKBJ.v1` | active | `rh_up_to` | numerical | 0 | - |
 | `FKS.v1` | active | `psi_bound_all_x` | literature | 3 | - |
 | `FKS.v1` | active | `psi_classical_bound` | literature | 3 | - |
+| `FKS.v1` | active | `rescaled_A_exceeds_printed` | numerical | 0 | - |
+| `FKS.v1` | active | `rescaled_C_is_short_of_two` | numerical | 0 | - |
 | `FKS2.v1` | active | `corollary_14` | lean-comparator-stale | 6 | - |
 | `FKS2.v1` | active | `corollary_22` | lean-comparator-stale | 8 | - |
 | `FKS2.v1` | active | `corollary_23` | lean-comparator-stale | 10 | - |

--- a/docs/nodes/FKS-v1.md
+++ b/docs/nodes/FKS-v1.md
@@ -59,7 +59,7 @@ def psi_bound_all_x : Prop :=
 | Assumes | [`KLN.v1.subconvexity_bound`](KLN-v1.md#subconvexity_bound), [`MT.v1.zero_free_region_sharpened`](MT-v1.md#zero_free_region_sharpened), [`PlattTrudgian.v1.rh_up_to`](PlattTrudgian-v1.md#rh_up_to) |
 | Assumed by | nothing yet |
 
-**Justification `fks-paper`** — **designated** — literature, arXiv:2204.02588v2, Corollary 1.4
+**Justification `fks-paper`** — **designated** — literature, arXiv:2204.02588v2, Corollary 1.4 (preprint numbering, checked)
 
 > Asserted on the authority of the paper, and transcribed from the preprint in the paper's own normalisation rather than converted to the admissible-bound shape. The conversion is not free: with R = 5.5666305 it gives A = 9.22022 * R^(3/2) = 121.09602174... and C = 0.8476836 * sqrt(R) = 1.99999992..., so the printed 121.096 / C = 2 are strengthenings rather than benign rounding versus this rescaling. Imports: Settled against the published version (J. Math. Anal. Appl. 527 (2023) 127426). FKS names three inputs: the verification height H0 = 3 x 10^12 from Platt and Trudgian, the zero-free region R = 5.5666305 from Mossinghoff and Trudgian, and a zero-density bound for N-tilde(sigma, T) of the shape (2.6) from Kadiri, Lumley and Ng [18], the published J. Math. Anal. Appl. 465 (2018) paper that KLN.v1 records. The first two are recorded as edges. The third is now recorded too, at the point where the error FKS reports actually bites: KLN.v1 states the subconvexity bound of its Lemma 3.2 with FKS's corrected constant 0.77 rather than the printed 0.63, which is the value FKS itself uses. KLN's Theorem 1.1 and its numerical density tables remain unstated, because their constants were computed with the erroneous value and nobody has published recomputed ones. FKS's other Kadiri-Lumley-Ng reference [19], the unpublished preprint 'Bounding psi(x) with zero-density', is NOT an input: Lemma 2.5, the sums-over-zeros estimate, is proved in FKS itself and the preprint is cited as attribution. It is background, not an edge. Absolute values, checked against the rendered page. FKS (1.1) defines E_psi(x) = \|(psi(x) - x)/x\| and FKS2 (1) and (2) define E_pi, E_theta and E_psi the same way, all with bars, exactly as this network's Vocabulary does. An earlier note here claimed the papers defined these signed and that the conclusions were therefore stronger than the printed corollaries; that was wrong. PDF text extraction silently drops absolute-value bars around a displayed fraction, and the definitions were read from extracted text. They have since been read from the rendered page, where the bars are plainly there. Nothing about the statements needed to change.
 
@@ -100,12 +100,66 @@ def psi_classical_bound : Prop :=
 
 > Asserted on the authority of the paper. Transcribed from FKS2's proof of its Corollary 14, which quotes A = 121.096, B = 3/2, C = 2, R = 5.5666305 for x >= e^30 and attributes them to [8, Corollary 1.3]. The arXiv preprint numbers its results differently -- its Corollary 1.3 is a remark -- and tabulates A(x0) only for log x0 > 1000, so the value at e^30 could not be checked against the version to hand. CONFIRM the locator and the constant against the published J. Math. Anal. Appl. version before relying on this. Imports: Settled against the published version (J. Math. Anal. Appl. 527 (2023) 127426). FKS names three inputs: the verification height H0 = 3 x 10^12 from Platt and Trudgian, the zero-free region R = 5.5666305 from Mossinghoff and Trudgian, and a zero-density bound for N-tilde(sigma, T) of the shape (2.6) from Kadiri, Lumley and Ng [18], the published J. Math. Anal. Appl. 465 (2018) paper that KLN.v1 records. The first two are recorded as edges. The third is now recorded too, at the point where the error FKS reports actually bites: KLN.v1 states the subconvexity bound of its Lemma 3.2 with FKS's corrected constant 0.77 rather than the printed 0.63, which is the value FKS itself uses. KLN's Theorem 1.1 and its numerical density tables remain unstated, because their constants were computed with the erroneous value and nobody has published recomputed ones. FKS's other Kadiri-Lumley-Ng reference [19], the unpublished preprint 'Bounding psi(x) with zero-density', is NOT an input: Lemma 2.5, the sums-over-zeros estimate, is proved in FKS itself and the preprint is cited as attribution. It is background, not an edge. Absolute values, checked against the rendered page. FKS (1.1) defines E_psi(x) = \|(psi(x) - x)/x\| and FKS2 (1) and (2) define E_pi, E_theta and E_psi the same way, all with bars, exactly as this network's Vocabulary does. An earlier note here claimed the papers defined these signed and that the conclusions were therefore stronger than the printed corollaries; that was wrong. PDF text extraction silently drops absolute-value bars around a displayed fraction, and the definitions were read from extracted text. They have since been read from the rendered page, where the bars are plainly there. Nothing about the statements needed to change.
 
+### `rescaled_A_exceeds_printed`
+
+Rescaling the all-`x` bound into the `R = 5.5666305` shape overshoots the printed `A`.
+
+`9.22022 · R^{3/2} = 121.09602174… > 121.096`. So the printed classical constant is *not*
+the rescaling of Corollary 1.4, and a derivation that treats it as one fails. Recorded as a
+conclusion so the gap is a claim, not only a docstring.
+
+```lean
+def rescaled_A_exceeds_printed : Prop :=
+  (9.22022 : ℝ) * (5.5666305 : ℝ) ^ ((3 : ℝ) / 2) > 121.096
+```
+
+| | |
+|---|---|
+| Lean name | `FKS.v1.rescaled_A_exceeds_printed` |
+| Challenge | `FKS.v1.challenge_rescaled_A_exceeds_printed` |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L84) |
+| Evidence | computation (`numerical`) |
+| Sources traced | none |
+| Assumes | nothing recorded |
+| Assumed by | nothing yet |
+
+**Justification `fks-rescaling-A`** — **designated** — numerical, Corollary 1.4 versus the printed A = 121.096
+
+> Closed-form comparison of the two printed constants at R = 5.5666305. Imports none. This is the A-gap recorded on psi_bound_all_x: the rescaling overshoots 121.096, so the classical bound is not derivable from the all-x bound by converting R. The preprint's proof of Corollary 1.4 checks the other direction, 121.096 / R^{3/2} < 9.22022, which is the same inequality.
+
+### `rescaled_C_is_short_of_two`
+
+The matching gap in `C`: `0.8476836 · √R = 1.99999992… < 2`.
+
+A larger `C` is a stronger decay, so the printed `C = 2` is again a strengthening of the
+rescaling, not a rounding of it.
+
+```lean
+def rescaled_C_is_short_of_two : Prop :=
+  (0.8476836 : ℝ) * Real.sqrt 5.5666305 < 2
+```
+
+| | |
+|---|---|
+| Lean name | `FKS.v1.rescaled_C_is_short_of_two` |
+| Challenge | `FKS.v1.challenge_rescaled_C_is_short_of_two` |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L91) |
+| Evidence | computation (`numerical`) |
+| Sources traced | none |
+| Assumes | nothing recorded |
+| Assumed by | nothing yet |
+
+**Justification `fks-rescaling-C`** — **designated** — numerical, Corollary 1.4 versus the printed C = 2
+
+> The companion gap in C. 0.8476836 * sqrt(R) is strictly less than 2, so the printed classical decay is a strengthening of the rescaling rather than a rounding of it.
+
 ## Limitations
 
 Recorded by the node itself, not derived.
 
 - Both conclusions rest on the cited paper; neither is proved in Lean here.
-- The preprint and the published version number their results differently, and the second conclusion's locator is taken from FKS2's citation rather than read directly. It is flagged for confirmation in the node and in the module docstring.
+- The preprint (arXiv:2204.02588v2) numbers the all-x bound as Corollary 1.4; that is now checked against the rendered preprint. The second conclusion's locator remains FKS2's "[8, Corollary 1.3]" for the published numbering, which the preprint does not use.
+- psi_classical_bound is not derivable from psi_bound_all_x by rescaling at R = 5.5666305. The two new conclusions record the A and C gaps as claims.
 - R = 5.5666305 is not this paper's constant but Mossinghoff and Trudgian's, J. Number Theory 157 (2015). A sharper value is available from MTY.v1 and is the first thing to change when the chain is re-run.
 - No novelty is claimed. The results are Fiori, Kadiri and Swidinsky's.
 

--- a/docs/nodes/FKS-v1.md
+++ b/docs/nodes/FKS-v1.md
@@ -41,6 +41,9 @@ A note here once put the rescaled `A` at `≈ 121.0916` and called the discrepan
 figure was wrong — it is `121.09602` — and so was the gloss: the difference is not a benign
 rounding but a gap in the direction that breaks the derivation.
 
+The two conclusions `rescaled_A_exceeds_printed` and `rescaled_C_is_short_of_two` record those
+gaps as claims rather than only as comments.
+
 Keeping the printed form means the transcription can be checked against the paper by eye.
 
 ```lean
@@ -53,7 +56,7 @@ def psi_bound_all_x : Prop :=
 |---|---|
 | Lean name | `FKS.v1.psi_bound_all_x` |
 | Challenge | `FKS.v1.challenge_psi_bound_all_x` |
-| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L57) |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L60) |
 | Evidence | cited (`literature`) |
 | Sources traced | identified |
 | Assumes | [`KLN.v1.subconvexity_bound`](KLN-v1.md#subconvexity_bound), [`MT.v1.zero_free_region_sharpened`](MT-v1.md#zero_free_region_sharpened), [`PlattTrudgian.v1.rh_up_to`](PlattTrudgian-v1.md#rh_up_to) |
@@ -90,7 +93,7 @@ def psi_classical_bound : Prop :=
 |---|---|
 | Lean name | `FKS.v1.psi_classical_bound` |
 | Challenge | `FKS.v1.challenge_psi_classical_bound` |
-| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L76) |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L79) |
 | Evidence | cited (`literature`) |
 | Sources traced | identified |
 | Assumes | [`KLN.v1.subconvexity_bound`](KLN-v1.md#subconvexity_bound), [`MT.v1.zero_free_region_sharpened`](MT-v1.md#zero_free_region_sharpened), [`PlattTrudgian.v1.rh_up_to`](PlattTrudgian-v1.md#rh_up_to) |
@@ -117,7 +120,7 @@ def rescaled_A_exceeds_printed : Prop :=
 |---|---|
 | Lean name | `FKS.v1.rescaled_A_exceeds_printed` |
 | Challenge | `FKS.v1.challenge_rescaled_A_exceeds_printed` |
-| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L84) |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L87) |
 | Evidence | computation (`numerical`) |
 | Sources traced | none |
 | Assumes | nothing recorded |
@@ -143,7 +146,7 @@ def rescaled_C_is_short_of_two : Prop :=
 |---|---|
 | Lean name | `FKS.v1.rescaled_C_is_short_of_two` |
 | Challenge | `FKS.v1.challenge_rescaled_C_is_short_of_two` |
-| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L91) |
+| Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/FKS/v1/Conclusions.lean#L94) |
 | Evidence | computation (`numerical`) |
 | Sources traced | none |
 | Assumes | nothing recorded |

--- a/docs/nodes/README.md
+++ b/docs/nodes/README.md
@@ -26,7 +26,7 @@ One page per node: what it claims, in Lean and in prose, and everything recorded
 | [`DudekPlattNumerics.v2`](DudekPlattNumerics-v2.md) | computation | 1 | computation |
 | [`Dusart2018.v1`](Dusart2018-v1.md) | paper | 1 | cited |
 | [`FKBJ.v1`](FKBJ-v1.md) | computation | 1 | computation |
-| [`FKS.v1`](FKS-v1.md) | paper | 2 | cited |
+| [`FKS.v1`](FKS-v1.md) | paper | 4 | cited |
 | [`FKS2.v1`](FKS2-v1.md) | paper | 4 | verified, stale |
 | [`FKS2.v2`](FKS2-v2.md) | pipeline | 2 | verified, stale |
 | [`FKS2Numerics.v1`](FKS2Numerics-v1.md) | computation | 5 | computation |

--- a/fingerprints.json
+++ b/fingerprints.json
@@ -40,6 +40,8 @@
   "FKBJ.v1.rh_up_to": "a0e3f733f20d8df755c8016cd0e4509a233411a168cd2fd6cb4fc3ccb5918698",
   "FKS.v1.psi_bound_all_x": "f5963ba07855070c1cabac8cd3c5e22dc810b0d9b4acd4761bd28321646ad4ef",
   "FKS.v1.psi_classical_bound": "d42b43ed3148a6b9108804a3b64ca7cb37c4f909dd06606428700d7f32f39d54",
+  "FKS.v1.rescaled_A_exceeds_printed": "cca8506d3e40ba3a39e3bd091f98354b0ce96b25d35bdf50392bcb7324ed6601",
+  "FKS.v1.rescaled_C_is_short_of_two": "6daf19b9be841ab2d9bb79c3f651bc5504a47954c549877f548166f7edfeed59",
   "FKS2.v1.corollary_14": "16fe74e035b77aff8ccd9a02ecd9092d834b22b239894a2d0c10cb8455360a0b",
   "FKS2.v1.corollary_22": "e9ceaee5c7cdc90a04c7b7723c6a4236500c3cfa2ff085e72dd87e161435c87c",
   "FKS2.v1.corollary_23": "a4e8b9028e790796ea6cfd90000b6a6c8128a62bc8b12351cc4986cd3483380a",


### PR DESCRIPTION
## Summary
- State that the rescaled FKS constant A overshoots the printed 121.096, and that rescaled C falls short of 2.
- Leave `psi_classical_bound` as on main (FKS2 receipts).

Refs #52.

## Test plan
- [ ] `python scripts/ieantn.py check`
- [ ] CI build / fingerprint check