### PR TITLE
Record the verification receipt for ZetaZeroes.v1

### DIFF
--- a/GRAPH.md
+++ b/GRAPH.md
@@ -96,7 +96,7 @@ graph LR
   NZeroCount_v1["<b>ZeroCount.v1</b><br/>2 claims<br/><i>weakest: cited</i>"]
   NZeroFreeHeight_v1["<b>ZeroFreeHeight.v1</b><br/>1 claim<br/><i>weakest: verified, stale</i>"]
   NZetaLogDeriv_v1["<b>ZetaLogDeriv.v1</b><br/>1 claim<br/><i>weakest: verified</i>"]
-  NZetaZeroes_v1["<b>ZetaZeroes.v1</b><br/>6 claims<br/><i>weakest: unjustified</i>"]
+  NZetaZeroes_v1["<b>ZetaZeroes.v1</b><br/>6 claims<br/><i>weakest: verified</i>"]
   NBKLNW_v1 -->|8| NFKS2_v1
   NButhe_v1 -->|2| NBKLNW_v1
   NButhe_v2 -->|2| NButhe_v1
@@ -147,13 +147,13 @@ graph LR
   style NRosserSchoenfeld_v1 stroke-dasharray: 2 3;
   style NTrudgian2011_v1 stroke-dasharray: 2 3;
   style NWedeniwski_v1 stroke-dasharray: 2 3;
-  class NBrown1967_v1,NButhe_v2,NChengGraham2004_v1,NContourIntegration_v1,NGammaAsymptotics_v1,NMTY_v1,NZetaZeroes_v1 none_yet;
+  class NBrown1967_v1,NButhe_v2,NChengGraham2004_v1,NContourIntegration_v1,NGammaAsymptotics_v1,NMTY_v1 none_yet;
   class NCH2_v4 lean_comparator_drifted;
   class NWedeniwski_v1 asserted;
   class NBKLNW_v1,NButhe_v1,NButhe2016_v1,NCH2_v1,NDudekPlatt_v1,NDusart2018_v1,NFKS_v1,NHiary2016_v1,NKLN_v1,NKadiri2005_v1,NMT_v1,NPlattTrudgian_v1,NPlattTrudgian2021_v1,NRosserSchoenfeld_v1,NTrudgian2011_v1,NZeroCount_v1 literature;
   class NButheNumerics_v1,NDudekPlattNumerics_v1,NDudekPlattNumerics_v2,NFKBJ_v1,NFKS2Numerics_v1,NLowZeroes_v1,NPlatt2015_v1,NPlatt2017_v1 numerical;
   class NCH2_v2,NDudekPlatt_v2,NDudekPlatt_v3,NFKS2_v1,NFKS2_v2,NLcm_v1,NLcm_v2,NPrimeInterval_v1,NZeroFreeHeight_v1 lean_comparator_stale;
-  class NCH2_v3,NGammaAsymptotics_v2,NZetaLogDeriv_v1 lean_comparator;
+  class NCH2_v3,NGammaAsymptotics_v2,NZetaLogDeriv_v1,NZetaZeroes_v1 lean_comparator;
   click NBKLNW_v1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md" _blank
   click NButhe_v1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe-v1.md" _blank
   click NButhe_v2 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/Buthe-v2.md" _blank
@@ -375,12 +375,12 @@ graph LR
     ZetaLogDeriv_v1_logDeriv_functional_equation["<b>logDeriv_functional_equation</b><br/><i>verified</i>"]
   end
   subgraph sgZetaZeroes_v1["ZetaZeroes.v1"]
-    ZetaZeroes_v1_exists_ordinate_free_height["<b>exists_ordinate_free_height</b><br/><i>unjustified</i>"]
-    ZetaZeroes_v1_finite_zeroes_on_compact["<b>finite_zeroes_on_compact</b><br/><i>unjustified</i>"]
-    ZetaZeroes_v1_no_nontrivial_zeroes_left["<b>no_nontrivial_zeroes_left</b><br/><i>unjustified</i>"]
-    ZetaZeroes_v1_zeroes_off_axis_in_strip["<b>zeroes_off_axis_in_strip</b><br/><i>unjustified</i>"]
-    ZetaZeroes_v1_zeta_eq_zero_iff_zeta1["<b>zeta_eq_zero_iff_zeta1</b><br/><i>unjustified</i>"]
-    ZetaZeroes_v1_zeta_eq_zeta1_div["<b>zeta_eq_zeta1_div</b><br/><i>unjustified</i>"]
+    ZetaZeroes_v1_exists_ordinate_free_height["<b>exists_ordinate_free_height</b><br/><i>verified</i>"]
+    ZetaZeroes_v1_finite_zeroes_on_compact["<b>finite_zeroes_on_compact</b><br/><i>verified</i>"]
+    ZetaZeroes_v1_no_nontrivial_zeroes_left["<b>no_nontrivial_zeroes_left</b><br/><i>verified</i>"]
+    ZetaZeroes_v1_zeroes_off_axis_in_strip["<b>zeroes_off_axis_in_strip</b><br/><i>verified</i>"]
+    ZetaZeroes_v1_zeta_eq_zero_iff_zeta1["<b>zeta_eq_zero_iff_zeta1</b><br/><i>verified</i>"]
+    ZetaZeroes_v1_zeta_eq_zeta1_div["<b>zeta_eq_zeta1_div</b><br/><i>verified</i>"]
   end
   Buthe_v1_theorem_2_theta_lower --> BKLNW_v1_corollary_5_1
   Buthe2016_v1_theorem_2_psi --> BKLNW_v1_table8_psi_bound
@@ -514,11 +514,11 @@ graph LR
   class BRLcm_v1_lcmUpto_not_highlyAbundant__bridge_from_v2,BRPlatt2015_v1_rh_up_to__bridge_from_platt2017,BRRosserSchoenfeld_v1_zero_free_region_classical__bridge_from_shape,BRWedeniwski_v1_rh_up_to__bridge_from_platt2017 bridge;
   class Wedeniwski_v1_rh_up_to asserted;
   class RosserSchoenfeld_v1_zero_free_region_classical bridged;
-  class CH2_v3_extremal_majorant,CH2_v3_extremal_minorant,GammaAsymptotics_v2_digamma_sub_log_isBigO_strip,ZetaLogDeriv_v1_logDeriv_functional_equation lean_comparator;
+  class CH2_v3_extremal_majorant,CH2_v3_extremal_minorant,GammaAsymptotics_v2_digamma_sub_log_isBigO_strip,ZetaLogDeriv_v1_logDeriv_functional_equation,ZetaZeroes_v1_exists_ordinate_free_height,ZetaZeroes_v1_finite_zeroes_on_compact,ZetaZeroes_v1_no_nontrivial_zeroes_left,ZetaZeroes_v1_zeroes_off_axis_in_strip,ZetaZeroes_v1_zeta_eq_zero_iff_zeta1,ZetaZeroes_v1_zeta_eq_zeta1_div lean_comparator;
   class CH2_v4_contour_shift,CH2_v4_contour_shift_holomorphic lean_comparator_drifted;
   class CH2_v2_proposition_2_4_lower,CH2_v2_proposition_2_4_upper,DudekPlatt_v2_ramanujan_inequality_3915,DudekPlatt_v3_criterion,FKS2_v1_corollary_14,FKS2_v1_corollary_22,FKS2_v1_corollary_23,FKS2_v1_corollary_26,FKS2_v2_proposition_13,FKS2_v2_theorem_3,Lcm_v1_lcmUpto_not_highlyAbundant,Lcm_v2_lcmUpto_not_highlyAbundant_of_primeGap,PrimeInterval_v1_classicalBound_hasPrimeInInterval,PrimeInterval_v1_eTheta_criterion,PrimeInterval_v1_numericalBound_hasPrimeInInterval,PrimeInterval_v1_theta_characterisation,ZeroFreeHeight_v1_classical_region_descends lean_comparator_stale;
   class BKLNW_v1_corollary_5_1,BKLNW_v1_table8_psi_bound,BKLNW_v1_table8_psi_bound_above,BKLNW_v1_theta_error_le_one,Buthe_v1_theorem_2_li_gt_pi,Buthe_v1_theorem_2_li_minus_pi,Buthe_v1_theorem_2_li_minus_riemann_pi,Buthe_v1_theorem_2_psi,Buthe_v1_theorem_2_theta,Buthe_v1_theorem_2_theta_lower,Buthe2016_v1_theorem_2_li_minus_pi,Buthe2016_v1_theorem_2_li_minus_riemann_pi,Buthe2016_v1_theorem_2_psi,Buthe2016_v1_theorem_2_theta,CH2_v1_corollary_1_2_lambda_sum,CH2_v1_corollary_1_2_psi,CH2_v1_corollary_1_3_lambda_sum,CH2_v1_corollary_1_3_psi,DudekPlatt_v1_largest_counterexample_on_rh,DudekPlatt_v1_ramanujan_inequality,Dusart2018_v1_proposition_5_4,FKS_v1_psi_bound_all_x,FKS_v1_psi_classical_bound,Hiary2016_v1_zeta_half_line_bound,KLN_v1_subconvexity_bound,KLN_v1_zero_density,Kadiri2005_v1_zero_free_region,MT_v1_zero_free_region,MT_v1_zero_free_region_sharpened,PlattTrudgian_v1_rh_up_to,PlattTrudgian2021_v1_theorem_1_classical,PlattTrudgian2021_v1_theorem_1_numerical,RosserSchoenfeld_v1_zero_free_region,Trudgian2011_v1_integral_S_bound,ZeroCount_v1_rvm_error_bound,ZeroCount_v1_rvm_error_small literature;
-  class Buthe_v2_lemma_3_bounds,Buthe_v2_lemma_3_positivity,ContourIntegration_v1_residue_theorem_rectangle,GammaAsymptotics_v1_digamma_sub_log_isBigO,ZetaZeroes_v1_exists_ordinate_free_height,ZetaZeroes_v1_finite_zeroes_on_compact,ZetaZeroes_v1_no_nontrivial_zeroes_left,ZetaZeroes_v1_zeroes_off_axis_in_strip,ZetaZeroes_v1_zeta_eq_zero_iff_zeta1,ZetaZeroes_v1_zeta_eq_zeta1_div none_yet;
+  class Buthe_v2_lemma_3_bounds,Buthe_v2_lemma_3_positivity,ContourIntegration_v1_residue_theorem_rectangle,GammaAsymptotics_v1_digamma_sub_log_isBigO none_yet;
   class ButheNumerics_v1_lemma_3_constant_gt_at_10,ButheNumerics_v1_lemma_3_constant_nonpos,ButheNumerics_v1_li_minus_pi_below_1e7,DudekPlattNumerics_v1_pi_two_sided_paper,DudekPlattNumerics_v2_pi_two_sided_pnt,FKBJ_v1_rh_up_to,FKS2Numerics_v1_corollary_22_mid_range,FKS2Numerics_v1_corollary_23_mid_range,FKS2Numerics_v1_nu_asymp_e30_le,FKS2Numerics_v1_table6_row2_floor,FKS2Numerics_v1_theta_asymp_ge_one_below_e30,LowZeroes_v1_sum_inv_ordinates_below_2e4,Platt2015_v1_rh_up_to,Platt2017_v1_rh_up_to numerical;
   click BKLNW_v1_corollary_5_1 href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#corollary_5_1" _blank
   click BKLNW_v1_table8_psi_bound href "https://github.com/teorth/IEANTN/blob/main/docs/nodes/BKLNW-v1.md#table8_psi_bound" _blank
@@ -832,17 +832,17 @@ A line is one claim, indented under whatever assumes it.
 
 - [`ZetaLogDeriv.v1.logDeriv_functional_equation`](docs/nodes/ZetaLogDeriv-v1.md#logDeriv_functional_equation) — verified
 
-- [`ZetaZeroes.v1.exists_ordinate_free_height`](docs/nodes/ZetaZeroes-v1.md#exists_ordinate_free_height) — unjustified
+- [`ZetaZeroes.v1.exists_ordinate_free_height`](docs/nodes/ZetaZeroes-v1.md#exists_ordinate_free_height) — verified
 
-- [`ZetaZeroes.v1.finite_zeroes_on_compact`](docs/nodes/ZetaZeroes-v1.md#finite_zeroes_on_compact) — unjustified
+- [`ZetaZeroes.v1.finite_zeroes_on_compact`](docs/nodes/ZetaZeroes-v1.md#finite_zeroes_on_compact) — verified
 
-- [`ZetaZeroes.v1.no_nontrivial_zeroes_left`](docs/nodes/ZetaZeroes-v1.md#no_nontrivial_zeroes_left) — unjustified
+- [`ZetaZeroes.v1.no_nontrivial_zeroes_left`](docs/nodes/ZetaZeroes-v1.md#no_nontrivial_zeroes_left) — verified
 
-- [`ZetaZeroes.v1.zeroes_off_axis_in_strip`](docs/nodes/ZetaZeroes-v1.md#zeroes_off_axis_in_strip) — unjustified
+- [`ZetaZeroes.v1.zeroes_off_axis_in_strip`](docs/nodes/ZetaZeroes-v1.md#zeroes_off_axis_in_strip) — verified
 
-- [`ZetaZeroes.v1.zeta_eq_zero_iff_zeta1`](docs/nodes/ZetaZeroes-v1.md#zeta_eq_zero_iff_zeta1) — unjustified
+- [`ZetaZeroes.v1.zeta_eq_zero_iff_zeta1`](docs/nodes/ZetaZeroes-v1.md#zeta_eq_zero_iff_zeta1) — verified
 
-- [`ZetaZeroes.v1.zeta_eq_zeta1_div`](docs/nodes/ZetaZeroes-v1.md#zeta_eq_zeta1_div) — unjustified
+- [`ZetaZeroes.v1.zeta_eq_zeta1_div`](docs/nodes/ZetaZeroes-v1.md#zeta_eq_zeta1_div) — verified
 
 ## What the network takes on trust
 
@@ -908,12 +908,6 @@ rather than maintained.
 | [`RosserSchoenfeld.v1.zero_free_region`](docs/nodes/RosserSchoenfeld-v1.md#zero_free_region) | cited | 0 | **not yet traced** |
 | [`ZeroCount.v1.rvm_error_bound`](docs/nodes/ZeroCount-v1.md#rvm_error_bound) | cited | 0 | none |
 | [`ZeroCount.v1.rvm_error_small`](docs/nodes/ZeroCount-v1.md#rvm_error_small) | cited | 0 | none |
-| [`ZetaZeroes.v1.exists_ordinate_free_height`](docs/nodes/ZetaZeroes-v1.md#exists_ordinate_free_height) | unjustified | 0 | none |
-| [`ZetaZeroes.v1.finite_zeroes_on_compact`](docs/nodes/ZetaZeroes-v1.md#finite_zeroes_on_compact) | unjustified | 0 | none |
-| [`ZetaZeroes.v1.no_nontrivial_zeroes_left`](docs/nodes/ZetaZeroes-v1.md#no_nontrivial_zeroes_left) | unjustified | 0 | none |
-| [`ZetaZeroes.v1.zeroes_off_axis_in_strip`](docs/nodes/ZetaZeroes-v1.md#zeroes_off_axis_in_strip) | unjustified | 0 | none |
-| [`ZetaZeroes.v1.zeta_eq_zero_iff_zeta1`](docs/nodes/ZetaZeroes-v1.md#zeta_eq_zero_iff_zeta1) | unjustified | 0 | none |
-| [`ZetaZeroes.v1.zeta_eq_zeta1_div`](docs/nodes/ZetaZeroes-v1.md#zeta_eq_zeta1_div) | unjustified | 0 | none |
 
 ## Nodes that state nothing yet
 

--- a/IEANTN/Nodes/ZetaZeroes/v1/formalization.yaml
+++ b/IEANTN/Nodes/ZetaZeroes/v1/formalization.yaml
@@ -9,7 +9,7 @@ node:
   family: ZetaZeroes
   version: v1
   kind: standard
-  status: awaiting-verification
+  status: active
 
 project:
   name: "Location and finiteness of the zeroes of the Riemann zeta function"
@@ -59,11 +59,10 @@ conclusions:
       A PROOF EXISTS ALREADY, inside Solutions/CH2.v1/ZetaInstance as
       riemannZeta_ne_zero_of_re_neg, written when a ladder argument needed it. This node exists
       to state it where other consumers can reach it.
-  designated: unjustified
-  progress:
-    solution: Solutions/ZetaZeroes.v1/
-    state: in-progress
-    remaining_holes: 0
+  - id: comparator
+    kind: lean-comparator
+    note: 'Comparator accepted the solution. Run: https://github.com/teorth/IEANTN/actions/runs/34252215065'
+  designated: comparator
 - id: zeroes_off_axis_in_strip
   declaration: ZetaZeroes.v1.zeroes_off_axis_in_strip
   challenge: ZetaZeroes.v1.challenge_zeroes_off_axis_in_strip
@@ -77,11 +76,10 @@ conclusions:
       riemannZeta_ne_zero_of_one_le_re: to the right there are no zeroes, to the left the only
       ones are real, so anything with Im /= 0 is caught in 0 <= Re <= 1.
       Proved already as re_mem_Icc_of_riemannZeta_eq_zero in Solutions/CH2.v1/ZetaInstance.
-  designated: unjustified
-  progress:
-    solution: Solutions/ZetaZeroes.v1/
-    state: in-progress
-    remaining_holes: 0
+  - id: comparator
+    kind: lean-comparator
+    note: 'Comparator accepted the solution. Run: https://github.com/teorth/IEANTN/actions/runs/34252215065'
+  designated: comparator
 - id: finite_zeroes_on_compact
   declaration: ZetaZeroes.v1.finite_zeroes_on_compact
   challenge: ZetaZeroes.v1.challenge_finite_zeroes_on_compact
@@ -102,11 +100,10 @@ conclusions:
       complement.
       Proved already as finite_zeros_riemannZeta_of_isCompact in
       Solutions/CH2.v1/ZetaInstance.
-  designated: unjustified
-  progress:
-    solution: Solutions/ZetaZeroes.v1/
-    state: in-progress
-    remaining_holes: 0
+  - id: comparator
+    kind: lean-comparator
+    note: 'Comparator accepted the solution. Run: https://github.com/teorth/IEANTN/actions/runs/34252215065'
+  designated: comparator
 - id: exists_ordinate_free_height
   declaration: ZetaZeroes.v1.exists_ordinate_free_height
   challenge: ZetaZeroes.v1.challenge_exists_ordinate_free_height
@@ -124,11 +121,10 @@ conclusions:
       Note |Im z| rather than Im z. A contour has two horizontal pieces and both must miss the
       zeroes; the zeroes are symmetric about the real axis, so the two demands coincide.
       Proved already as exists_ordinate_free_height in Solutions/CH2.v1/ZetaInstance.
-  designated: unjustified
-  progress:
-    solution: Solutions/ZetaZeroes.v1/
-    state: in-progress
-    remaining_holes: 0
+  - id: comparator
+    kind: lean-comparator
+    note: 'Comparator accepted the solution. Run: https://github.com/teorth/IEANTN/actions/runs/34252215065'
+  designated: comparator
 - id: zeta_eq_zeta1_div
   declaration: ZetaZeroes.v1.zeta_eq_zeta1_div
   challenge: ZetaZeroes.v1.challenge_zeta_eq_zeta1_div
@@ -143,11 +139,10 @@ conclusions:
       because it is the bridge every argument needs that wants to replace zeta by an entire
       function -- which is to say every argument that wants the identity theorem.
       Proved already as riemannZeta_eq_riemannZeta₁_div in Solutions/CH2.v1/ZetaInstance.
-  designated: unjustified
-  progress:
-    solution: Solutions/ZetaZeroes.v1/
-    state: in-progress
-    remaining_holes: 0
+  - id: comparator
+    kind: lean-comparator
+    note: 'Comparator accepted the solution. Run: https://github.com/teorth/IEANTN/actions/runs/34252215065'
+  designated: comparator
 - id: zeta_eq_zero_iff_zeta1
   declaration: ZetaZeroes.v1.zeta_eq_zero_iff_zeta1
   challenge: ZetaZeroes.v1.challenge_zeta_eq_zero_iff_zeta1
@@ -164,12 +159,11 @@ conclusions:
       s = 1 is excluded because riemannZeta_1 1 = 1 /= 0 while zeta has a pole there, so the
       two sides say different things at that one point.
       Proved already as riemannZeta_eq_zero_iff_riemannZeta₁ in Solutions/CH2.v1/ZetaInstance.
-  designated: unjustified
+  - id: comparator
+    kind: lean-comparator
+    note: 'Comparator accepted the solution. Run: https://github.com/teorth/IEANTN/actions/runs/34252215065'
+  designated: comparator
 
-  progress:
-    solution: Solutions/ZetaZeroes.v1/
-    state: in-progress
-    remaining_holes: 0
 sources:
 - title: "Location of the zeroes of the Riemann zeta function"
   authors: ["folklore"]

--- a/STATE.md
+++ b/STATE.md
@@ -15,9 +15,9 @@ adds the environment detail.
 |---|---:|
 | `asserted` | 1 |
 | `bridged` | 1 |
-| `lean-comparator` | 23 |
+| `lean-comparator` | 29 |
 | `literature` | 36 |
-| `none-yet` | 10 |
+| `none-yet` | 4 |
 | `numerical` | 14 |
 
 ## Nodes
@@ -106,12 +106,12 @@ adds the environment detail.
 | `ZeroCount.v1` | stub | `rvm_error_small` | literature | 0 | #64 |
 | `ZeroFreeHeight.v1` | active | `classical_region_descends` | lean-comparator-stale | 0 | #30 |
 | `ZetaLogDeriv.v1` | active | `logDeriv_functional_equation` | lean-comparator | 0 | #64 |
-| `ZetaZeroes.v1` | awaiting-verification | `no_nontrivial_zeroes_left` | none-yet | 0 | - |
-| `ZetaZeroes.v1` | awaiting-verification | `zeroes_off_axis_in_strip` | none-yet | 0 | - |
-| `ZetaZeroes.v1` | awaiting-verification | `finite_zeroes_on_compact` | none-yet | 0 | - |
-| `ZetaZeroes.v1` | awaiting-verification | `exists_ordinate_free_height` | none-yet | 0 | - |
-| `ZetaZeroes.v1` | awaiting-verification | `zeta_eq_zeta1_div` | none-yet | 0 | - |
-| `ZetaZeroes.v1` | awaiting-verification | `zeta_eq_zero_iff_zeta1` | none-yet | 0 | - |
+| `ZetaZeroes.v1` | active | `no_nontrivial_zeroes_left` | lean-comparator | 0 | - |
+| `ZetaZeroes.v1` | active | `zeroes_off_axis_in_strip` | lean-comparator | 0 | - |
+| `ZetaZeroes.v1` | active | `finite_zeroes_on_compact` | lean-comparator | 0 | - |
+| `ZetaZeroes.v1` | active | `exists_ordinate_free_height` | lean-comparator | 0 | - |
+| `ZetaZeroes.v1` | active | `zeta_eq_zeta1_div` | lean-comparator | 0 | - |
+| `ZetaZeroes.v1` | active | `zeta_eq_zero_iff_zeta1` | lean-comparator | 0 | - |
 
 ## Receipts needing attention
 

--- a/docs/nodes/README.md
+++ b/docs/nodes/README.md
@@ -50,5 +50,5 @@ One page per node: what it claims, in Lean and in prose, and everything recorded
 | [`ZeroCount.v1`](ZeroCount-v1.md) | paper | 2 | cited |
 | [`ZeroFreeHeight.v1`](ZeroFreeHeight-v1.md) | folklore | 1 | verified, stale |
 | [`ZetaLogDeriv.v1`](ZetaLogDeriv-v1.md) | standard | 1 | verified |
-| [`ZetaZeroes.v1`](ZetaZeroes-v1.md) | standard | 6 | unjustified |
+| [`ZetaZeroes.v1`](ZetaZeroes-v1.md) | standard | 6 | verified |
 

--- a/docs/nodes/ZetaZeroes-v1.md
+++ b/docs/nodes/ZetaZeroes-v1.md
@@ -7,7 +7,7 @@
 | | |
 |---|---|
 | Kind | standard |
-| Status | awaiting-verification |
+| Status | active |
 | Maintainers | Terence Tao |
 | Licence | Apache-2.0 |
 | Review | self-assessed |
@@ -46,14 +46,19 @@ def no_nontrivial_zeroes_left : Prop :=
 | Challenge | `ZetaZeroes.v1.challenge_no_nontrivial_zeroes_left` |
 | Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/ZetaZeroes/v1/Conclusions.lean#L65) |
 | Solution | [`Solutions/ZetaZeroes.v1`](https://github.com/teorth/IEANTN/tree/main/Solutions/ZetaZeroes.v1) |
-| Evidence | unjustified (`none-yet`) |
+| Receipt | [`ZetaZeroes.v1.no_nontrivial_zeroes_left.json`](https://github.com/teorth/IEANTN/blob/main/receipts/ZetaZeroes.v1.no_nontrivial_zeroes_left.json) |
+| Evidence | verified (`lean-comparator`) |
 | Sources traced | none |
 | Assumes | nothing recorded |
 | Assumed by | nothing yet |
 
-**Justification `unjustified`** — **designated** — none-yet
+**Justification `unjustified`** — none-yet
 
 > Imports `none`, and that is a real none: s is universally quantified with every condition a hypothesis, so a Lean proof is the whole justification. THE ROUTE IS THE FUNCTIONAL EQUATION AND NOTHING ELSE. Writing s = 1 - w with Re w > 1, riemannZeta_one_sub expresses zeta(s) as a product of 2, (2 pi)^-w, Gamma(w), cos(pi w/2) and zeta(w). Every factor but the cosine is nonzero for free -- Gamma never vanishes, and zeta(w) is nonzero because Re w > 1 -- so zeta(s) = 0 forces cos(pi w/2) = 0, hence w = 2k+1 and s = -2k, and Re s < 0 makes k positive. That is the trivial zeroes exactly. A PROOF EXISTS ALREADY, inside Solutions/CH2.v1/ZetaInstance as riemannZeta_ne_zero_of_re_neg, written when a ladder argument needed it. This node exists to state it where other consumers can reach it.
+
+**Justification `comparator`** — **designated** — lean-comparator
+
+> Comparator accepted the solution. Run: https://github.com/teorth/IEANTN/actions/runs/34252215065
 
 ### `zeroes_off_axis_in_strip`
 
@@ -74,14 +79,19 @@ def zeroes_off_axis_in_strip : Prop :=
 | Challenge | `ZetaZeroes.v1.challenge_zeroes_off_axis_in_strip` |
 | Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/ZetaZeroes/v1/Conclusions.lean#L73) |
 | Solution | [`Solutions/ZetaZeroes.v1`](https://github.com/teorth/IEANTN/tree/main/Solutions/ZetaZeroes.v1) |
-| Evidence | unjustified (`none-yet`) |
+| Receipt | [`ZetaZeroes.v1.zeroes_off_axis_in_strip.json`](https://github.com/teorth/IEANTN/blob/main/receipts/ZetaZeroes.v1.zeroes_off_axis_in_strip.json) |
+| Evidence | verified (`lean-comparator`) |
 | Sources traced | none |
 | Assumes | nothing recorded |
 | Assumed by | nothing yet |
 
-**Justification `unjustified`** — **designated** — none-yet
+**Justification `unjustified`** — none-yet
 
 > The complement of the previous conclusion together with Mathlib's riemannZeta_ne_zero_of_one_le_re: to the right there are no zeroes, to the left the only ones are real, so anything with Im /= 0 is caught in 0 <= Re <= 1. Proved already as re_mem_Icc_of_riemannZeta_eq_zero in Solutions/CH2.v1/ZetaInstance.
+
+**Justification `comparator`** — **designated** — lean-comparator
+
+> Comparator accepted the solution. Run: https://github.com/teorth/IEANTN/actions/runs/34252215065
 
 ### `finite_zeroes_on_compact`
 
@@ -106,14 +116,19 @@ def finite_zeroes_on_compact : Prop :=
 | Challenge | `ZetaZeroes.v1.challenge_finite_zeroes_on_compact` |
 | Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/ZetaZeroes/v1/Conclusions.lean#L85) |
 | Solution | [`Solutions/ZetaZeroes.v1`](https://github.com/teorth/IEANTN/tree/main/Solutions/ZetaZeroes.v1) |
-| Evidence | unjustified (`none-yet`) |
+| Receipt | [`ZetaZeroes.v1.finite_zeroes_on_compact.json`](https://github.com/teorth/IEANTN/blob/main/receipts/ZetaZeroes.v1.finite_zeroes_on_compact.json) |
+| Evidence | verified (`lean-comparator`) |
 | Sources traced | none |
 | Assumes | nothing recorded |
 | Assumed by | nothing yet |
 
-**Justification `unjustified`** — **designated** — none-yet
+**Justification `unjustified`** — none-yet
 
 > THE WORKHORSE, and the conclusion that makes a sum over zeroes mean anything. IEANTN.zetaZeroesSum is a tsum, and a tsum of a non-summable family is 0, so a zero-counting argument that never establishes finiteness can be vacuously true rather than false. This is what rules that out. The route is the identity theorem, applied to riemannZeta_1 rather than to zeta -- zeta has a pole at s = 1 and cannot be fed to it on any set containing that point, which is why the hypothesis excludes it. riemannZeta_1 is entire and riemannZeta_1 1 = 1, so its non-vanishing is codiscrete, and a codiscrete set meets a compact set in a finite complement. Proved already as finite_zeros_riemannZeta_of_isCompact in Solutions/CH2.v1/ZetaInstance.
+
+**Justification `comparator`** — **designated** — lean-comparator
+
+> Comparator accepted the solution. Run: https://github.com/teorth/IEANTN/actions/runs/34252215065
 
 ### `exists_ordinate_free_height`
 
@@ -139,14 +154,19 @@ def exists_ordinate_free_height : Prop :=
 | Challenge | `ZetaZeroes.v1.challenge_exists_ordinate_free_height` |
 | Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/ZetaZeroes/v1/Conclusions.lean#L97) |
 | Solution | [`Solutions/ZetaZeroes.v1`](https://github.com/teorth/IEANTN/tree/main/Solutions/ZetaZeroes.v1) |
-| Evidence | unjustified (`none-yet`) |
+| Receipt | [`ZetaZeroes.v1.exists_ordinate_free_height.json`](https://github.com/teorth/IEANTN/blob/main/receipts/ZetaZeroes.v1.exists_ordinate_free_height.json) |
+| Evidence | verified (`lean-comparator`) |
 | Sources traced | none |
 | Assumes | nothing recorded |
 | Assumed by | nothing yet |
 
-**Justification `unjustified`** — **designated** — none-yet
+**Justification `unjustified`** — none-yet
 
 > What a contour needs when its horizontal pieces must miss the zeroes and the height is a free parameter. The argument is a counting one: a zero with \|Im z\| in [T0, T0+1] is off the real axis, hence in the closed critical strip, hence in a compact band missing the pole -- of which there are finitely many, and finitely many ordinates cannot exhaust an interval. Note \|Im z\| rather than Im z. A contour has two horizontal pieces and both must miss the zeroes; the zeroes are symmetric about the real axis, so the two demands coincide. Proved already as exists_ordinate_free_height in Solutions/CH2.v1/ZetaInstance.
+
+**Justification `comparator`** — **designated** — lean-comparator
+
+> Comparator accepted the solution. Run: https://github.com/teorth/IEANTN/actions/runs/34252215065
 
 ### `zeta_eq_zeta1_div`
 
@@ -168,14 +188,19 @@ def zeta_eq_zeta1_div : Prop :=
 | Challenge | `ZetaZeroes.v1.challenge_zeta_eq_zeta1_div` |
 | Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/ZetaZeroes/v1/Conclusions.lean#L107) |
 | Solution | [`Solutions/ZetaZeroes.v1`](https://github.com/teorth/IEANTN/tree/main/Solutions/ZetaZeroes.v1) |
-| Evidence | unjustified (`none-yet`) |
+| Receipt | [`ZetaZeroes.v1.zeta_eq_zeta1_div.json`](https://github.com/teorth/IEANTN/blob/main/receipts/ZetaZeroes.v1.zeta_eq_zeta1_div.json) |
+| Evidence | verified (`lean-comparator`) |
 | Sources traced | none |
 | Assumes | nothing recorded |
 | Assumed by | nothing yet |
 
-**Justification `unjustified`** — **designated** — none-yet
+**Justification `unjustified`** — none-yet
 
 > Immediate from riemannZeta_eq_inv_sub_add and the definition of riemannZeta_1, and apparently absent from Mathlib, where riemannZeta_1 is never related back to zeta. Stated because it is the bridge every argument needs that wants to replace zeta by an entire function -- which is to say every argument that wants the identity theorem. Proved already as riemannZeta_eq_riemannZeta₁_div in Solutions/CH2.v1/ZetaInstance.
+
+**Justification `comparator`** — **designated** — lean-comparator
+
+> Comparator accepted the solution. Run: https://github.com/teorth/IEANTN/actions/runs/34252215065
 
 ### `zeta_eq_zero_iff_zeta1`
 
@@ -199,14 +224,19 @@ def zeta_eq_zero_iff_zeta1 : Prop :=
 | Challenge | `ZetaZeroes.v1.challenge_zeta_eq_zero_iff_zeta1` |
 | Source | [Conclusions.lean](https://github.com/teorth/IEANTN/blob/main/IEANTN/Nodes/ZetaZeroes/v1/Conclusions.lean#L118) |
 | Solution | [`Solutions/ZetaZeroes.v1`](https://github.com/teorth/IEANTN/tree/main/Solutions/ZetaZeroes.v1) |
-| Evidence | unjustified (`none-yet`) |
+| Receipt | [`ZetaZeroes.v1.zeta_eq_zero_iff_zeta1.json`](https://github.com/teorth/IEANTN/blob/main/receipts/ZetaZeroes.v1.zeta_eq_zero_iff_zeta1.json) |
+| Evidence | verified (`lean-comparator`) |
 | Sources traced | none |
 | Assumes | nothing recorded |
 | Assumed by | nothing yet |
 
-**Justification `unjustified`** — **designated** — none-yet
+**Justification `unjustified`** — none-yet
 
 > The form the bridge is usually used in, and a one-line consequence of the previous conclusion. CH2.v1 runs its entire ladder argument on -logDeriv riemannZeta_1 rather than on -zeta'/zeta precisely so that the identity theorem applies, and this is what transfers zero facts between the two. s = 1 is excluded because riemannZeta_1 1 = 1 /= 0 while zeta has a pole there, so the two sides say different things at that one point. Proved already as riemannZeta_eq_zero_iff_riemannZeta₁ in Solutions/CH2.v1/ZetaInstance.
+
+**Justification `comparator`** — **designated** — lean-comparator
+
+> Comparator accepted the solution. Run: https://github.com/teorth/IEANTN/actions/runs/34252215065
 
 ## Limitations
 

--- a/receipts/ZetaZeroes.v1.exists_ordinate_free_height.json
+++ b/receipts/ZetaZeroes.v1.exists_ordinate_free_height.json
@@ -1,0 +1,28 @@
+{
+  "challenge": "ZetaZeroes.v1.challenge_exists_ordinate_free_height",
+  "conclusion": "ZetaZeroes.v1.exists_ordinate_free_height",
+  "environment": {
+    "lean_toolchain": "leanprover/lean4:v4.34.0-rc2",
+    "mathlib_rev": "71a80585ee495fc24472fd0eaffc89d94e4fd8d6"
+  },
+  "repository": {
+    "commit": "5927b0e28364b4baa76ef54553ef95ff5d73eb91"
+  },
+  "run": {
+    "recorded_at": "2026-09-08T17:01:53Z",
+    "workflow_run": "https://github.com/teorth/IEANTN/actions/runs/34252215065"
+  },
+  "schema": 2,
+  "solution": {
+    "project": "Solutions/ZetaZeroes.v1"
+  },
+  "statement": {
+    "ZetaZeroes.v1.exists_ordinate_free_height": "2d148f173e6c334bccf4f3e40b39f6243c3d5d622ad4ed533b4246a28c3b9f77"
+  },
+  "tools": {
+    "comparator": "10dd2b33dc43751af3257f4d684535375306f162",
+    "landrun": "811cfff51ceaf3d9843708aa6d22e9b84ccac8b4",
+    "lean4export": "cacf989bd75f608700820f6afc595f32e7a99a4d",
+    "nanoda": "68d5ca9db226849b41a6fff59d796ff19d0a8840"
+  }
+}

--- a/receipts/ZetaZeroes.v1.finite_zeroes_on_compact.json
+++ b/receipts/ZetaZeroes.v1.finite_zeroes_on_compact.json
@@ -1,0 +1,28 @@
+{
+  "challenge": "ZetaZeroes.v1.challenge_finite_zeroes_on_compact",
+  "conclusion": "ZetaZeroes.v1.finite_zeroes_on_compact",
+  "environment": {
+    "lean_toolchain": "leanprover/lean4:v4.34.0-rc2",
+    "mathlib_rev": "71a80585ee495fc24472fd0eaffc89d94e4fd8d6"
+  },
+  "repository": {
+    "commit": "5927b0e28364b4baa76ef54553ef95ff5d73eb91"
+  },
+  "run": {
+    "recorded_at": "2026-09-08T17:01:53Z",
+    "workflow_run": "https://github.com/teorth/IEANTN/actions/runs/34252215065"
+  },
+  "schema": 2,
+  "solution": {
+    "project": "Solutions/ZetaZeroes.v1"
+  },
+  "statement": {
+    "ZetaZeroes.v1.finite_zeroes_on_compact": "8b46117beaf9ec969928890d242e090dc626121c41d5746adc57a92bf520dec6"
+  },
+  "tools": {
+    "comparator": "10dd2b33dc43751af3257f4d684535375306f162",
+    "landrun": "811cfff51ceaf3d9843708aa6d22e9b84ccac8b4",
+    "lean4export": "cacf989bd75f608700820f6afc595f32e7a99a4d",
+    "nanoda": "68d5ca9db226849b41a6fff59d796ff19d0a8840"
+  }
+}

--- a/receipts/ZetaZeroes.v1.no_nontrivial_zeroes_left.json
+++ b/receipts/ZetaZeroes.v1.no_nontrivial_zeroes_left.json
@@ -1,0 +1,28 @@
+{
+  "challenge": "ZetaZeroes.v1.challenge_no_nontrivial_zeroes_left",
+  "conclusion": "ZetaZeroes.v1.no_nontrivial_zeroes_left",
+  "environment": {
+    "lean_toolchain": "leanprover/lean4:v4.34.0-rc2",
+    "mathlib_rev": "71a80585ee495fc24472fd0eaffc89d94e4fd8d6"
+  },
+  "repository": {
+    "commit": "5927b0e28364b4baa76ef54553ef95ff5d73eb91"
+  },
+  "run": {
+    "recorded_at": "2026-09-08T17:01:53Z",
+    "workflow_run": "https://github.com/teorth/IEANTN/actions/runs/34252215065"
+  },
+  "schema": 2,
+  "solution": {
+    "project": "Solutions/ZetaZeroes.v1"
+  },
+  "statement": {
+    "ZetaZeroes.v1.no_nontrivial_zeroes_left": "4a09adf1439008a11302613ba72f868de02a3941d9708e3f626fa7e73630258c"
+  },
+  "tools": {
+    "comparator": "10dd2b33dc43751af3257f4d684535375306f162",
+    "landrun": "811cfff51ceaf3d9843708aa6d22e9b84ccac8b4",
+    "lean4export": "cacf989bd75f608700820f6afc595f32e7a99a4d",
+    "nanoda": "68d5ca9db226849b41a6fff59d796ff19d0a8840"
+  }
+}

--- a/receipts/ZetaZeroes.v1.zeroes_off_axis_in_strip.json
+++ b/receipts/ZetaZeroes.v1.zeroes_off_axis_in_strip.json
@@ -1,0 +1,28 @@
+{
+  "challenge": "ZetaZeroes.v1.challenge_zeroes_off_axis_in_strip",
+  "conclusion": "ZetaZeroes.v1.zeroes_off_axis_in_strip",
+  "environment": {
+    "lean_toolchain": "leanprover/lean4:v4.34.0-rc2",
+    "mathlib_rev": "71a80585ee495fc24472fd0eaffc89d94e4fd8d6"
+  },
+  "repository": {
+    "commit": "5927b0e28364b4baa76ef54553ef95ff5d73eb91"
+  },
+  "run": {
+    "recorded_at": "2026-09-08T17:01:53Z",
+    "workflow_run": "https://github.com/teorth/IEANTN/actions/runs/34252215065"
+  },
+  "schema": 2,
+  "solution": {
+    "project": "Solutions/ZetaZeroes.v1"
+  },
+  "statement": {
+    "ZetaZeroes.v1.zeroes_off_axis_in_strip": "6735853d24d496f4e7a6c64fbaeb3a5a7df155f0c794350cb042cc1e9e7edc2e"
+  },
+  "tools": {
+    "comparator": "10dd2b33dc43751af3257f4d684535375306f162",
+    "landrun": "811cfff51ceaf3d9843708aa6d22e9b84ccac8b4",
+    "lean4export": "cacf989bd75f608700820f6afc595f32e7a99a4d",
+    "nanoda": "68d5ca9db226849b41a6fff59d796ff19d0a8840"
+  }
+}

--- a/receipts/ZetaZeroes.v1.zeta_eq_zero_iff_zeta1.json
+++ b/receipts/ZetaZeroes.v1.zeta_eq_zero_iff_zeta1.json
@@ -1,0 +1,28 @@
+{
+  "challenge": "ZetaZeroes.v1.challenge_zeta_eq_zero_iff_zeta1",
+  "conclusion": "ZetaZeroes.v1.zeta_eq_zero_iff_zeta1",
+  "environment": {
+    "lean_toolchain": "leanprover/lean4:v4.34.0-rc2",
+    "mathlib_rev": "71a80585ee495fc24472fd0eaffc89d94e4fd8d6"
+  },
+  "repository": {
+    "commit": "5927b0e28364b4baa76ef54553ef95ff5d73eb91"
+  },
+  "run": {
+    "recorded_at": "2026-09-08T17:01:53Z",
+    "workflow_run": "https://github.com/teorth/IEANTN/actions/runs/34252215065"
+  },
+  "schema": 2,
+  "solution": {
+    "project": "Solutions/ZetaZeroes.v1"
+  },
+  "statement": {
+    "ZetaZeroes.v1.zeta_eq_zero_iff_zeta1": "ee9115fc5ab28f07cadb9c7f90c7648499786c493ac3c31f2232f099f57e33c7"
+  },
+  "tools": {
+    "comparator": "10dd2b33dc43751af3257f4d684535375306f162",
+    "landrun": "811cfff51ceaf3d9843708aa6d22e9b84ccac8b4",
+    "lean4export": "cacf989bd75f608700820f6afc595f32e7a99a4d",
+    "nanoda": "68d5ca9db226849b41a6fff59d796ff19d0a8840"
+  }
+}

--- a/receipts/ZetaZeroes.v1.zeta_eq_zeta1_div.json
+++ b/receipts/ZetaZeroes.v1.zeta_eq_zeta1_div.json
@@ -1,0 +1,28 @@
+{
+  "challenge": "ZetaZeroes.v1.challenge_zeta_eq_zeta1_div",
+  "conclusion": "ZetaZeroes.v1.zeta_eq_zeta1_div",
+  "environment": {
+    "lean_toolchain": "leanprover/lean4:v4.34.0-rc2",
+    "mathlib_rev": "71a80585ee495fc24472fd0eaffc89d94e4fd8d6"
+  },
+  "repository": {
+    "commit": "5927b0e28364b4baa76ef54553ef95ff5d73eb91"
+  },
+  "run": {
+    "recorded_at": "2026-09-08T17:01:53Z",
+    "workflow_run": "https://github.com/teorth/IEANTN/actions/runs/34252215065"
+  },
+  "schema": 2,
+  "solution": {
+    "project": "Solutions/ZetaZeroes.v1"
+  },
+  "statement": {
+    "ZetaZeroes.v1.zeta_eq_zeta1_div": "fdb34142793bb6d34ed2225eefb354fd9065dbe19e5f59ddacd7722a64871fb7"
+  },
+  "tools": {
+    "comparator": "10dd2b33dc43751af3257f4d684535375306f162",
+    "landrun": "811cfff51ceaf3d9843708aa6d22e9b84ccac8b4",
+    "lean4export": "cacf989bd75f608700820f6afc595f32e7a99a4d",
+    "nanoda": "68d5ca9db226849b41a6fff59d796ff19d0a8840"
+  }
+}


### PR DESCRIPTION
Comparator accepted `Solutions/ZetaZeroes.v1`. Six receipts, one per conclusion, written by [run 34252215065](https://github.com/teorth/IEANTN/actions/runs/34252215065) — not by hand.

All six conclusions go **green**, and the node moves to `active`.

| | |
|---|---|
| Attests to commit | `5927b0e` — the merge of #103, i.e. exactly what is on `main` |
| Mathlib | `71a80585` |
| Toolchain | `leanprover/lean4:v4.34.0-rc2` |
| Axioms | `propext`, `Classical.choice`, `Quot.sound` |

## Why this is a separate PR rather than part of #103

#103 was merged before the verification ran. That is harmless — what landed said the six conclusions were **unjustified**, which was true, and nothing downstream imported them — but it left the receipt with nowhere to go, since `verify.yml` refuses to write to the default branch:

> A receipt goes onto the branch being verified, and then through review like anything else. Writing one straight to the default branch would put the one file the network trusts most into `main` without a pull request — and this job is the only place in the repository holding a write token.

So the remedy was a branch off `main` at the same commit, verified, with the receipt landing there for review. That is this PR. No revert was needed and none was done.

## What is in the diff

Beyond the six receipts, the workflow regenerated three views, because designating a `lean-comparator` justification changes all of them and `check` verifies all three:

- `STATE.md`
- `GRAPH.md` — box colour, and the conclusions leave the "taken on trust" table
- `docs/nodes/` — the evidence rows

Plus `formalization.yaml`, where the justification kind and `designated` moved, and `node.status` went `awaiting-verification` → `active`.

Everything here except this description was written by the verification workflow.

## Gate

`check` 8/8, including receipt provenance, which fetches each recorded run and confirms it really is a successful run of this repository's verification workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
